### PR TITLE
Fix broken href.

### DIFF
--- a/api_docs.html
+++ b/api_docs.html
@@ -36,11 +36,11 @@
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
 <dl>
-<dt><code class="name"><a title="dearpygui.core" href="core.html">dearpygui.core</a></code></dt>
+<dt><code class="name"><a title="dearpygui.core" href="api_core.html">dearpygui.core</a></code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt><code class="name"><a title="dearpygui.simple" href="simple.html">dearpygui.simple</a></code></dt>
+<dt><code class="name"><a title="dearpygui.simple" href="api_simple.html">dearpygui.simple</a></code></dt>
 <dd>
 <div class="desc"></div>
 </dd>


### PR DESCRIPTION
The body section's links to dearpygui.core and dearpygui.simple were broken. I updated them to match the sidebar's links, which were functional.

---
name: Fix for broken href.
about: Typo fix.
title: ''
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
Simple href fix.

**Concerning Areas:**
None.