### PR TITLE
docs: Fix simple typo, succeded -> succeeded

### DIFF
--- a/DearPyGui/src/Core/mvApp.cpp
+++ b/DearPyGui/src/Core/mvApp.cpp
@@ -700,7 +700,7 @@ namespace Marvel {
 
 			PyObject* result = PyObject_CallObject(callback, pArgs);
 
-			// check if call succeded
+			// check if call succeeded
 			if (!result)
 			{
 				PyErr_Print();
@@ -784,7 +784,7 @@ namespace Marvel {
 
 		PyObject* result = PyObject_CallObject(callable, pArgs);
 
-		// check if call succeded
+		// check if call succeeded
 		if (!result)
 		{
 			PyErr_Print();


### PR DESCRIPTION
There is a small typo in DearPyGui/src/Core/mvApp.cpp.

Should read `succeeded` rather than `succeded`.

