### PR TITLE
Spelling - Tutorial/Callbacks

### DIFF
--- a/tutorial.html
+++ b/tutorial.html
@@ -188,7 +188,7 @@ start_dearpygui()</code></pre>
             <br><br>
             Every callback function used in DearPyGui must take in a "sender" and "data" argument.
             <br><br>
-            The "sender" is used by DearPyGui to inform the callback which which triggered the callback.
+            The "sender" is used by DearPyGui to inform the callback which widget triggered the callback.
             <br><br>
             The "data" argument is used by various standard callbacks to send additional data.
         </p>


### PR DESCRIPTION
---
name: Documentation Improvement
about: Correction Spelling in Tutorial -> Callbacks
title: 'Spelling - Tutorial/Callbacks'
labels: ''
assignees: ''

---
Just a small correction in the tutorial/callbacks (which -> widget)

Sorry in advance if I bother anybody with this.

PS: DearPyGui is awesome! :+1: 