### PR TITLE
Example typo fix

### DIFF
--- a/Examples/menus_advanced_example.py
+++ b/Examples/menus_advanced_example.py
@@ -10,10 +10,10 @@ def showMenu(sender, data):
 def changeCallback(sender, data):
     callbackName=get_item_callback("Show Docs")
     print(callbackName)
-    if callbackName == "showDocs":
-        set_item_callback("Show Docs", "showMetrics")
+    if callbackName == showDocs:
+        set_item_callback("Show Docs", showMetrics)
     else:
-        set_item_callback("Show Docs", "showDocs")
+        set_item_callback("Show Docs", showDocs)
 
 def showDocs(sender, data):
     show_documentation()

--- a/Examples/menus_advanced_example.py
+++ b/Examples/menus_advanced_example.py
@@ -43,22 +43,22 @@ add_menu_item("Hide Tools", callback=hideMenu)
 add_menu_item('Change "Show Docs" Callback', callback=changeCallback)
 add_tooltip('Change "Show Docs" Callback', "tooltip1")
 add_text('this will change the "show Docs" callback to a show metrics callback')
-end_tooltip()
+end() # tooltip
 add_menu("Empty Menu")
 add_menu_item("Nothing")
-end()
-end()
+end() # menu::Empty Menu
+end() # menu::Show/Hide
 
 add_menu("Tools")
 add_menu_item("Show Docs", callback=showDocs)
-end()
+end() # menu::Tools
 add_menu("Add/Remove")
 add_menu_item("Add Themes", callback=addThemes)
 add_menu_item("Delete Themes", callback=deleteThemes)
 hide_item("Delete Themes")
-end()
+end() # menu::Add/Remove
 
-end()
+end() # menu::MenuBar
 
 add_text("This menu bar demonstrates:")
 add_text('standard menu bar, menus, and menu items', bullet=True)

--- a/Examples/plot_query_example.py
+++ b/Examples/plot_query_example.py
@@ -54,7 +54,7 @@ add_color_picker4("Color", default_value=[255, 0, 0, 255], callback=plot_callbac
 add_color_picker4("Fill", default_value=[255, 0, 0, 100], callback=plot_callback)
 end()
 add_same_line()
-add_plot("Plot1", "x-axis", "y-axis", height=-1, query_callback=query)
+add_plot("Plot1", "x-axis", "y-axis", height=-1, query_callback="query")
 
 add_window("Plot Window", width=500, height=500, hide=True)
 add_plot("Plot2", "x-axis", "y-axis", height=-1)

--- a/Examples/widget_example.py
+++ b/Examples/widget_example.py
@@ -3,7 +3,6 @@ from dearpygui.dearpygui import *
 # callback
 def retrieve_values(sender, data):
     show_logger()
-    log_info("Data Storage:" + str(get_data("DataStorage1")))
     log_info("Checkbox: " + str(get_value("Checkbox##widget")))
     log_info("Combo: " + str(get_value("Combo##widget")))
     log_info("Radio Button: " + str(get_value("Radio Button##widget")))

--- a/Examples/window_example.py
+++ b/Examples/window_example.py
@@ -17,7 +17,7 @@ def window_creator(sender, data):
 
     add_window(title, width, height, start_x=start_x, start_y=start_y,
                autosize=autosize, resizable=resizable, title_bar=title_bar,
-               movable=movable, on_close="on_window_close")
+               movable=movable, on_close=on_window_close)
     for i in range(0, 10):
         add_button("button" + str(i))
     end()


### PR DESCRIPTION

**Description:**
When you run some examples, you get errors. I've fixed them.
More details see commit message.

*version info*
```
[DearPyGui Version] 0.3.5
[Python Version] 3.8.5
[DearImGui Version] 1.78
[Compiler] MSVC version 1927
```

**Concerning Areas:**
None.
