### PR TITLE
get rid of compiler warnings

### DIFF
--- a/DearPyGui/CMakeLists.txt
+++ b/DearPyGui/CMakeLists.txt
@@ -45,6 +45,7 @@ set(MARVEL_SOURCES
 
 	"src/Core/mvPythonTranslator.cpp"
 	"src/Core/mvPythonParser.cpp"
+	"src/Core/mvPythonExceptions.cpp"
 
 	"src/Core/PythonCommands/mvInterfaceCore.cpp"
 	"src/Core/PythonCommands/mvPlotInterface.cpp"

--- a/DearPyGui/src/Core/AppItems/mvAppItem.cpp
+++ b/DearPyGui/src/Core/AppItems/mvAppItem.cpp
@@ -28,7 +28,7 @@ namespace Marvel{
 		}
 		for (auto key : configKeys)
 		{
-			int i = 0;
+			size_t i = 0;
 			while (i < parserKeywords.size() - 1)
 			{
 				if (key == parserKeywords[i])
@@ -172,7 +172,7 @@ namespace Marvel{
 	bool  mvAppItem::moveChildDown(const std::string& name)
 	{
 		bool found = false;
-		int index = 0;
+		size_t index = 0;
 
 		// check children
 		for (size_t i = 0; i < m_children.size(); i++)

--- a/DearPyGui/src/Core/AppItems/mvBasicItems.h
+++ b/DearPyGui/src/Core/AppItems/mvBasicItems.h
@@ -302,7 +302,7 @@ namespace Marvel {
 			auto conflictingflagop = [dict](const std::vector<std::string>& keywords, std::vector<int> flags, int& mflags)
 			{
 
-				for (int i = 0; i < keywords.size(); i++)
+				for (size_t i = 0; i < keywords.size(); i++)
 				{
 					if (PyObject* item = PyDict_GetItemString(dict, keywords[i].c_str()))
 					{

--- a/DearPyGui/src/Core/AppItems/mvColorItems.h
+++ b/DearPyGui/src/Core/AppItems/mvColorItems.h
@@ -142,7 +142,7 @@ namespace Marvel {
 			auto conflictingflagop = [dict](const std::vector<std::string>& keywords, std::vector<int> flags, int& mflags)
 			{
 
-				for (int i = 0; i < keywords.size(); i++)
+				for (size_t i = 0; i < keywords.size(); i++)
 				{
 					if (PyObject* item = PyDict_GetItemString(dict, keywords[i].c_str()))
 					{
@@ -270,7 +270,7 @@ namespace Marvel {
 			auto conflictingflagop = [dict](const std::vector<std::string>& keywords, std::vector<int> flags, int& mflags)
 			{
 
-				for (int i = 0; i < keywords.size(); i++)
+				for (size_t i = 0; i < keywords.size(); i++)
 				{
 					if (PyObject* item = PyDict_GetItemString(dict, keywords[i].c_str()))
 					{
@@ -400,7 +400,7 @@ namespace Marvel {
 			auto conflictingflagop = [dict](const std::vector<std::string>& keywords, std::vector<int> flags, int& mflags)
 			{
 
-				for (int i = 0; i < keywords.size(); i++)
+				for (size_t i = 0; i < keywords.size(); i++)
 				{
 					if (PyObject* item = PyDict_GetItemString(dict, keywords[i].c_str()))
 					{
@@ -530,7 +530,7 @@ namespace Marvel {
 			auto conflictingflagop = [dict](const std::vector<std::string>& keywords, std::vector<int> flags, int& mflags)
 			{
 
-				for (int i = 0; i < keywords.size(); i++)
+				for (size_t i = 0; i < keywords.size(); i++)
 				{
 					if (PyObject* item = PyDict_GetItemString(dict, keywords[i].c_str()))
 					{

--- a/DearPyGui/src/Core/AppItems/mvColumns.h
+++ b/DearPyGui/src/Core/AppItems/mvColumns.h
@@ -32,7 +32,7 @@ namespace Marvel {
 			else
 				m_columns = columns;
 
-			for (size_t i = 0; i < m_columns; i++)
+			for (int i = 0; i < m_columns; i++)
 				m_widths.push_back(0);
 			m_container = true;
 		}
@@ -99,7 +99,7 @@ namespace Marvel {
 					m_columns = 64;
 
 				m_widths.clear();
-				for (size_t i = 0; i < m_columns; i++)
+				for (int i = 0; i < m_columns; i++)
 					m_widths.push_back(0);
 			}
 		}

--- a/DearPyGui/src/Core/AppItems/mvDrawing.cpp
+++ b/DearPyGui/src/Core/AppItems/mvDrawing.cpp
@@ -129,19 +129,19 @@ namespace Marvel {
 
 		if (m_fill.specified)
 		{
-			int i;
+			size_t i;
 			int y;
 			int miny, maxy;
 			int x1, y1;
 			int x2, y2;
 			int ind1, ind2;
-			int ints;
+			size_t ints;
 			size_t n = m_points.size();
 			int* polyints = new int[n];
 
 			/* Determine Y maxima */
-			miny = (int)m_points[0].y;
-			maxy = (int)m_points[0].y;
+			miny = m_points[0].y;
+			maxy = m_points[0].y;
 			for (i = 1; i < n; i++)
 			{
 				miny = std::min(miny, (int)m_points[i].y);
@@ -240,7 +240,7 @@ namespace Marvel {
 
 	void mvDrawing::convertToModelSpace(std::vector<mvVec2>& points, const std::vector<mvVec2>& pointso)
 	{
-		for (int i = 0; i < points.size(); i++)
+		for (size_t i = 0; i < points.size(); i++)
 		{
 			points[i].x = pointso[i].x * m_scalex + m_originx;
 			points[i].y = (float)m_height - pointso[i].y * m_scaley - m_originy;
@@ -658,7 +658,7 @@ namespace Marvel {
 	{
 
 		bool tagFound = false;
-		int index = 0;
+		size_t index = 0;
 
 		for(index = 0; index < m_commands.size(); index++)
 		{

--- a/DearPyGui/src/Core/AppItems/mvTable.cpp
+++ b/DearPyGui/src/Core/AppItems/mvTable.cpp
@@ -22,7 +22,7 @@ namespace Marvel {
 			return false;
 		}
 
-		if (column > m_columns + 1 || row > (int)m_values.size() + 1)
+		if (static_cast<size_t>(column) > m_columns + 1 || static_cast<size_t>(row) > m_values.size() + 1)
 		{
 			ThrowPythonException("Table indices out of range.");
 			return false;
@@ -181,7 +181,7 @@ namespace Marvel {
 
 		else
 		{
-			int index = 0;
+			size_t index = 0;
 			for (auto& row : m_values)
 			{
 				if (index >= column.size())
@@ -207,7 +207,7 @@ namespace Marvel {
 		if (!isIndexValid(0, column_index))
 			return;
 
-		if (column_index == m_headers.size())
+		if (static_cast<size_t>(column_index) == m_headers.size())
 		{
 			addColumn(name, column);
 			return;
@@ -222,9 +222,9 @@ namespace Marvel {
 
 		for (size_t i = 0; i < m_columns; i++)
 		{
-			if (i < column_index)
+			if (i < static_cast<size_t>(column_index))
 				m_headers.push_back(oldHeaders[i]);
-			else if (i == column_index)
+			else if (i == static_cast<size_t>(column_index))
 				m_headers.push_back(name);
 			else
 				m_headers.push_back(oldHeaders[i - 1]);
@@ -239,13 +239,13 @@ namespace Marvel {
 					std::vector<std::string> row;
 					for (size_t j = 0; j < oldHeaders.size(); j++)
 					{
-						if (j == column_index)
+						if (j == static_cast<size_t>(column_index))
 						{
 							row.push_back(column[i]);
 							continue;
 						}
 
-						if (j > column_index)
+						if (j > static_cast<size_t>(column_index))
 							row.push_back(oldValues[i][j - 1]);
 
 						else
@@ -262,7 +262,7 @@ namespace Marvel {
 					std::vector<std::string> row;
 					for (size_t j = 0; j < oldHeaders.size(); j++)
 					{
-						if (j == column_index)
+						if (j == static_cast<size_t>(column_index))
 						{
 							row.push_back(column[i]);
 							continue;
@@ -283,7 +283,7 @@ namespace Marvel {
 				std::vector<std::string> row;
 				for (size_t j = 0; j < oldHeaders.size(); j++)
 				{
-					if (j == column_index)
+					if (j == static_cast<size_t>(column_index))
 					{
 						if (i >= column.size())
 							row.emplace_back("");
@@ -292,7 +292,7 @@ namespace Marvel {
 						continue;
 					}
 
-					if (j > column_index)
+					if (j > static_cast<size_t>(column_index))
 						row.push_back(oldValues[i][j - 1]);
 
 					else
@@ -329,7 +329,7 @@ namespace Marvel {
 		if (!isIndexValid(row_index, 0))
 			return;
 
-		if (row_index >= m_values.size())
+		if (static_cast<size_t>(row_index) >= m_values.size())
 		{
 			addRow(row);
 			return;
@@ -341,13 +341,13 @@ namespace Marvel {
 
 		for (size_t i = 0; i < oldValues.size(); i++)
 		{
-			if (i == row_index)
+			if (i == static_cast<size_t>(row_index))
 			{
 				m_values.push_back(row);
 				continue;
 			}
 
-			if(i > row_index)
+			if(i > static_cast<size_t>(row_index))
 				m_values.push_back(oldValues[i-1]);
 			else
 				m_values.push_back(oldValues[i]);
@@ -424,7 +424,7 @@ namespace Marvel {
 		if (!isIndexValid(0, column))
 			return;
 
-		if (column >= m_headers.size())
+		if (static_cast<size_t>(column) >= m_headers.size())
 		{
 			ThrowPythonException("Column to delete does not exist.");
 			return;
@@ -439,7 +439,7 @@ namespace Marvel {
 
 		for (size_t i = 0; i < oldHeaders.size(); i++)
 		{
-			if (i == column)
+			if (i == static_cast<size_t>(column))
 				continue;
 			m_headers.push_back(oldHeaders[i]);
 		}
@@ -450,7 +450,7 @@ namespace Marvel {
 			std::vector<std::string> row;
 			for (size_t j = 0; j < oldHeaders.size(); j++)
 			{
-				if (j == column)
+				if (j == static_cast<size_t>(column))
 					continue;
 				row.push_back(oldvalue[j]);
 			}

--- a/DearPyGui/src/Core/AppItems/mvTable.h
+++ b/DearPyGui/src/Core/AppItems/mvTable.h
@@ -53,7 +53,7 @@ namespace Marvel {
 		std::vector<std::string>              m_headers;
 		std::vector<std::vector<std::string>> m_hashValues;
 		std::vector<std::vector<std::string>> m_values;
-		int                                   m_columns;
+		size_t                                m_columns;
 
 	};
 

--- a/DearPyGui/src/Core/PlotAppItems/mvAreaSeries.cpp
+++ b/DearPyGui/src/Core/PlotAppItems/mvAreaSeries.cpp
@@ -20,13 +20,13 @@ namespace Marvel {
 
 		if (m_fill.specified)
 		{
-			int i;
+			size_t i;
 			int y;
 			int miny, maxy;
 			int x1, y1;
 			int x2, y2;
 			int ind1, ind2;
-			int ints;
+			size_t ints;
 			size_t n = points.size();
 			int* polyints = new int[n];
 

--- a/DearPyGui/src/Core/PythonCommands/mvBasicWidgetInterface.cpp
+++ b/DearPyGui/src/Core/PythonCommands/mvBasicWidgetInterface.cpp
@@ -622,10 +622,10 @@ namespace Marvel {
 			&height, &uv_min, &uv_max, &popup, &show))
 			return ToPyBool(false);
 
-		auto mtintcolor = ToColor(tintcolor);
-		auto mbordercolor = ToColor(bordercolor);
-		mvVec2 muv_min = ToVec2(uv_min);
-		mvVec2 muv_max = ToVec2(uv_max);
+		//auto mtintcolor = ToColor(tintcolor);
+		//auto mbordercolor = ToColor(bordercolor);
+		//mvVec2 muv_min = ToVec2(uv_min);
+		//mvVec2 muv_max = ToVec2(uv_max);
 
 		mvAppItem* item = new mvImage(name, value);
 
@@ -672,10 +672,10 @@ namespace Marvel {
 			&before, &width, &height, &frame_padding, &uv_min, &uv_max, &popup, &show))
 			return ToPyBool(false);
 
-		auto mtintcolor = ToColor(tintcolor);
-		auto mbackgroundColor = ToColor(backgroundColor);
-		mvVec2 muv_min = ToVec2(uv_min);
-		mvVec2 muv_max = ToVec2(uv_max);
+		//auto mtintcolor = ToColor(tintcolor);
+		//auto mbackgroundColor = ToColor(backgroundColor);
+		//mvVec2 muv_min = ToVec2(uv_min);
+		//mvVec2 muv_max = ToVec2(uv_max);
 
 		mvAppItem* item = new mvImageButton(name, value);
 		if (callback)
@@ -855,7 +855,7 @@ namespace Marvel {
 		int show = true;
 		int span_columns = false;
 
-		ImGuiSelectableFlags flags = ImGuiSelectableFlags_None;
+		//ImGuiSelectableFlags flags = ImGuiSelectableFlags_None;
 
 		if (!(*mvApp::GetApp()->getParsers())["add_selectable"].parse(args, kwargs, __FUNCTION__, &name,
 			&default_value, &callback, &callback_data, &tip, &parent, &before, &source, &disabled,

--- a/DearPyGui/src/Core/PythonCommands/mvContainerInterface.cpp
+++ b/DearPyGui/src/Core/PythonCommands/mvContainerInterface.cpp
@@ -601,7 +601,7 @@ namespace Marvel {
 		int show = true;
 		PyObject* closing_callback = nullptr;
 
-		ImGuiWindowFlags flags = ImGuiWindowFlags_NoSavedSettings;
+		//ImGuiWindowFlags flags = ImGuiWindowFlags_NoSavedSettings;
 
 		if (!(*mvApp::GetApp()->getParsers())["add_window"].parse(args, kwargs, __FUNCTION__, &name, &width,
 			&height, &x_pos, &y_pos, &autosize, &no_resize, &no_title_bar, &no_move, &no_scrollbar, 

--- a/DearPyGui/src/Core/PythonCommands/mvInputsInterface.cpp
+++ b/DearPyGui/src/Core/PythonCommands/mvInputsInterface.cpp
@@ -201,7 +201,7 @@ namespace Marvel {
 		const char* popup = "";
 		int show = true;
 
-		int flags = 0;
+		//int flags = 0;
 
 		if (!(*mvApp::GetApp()->getParsers())["add_input_text"].parse(args, kwargs, __FUNCTION__, 
 			&name, &default_value, &hint, &multiline, &no_spaces,

--- a/DearPyGui/src/Core/PythonCommands/mvSliderInterface.cpp
+++ b/DearPyGui/src/Core/PythonCommands/mvSliderInterface.cpp
@@ -238,9 +238,9 @@ namespace Marvel {
 			&on_enter, &label, &popup, &show))
 			return ToPyBool(false);
 
-		ImGuiInputTextFlags flags = 0;
-		if (on_enter)
-			flags = ImGuiInputTextFlags_EnterReturnsTrue;
+		//ImGuiInputTextFlags flags = 0;
+		//if (on_enter)
+		//	flags = ImGuiInputTextFlags_EnterReturnsTrue;
 
 		auto vec = ToFloatVect(default_value);
 

--- a/DearPyGui/src/Core/StandardWindows/mvDebugWindow.cpp
+++ b/DearPyGui/src/Core/StandardWindows/mvDebugWindow.cpp
@@ -138,8 +138,8 @@ namespace Marvel {
 				DebugItem("Int3 Values", std::to_string(mvValueStorage::s_int3s.size()).c_str());
 				DebugItem("Int4 Values", std::to_string(mvValueStorage::s_int4s.size()).c_str());
 				ImGui::Separator();
-				auto & yy = mvValueStorage::s_refStorage;
-				auto & xx = mvValueStorage::s_floats;
+				//auto & yy = mvValueStorage::s_refStorage;
+				//auto & xx = mvValueStorage::s_floats;
 				DebugItem("Float Values", std::to_string(mvValueStorage::s_floats.size()).c_str());
 				DebugItem("Float2 Values", std::to_string(mvValueStorage::s_float2s.size()).c_str());
 				DebugItem("Float3 Values", std::to_string(mvValueStorage::s_float3s.size()).c_str());
@@ -263,7 +263,7 @@ namespace Marvel {
 			if (ImGui::BeginTabItem("Commands##debug"))
 			{
 
-				static int commandselection = 0;
+				static size_t commandselection = 0;
 				const char* commanddoc = m_commands[commandselection].second.c_str();
 				static ImGuiTextFilter filter;
 				filter.Draw();

--- a/DearPyGui/src/Core/StandardWindows/mvDocWindow.cpp
+++ b/DearPyGui/src/Core/StandardWindows/mvDocWindow.cpp
@@ -636,7 +636,7 @@ namespace Marvel {
 			if (ImGui::BeginTabItem("Search Commands##doc"))
 			{
 
-				static int commandselection = 0;
+				static size_t commandselection = 0;
 				const char* commanddoc = m_commands[commandselection].second.c_str();
 				static ImGuiTextFilter filter;
 				filter.Draw();

--- a/DearPyGui/src/Core/mvDataStorage.cpp
+++ b/DearPyGui/src/Core/mvDataStorage.cpp
@@ -87,7 +87,7 @@ namespace Marvel {
 			return nullptr;
 		}
 		Py_XINCREF(s_dataStorage.at(name));
-		auto blah = s_dataStorage.at(name);
+		//auto blah = s_dataStorage.at(name);
 		return s_dataStorage.at(name);
 	}
 

--- a/DearPyGui/src/Core/mvPythonExceptions.cpp
+++ b/DearPyGui/src/Core/mvPythonExceptions.cpp
@@ -1,0 +1,22 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <frameobject.h>
+#include <string>
+#include "mvPythonTranslator.h"
+
+namespace Marvel
+{
+
+	void ThrowPythonException(const std::string& message)
+	{
+
+		std::string fullMessage = "Line: %d \t" + message;
+
+		mvGlobalIntepreterLock gil;
+
+		int line = PyFrame_GetLineNumber(PyEval_GetFrame());
+		PyErr_Format(PyExc_Exception, fullMessage.c_str(), line);
+		PyErr_Print();
+	}
+
+}

--- a/DearPyGui/src/Core/mvPythonExceptions.h
+++ b/DearPyGui/src/Core/mvPythonExceptions.h
@@ -9,16 +9,6 @@
 namespace Marvel
 {
 
-	static void ThrowPythonException(const std::string& message)
-	{
-
-		std::string fullMessage = "Line: %d \t" + message;
-
-		mvGlobalIntepreterLock gil;
-
-		int line = PyFrame_GetLineNumber(PyEval_GetFrame());
-		PyErr_Format(PyExc_Exception, fullMessage.c_str(), line);
-		PyErr_Print();
-	}
+	void ThrowPythonException(const std::string& message);
 
 }

--- a/DearPyGui/src/Core/mvPythonParser.cpp
+++ b/DearPyGui/src/Core/mvPythonParser.cpp
@@ -183,7 +183,7 @@ namespace Marvel {
 
 			bool adddefault = false;
 
-			for (int i = 0; i < elements.size(); i++)
+			for (size_t i = 0; i < elements.size(); i++)
 			{
 				if (elements[i].type == mvPythonDataType::KeywordOnly || elements[i].type == mvPythonDataType::Optional)
 				{

--- a/DearPyGui/src/Core/mvPythonTranslator.cpp
+++ b/DearPyGui/src/Core/mvPythonTranslator.cpp
@@ -28,9 +28,9 @@ namespace Marvel {
 		}
 		
 
-		for (size_t i = 0; i < PyList_Size(pyvalue); i++)
+		for (Py_ssize_t i = 0; i < PyList_Size(pyvalue); i++)
 		{
-			if (i == value.size())
+			if (static_cast<size_t>(i) == value.size())
 				break;
 			PyList_SetItem(pyvalue, i, PyLong_FromLong(value[i]));
 		}
@@ -49,9 +49,9 @@ namespace Marvel {
 		}
 
 
-		for (size_t i = 0; i < PyList_Size(pyvalue); i++)
+		for (Py_ssize_t i = 0; i < PyList_Size(pyvalue); i++)
 		{
-			if (i == value.size())
+			if (static_cast<size_t>(i) == value.size())
 				break;
 			PyList_SetItem(pyvalue, i, PyFloat_FromDouble(value[i]));
 		}
@@ -70,14 +70,14 @@ namespace Marvel {
 		}
 
 
-		for (size_t i = 0; i < PyList_Size(pyvalue); i++)
+		for (Py_ssize_t i = 0; i < PyList_Size(pyvalue); i++)
 		{
-			if (i == value.size())
+			if (static_cast<size_t>(i) == value.size())
 				break;
 			PyObject* row = PyList_GetItem(pyvalue, i);
-			for (size_t j = 0; j < PyList_Size(row); j++)
+			for (Py_ssize_t j = 0; j < PyList_Size(row); j++)
 			{
-				if (j == value[i].size())
+				if (static_cast<size_t>(j) == value[i].size())
 					break;
 				PyList_SetItem(row, i, PyUnicode_FromString(value[i][j].c_str()));
 			}
@@ -240,7 +240,7 @@ namespace Marvel {
 
 		PyObject* result = PyList_New(count);
 
-		for (size_t i = 0; i < count; i++)
+		for (int i = 0; i < count; i++)
 			PyList_SetItem(result, i, PyLong_FromLong(value[i]));
 
 		return result;
@@ -252,7 +252,7 @@ namespace Marvel {
 
 		PyObject* result = PyList_New(count);
 
-		for (size_t i = 0; i < count; i++)
+		for (int i = 0; i < count; i++)
 			PyList_SetItem(result, i, PyFloat_FromDouble(value[i]));
 
 		return result;
@@ -368,7 +368,7 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 			{
 				PyObject* item = PyTuple_GetItem(value, i);
 				if(PyLong_Check(item))
@@ -378,7 +378,7 @@ namespace Marvel {
 
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 			{
 				PyObject* item = PyList_GetItem(value, i);
 				if (PyLong_Check(item))
@@ -403,7 +403,7 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 			{
 				PyObject* item = PyTuple_GetItem(value, i);
 				if (PyNumber_Check(item))
@@ -413,7 +413,7 @@ namespace Marvel {
 
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 			{
 				PyObject* item = PyList_GetItem(value, i);
 				if (PyNumber_Check(item))
@@ -438,7 +438,7 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 			{
 				PyObject* item = PyTuple_GetItem(value, i);
 				if (PyUnicode_Check(item))
@@ -454,7 +454,7 @@ namespace Marvel {
 
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 			{
 				PyObject* item = PyList_GetItem(value, i);
 				if (PyUnicode_Check(item))
@@ -486,7 +486,7 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 			{
 				if (i >= 4)
 					break;
@@ -498,7 +498,7 @@ namespace Marvel {
 		}
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 			{
 				if (i >= 4)
 					break;
@@ -554,7 +554,7 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 			{
 				PyObject* item = PyTuple_GetItem(value, i);
 				if (PyTuple_Size(item) == 2)
@@ -565,7 +565,7 @@ namespace Marvel {
 		}
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 			{
 				PyObject* item = PyList_GetItem(value, i);
 				if (PyList_Size(item) == 2)
@@ -589,12 +589,12 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 				items.push_back(ToVec2(PyTuple_GetItem(value, i)));
 		}
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 				items.push_back(ToVec2(PyList_GetItem(value, i)));
 		}
 
@@ -613,12 +613,12 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 				items.push_back(ToVec4(PyTuple_GetItem(value, i)));
 		}
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 				items.push_back(ToVec4(PyList_GetItem(value, i)));
 		}
 
@@ -637,7 +637,7 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 			{
 				PyObject* point = PyTuple_GetItem(value, i);
 				if(PyTuple_Check(point))
@@ -663,7 +663,7 @@ namespace Marvel {
 
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 			{
 				PyObject* point = PyList_GetItem(value, i);
                 if(PyTuple_Check(point))
@@ -703,13 +703,13 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 				items.emplace_back(ToStringVect(PyTuple_GetItem(value, i), message));
 		}
 
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 				items.emplace_back(ToStringVect(PyList_GetItem(value, i), message));
 		}
 
@@ -725,7 +725,7 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 			{
 				PyObject* item = PyTuple_GetItem(value, i);
 				if (PyTuple_Size(item) == 2)
@@ -736,7 +736,7 @@ namespace Marvel {
 		}
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 			{
 				PyObject* item = PyList_GetItem(value, i);
 				if (PyList_Size(item) == 2)
@@ -760,13 +760,13 @@ namespace Marvel {
 
 		if (PyTuple_Check(value))
 		{
-			for (size_t i = 0; i < PyTuple_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyTuple_Size(value); i++)
 				items.emplace_back(ToFloatVect(PyTuple_GetItem(value, i), message));
 		}
 
 		else if (PyList_Check(value))
 		{
-			for (size_t i = 0; i < PyList_Size(value); i++)
+			for (Py_ssize_t i = 0; i < PyList_Size(value); i++)
 				items.emplace_back(ToFloatVect(PyList_GetItem(value, i), message));
 		}
 

--- a/DearPyGui/src/Core/mvValueStorage.cpp
+++ b/DearPyGui/src/Core/mvValueStorage.cpp
@@ -712,6 +712,7 @@ namespace Marvel {
 			case ValueTypes::Int2: return s_int2s[name].data();
 			case ValueTypes::Int3: return s_int3s[name].data();
 			case ValueTypes::Int4: return s_int4s[name].data();
+			default: return nullptr; // should not get here; silence compiler warning
 			}
 		}
 		return &s_ints["common"];
@@ -726,6 +727,7 @@ namespace Marvel {
 			case ValueTypes::Int2: return s_int2s[name].data();
 			case ValueTypes::Int3: return s_int3s[name].data();
 			case ValueTypes::Int4: return s_int4s[name].data();
+			default: return nullptr; // should not get here; silence compiler warning
 			}
 		}
 		return s_int2s["common"].data();
@@ -739,6 +741,7 @@ namespace Marvel {
 			{
 			case ValueTypes::Int3: return s_int3s[name].data();
 			case ValueTypes::Int4: return s_int4s[name].data();
+			default: return nullptr; // should not get here; silence compiler warning
 			}
 		}
 		return s_int3s["common"].data();
@@ -762,6 +765,7 @@ namespace Marvel {
 			case ValueTypes::Float3: return s_float3s[name].data();
 			case ValueTypes::Float4: return s_float4s[name].data();
 			case ValueTypes::FloatVect: return s_floatvects[name].data();
+			default: return nullptr; // should not get here; silence compiler warning
 			}
 		}
 		return &s_floats["common"];
@@ -777,6 +781,7 @@ namespace Marvel {
 			case ValueTypes::Float3: return s_float3s[name].data();
 			case ValueTypes::Float4: return s_float4s[name].data();
 			case ValueTypes::FloatVect: return s_floatvects[name].data();
+			default: return nullptr; // should not get here; silence compiler warning
 			}
 		}
 		return s_float2s["common"].data();
@@ -791,6 +796,7 @@ namespace Marvel {
 			case ValueTypes::Float3: return s_float3s[name].data();
 			case ValueTypes::Float4: return s_float4s[name].data();
 			case ValueTypes::FloatVect: return s_floatvects[name].data();
+			default: return nullptr; // should not get here; silence compiler warning
 			}
 		}
 		return s_float3s["common"].data();
@@ -805,6 +811,7 @@ namespace Marvel {
 			case ValueTypes::Color: return s_float4s[name].data();
 			case ValueTypes::Float4: return s_float4s[name].data();
 			case ValueTypes::FloatVect: return s_floatvects[name].data();
+			default: return nullptr; // should not get here; silence compiler warning
 			}
 		}
 		return s_float4s["common"].data();
@@ -892,6 +899,7 @@ namespace Marvel {
 			case ValueTypes::Bool: s_bools.erase(name); break;
 			case ValueTypes::FloatVect: s_floatvects.erase(name); break;
 			case ValueTypes::Time: s_times.erase(name); s_imtimes.erase(name); break;
+			default: break; // should not get here; silence compiler warning
 			}
 
 			s_typeStorage.erase(name);

--- a/DearPyGui/src/Platform/Linux/mvUtilities.cpp
+++ b/DearPyGui/src/Platform/Linux/mvUtilities.cpp
@@ -33,7 +33,7 @@ namespace Marvel {
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, image_width, image_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image_data);
         stbi_image_free(image_data);
 
-        storage.texture = (void *)image_texture;
+        storage.texture = reinterpret_cast<void *>(image_texture);
         storage.width = image_width;
         storage.height = image_height;
 


### PR DESCRIPTION
This commit fixes almost all compiler warning with gcc 10.2.1, and should ease the development of new code. There are a few static_cast here and there; these should be dropped later, but this would need to change the declaration of some methods (int -> size_t). I've chosen to cast int into size_t because, if I get it right, having those int variables negative would be an error anyway; this way we are sure that the int fits into what it is being casted.