### PR TITLE
Fix issue #246

### DIFF
--- a/DearPyGui/dearpygui/core.pyi
+++ b/DearPyGui/dearpygui/core.pyi
@@ -248,7 +248,8 @@ def add_label_text(name: str, value: str = "", color: List[float] = [0, 0, 0, -1
 	"""Adds text with a label. Useful for output values."""
 	...
 
-def add_line_series(plot: str, name: str, data: List[List[float]], color: List[float] = [0, 0, 0, -1], weight: float = 1.0, update_bounds: bool = True) -> None:
+def add_line_series(plot: str, name: str, data: List[List[float]], color: List[float] = [0, 0, 0, -1], 
+					weight: float = 1.0, update_bounds: bool = True, xy_data_format: bool = False) -> None:
 	"""Adds a line series to a plot."""
 	...
 
@@ -320,7 +321,8 @@ def add_same_line(name: str = "sameline", xoffset: float = 0.0, spacing: float =
 	...
 
 def add_scatter_series(plot: str, name: str, data: List[float], marker: int = 2, size: float = 4.0, weight: float = 1.0, 
-					   outline: List[float] = [0, 0, 0, -1], fill: List[float] = [0, 0, 0, -1], update_bounds: bool = True) -> None:
+					   outline: List[float] = [0, 0, 0, -1], fill: List[float] = [0, 0, 0, -1], update_bounds: bool = True,
+					   xy_data_format: bool = False) -> None:
 	"""Adds a scatter series to a plot."""
 	...
 

--- a/DearPyGui/dearpygui/demo.py
+++ b/DearPyGui/dearpygui/demo.py
@@ -812,14 +812,18 @@ def show_demo():
                     #sindata.append([3.14*i/180, 0.5+ 0.5*cos(50*3.14*i/180)])
                     sindata.append([i/1000, 0.5 + 0.5*sin(50*i/1000)])
 
-                x2data = []
+                # using xy_format
+                x2datax = []
+                x2datay = []
                 for i in range(0, 100):
-                    x2data.append([1/(i+1), (1/(i+1))**2])
+                    x2datax.append(1/(i+1))
+                    x2datay.append((1/(i+1))**2)
+                x2data = [x2datax, x2datay]
 
                 add_text("Anti-aliasing can be enabled from the plot's context menu (see Help).", bullet=True)
                 add_plot("Line Plot##demo", x_axis_name="x", y_axis_name="y", height=400)
                 add_line_series("Line Plot##demo", "0.5 + 0.5 * sin(x)", sindata)
-                add_line_series("Line Plot##demo", "x^2", x2data)
+                add_line_series("Line Plot##demo", "x^2", x2data, xy_data_format=True)
 
             with tree_node("Time Plots##demo"):
 
@@ -835,7 +839,6 @@ def show_demo():
                 add_plot("Time Plot##demo", y_axis_name="Days since 1970", height=400, xaxis_time=True)
                 add_line_series("Time Plot##demo", "Days", timedata)
                 
-
             with tree_node("Shade Plots##demo"):
 
                 stock_data1 = []
@@ -857,16 +860,21 @@ def show_demo():
             with tree_node("Scatter Plots##demo"):
 
                 scatter_data1 = []
-                scatter_data2 = []
                 for i in range(0, 100):
                     scatter_data1.append([i/100, (i + random.random())/100])
 
+                # using xy_format
+                scatter_data2x = []
+                scatter_data2y = []
                 for i in range(0, 100):
-                    scatter_data2.append([0.25 + 0.25*random.random(), 0.65 + 0.25*random.random()])
+                    scatter_data2x.append(0.25 + 0.25*random.random())
+                    scatter_data2y.append(0.65 + 0.25*random.random())
+                scatter_data2 = [scatter_data2x, scatter_data2y]
 
                 add_plot("Scatter Plot##demo", height=400)
                 add_scatter_series("Scatter Plot##demo", "Data 1", scatter_data1)
-                add_scatter_series("Scatter Plot##demo", "Data 2", scatter_data2, size=7, marker=mvPlotMarker_Square, fill=[255, 0, 0, 100])
+                add_scatter_series("Scatter Plot##demo", "Data 2", scatter_data2, 
+                                   size=7, marker=mvPlotMarker_Square, fill=[255, 0, 0, 100], xy_data_format=True)
 
             with tree_node("Bar Plots##demo"):
 

--- a/DearPyGui/include/mvPythonTranslator.h
+++ b/DearPyGui/include/mvPythonTranslator.h
@@ -78,6 +78,7 @@ namespace Marvel {
 	tm          ToTime  (PyObject* value, const std::string& message = "Type must be a dict");
 
 	std::vector<mvVec2>                              ToVectVec2           (PyObject* value, const std::string& message = "Type must be a list/tuple of list/tuple.");
+	std::pair<std::vector<float>, std::vector<float>>ToPairVec            (PyObject* value, const std::string& message = "Type must be a list/tuple of two list/tuple.");
 	std::vector<mvVec4>                              ToVectVec4           (PyObject* value, const std::string& message = "Type must be a list/tuple of list/tuple.");
 	std::vector<int>                                 ToIntVect            (PyObject* value, const std::string& message = "Type must be a list or tuple of integers.");
 	std::vector<float>                               ToFloatVect          (PyObject* value, const std::string& message = "Type must be a list or tuple of floats.");

--- a/DearPyGui/src/Core/PlotAppItems/mvLineSeries.h
+++ b/DearPyGui/src/Core/PlotAppItems/mvLineSeries.h
@@ -14,6 +14,12 @@ namespace Marvel {
 		{
 		}
 
+		mvLineSeries(const std::string& name, const std::vector<float>& points_x,
+			const std::vector<float>& points_y, mvColor color)
+			: mvSeries(name, points_x, points_y), m_color(color)
+		{
+		}
+
 		mvSeriesType getSeriesType() override { return mvSeriesType::Line; }
 
 		void draw() override

--- a/DearPyGui/src/Core/PlotAppItems/mvPlot.cpp
+++ b/DearPyGui/src/Core/PlotAppItems/mvPlot.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "mvPlot.h"
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -59,6 +61,27 @@ namespace Marvel {
 			m_extra1.push_back(point.z);
 			m_extra2.push_back(point.w);
 		}
+
+	}
+
+	mvSeries::mvSeries(std::string name, const std::vector<float>& points_x, const std::vector<float>& points_y)
+		: m_name(std::move(name))
+	{
+		// FIXME:
+		// Need to check if points_x.size() == points_y.size() ???
+		
+		if (!points_x.empty())
+		{
+			auto minmax = minmax_element(points_x.begin(), points_x.end());
+			m_maxX = *minmax.second;
+			m_minX = *minmax.first;
+			minmax = minmax_element(points_y.begin(), points_y.end());
+			m_maxY = *minmax.second;
+			m_minY = *minmax.first;
+		}
+		
+		m_xs = points_x;
+		m_ys = points_y;
 
 	}
 

--- a/DearPyGui/src/Core/PlotAppItems/mvPlot.h
+++ b/DearPyGui/src/Core/PlotAppItems/mvPlot.h
@@ -197,6 +197,7 @@ namespace Marvel {
 		mvSeries(std::string  name, const ImPlotPoint& boundsMin, const ImPlotPoint& boundsMax);
 		mvSeries(std::string  name, const std::vector<mvVec2>& points);
 		mvSeries(std::string  name, const std::vector<mvVec4>& points);
+		mvSeries(std::string  name, const std::vector<float>& points_x, const std::vector<float>& points_y);
 		mvSeries(std::string  name, const std::vector<std::vector<float>>& points);
 
 		virtual ~mvSeries() = default;

--- a/DearPyGui/src/Core/PlotAppItems/mvScatterSeries.h
+++ b/DearPyGui/src/Core/PlotAppItems/mvScatterSeries.h
@@ -15,6 +15,14 @@ namespace Marvel {
 		{
 		}
 
+		mvScatterSeries(const std::string& name, const std::vector<float>& points_x, const std::vector<float>& points_y, 
+			int marker, float markerSize, float markerWeight,
+			mvColor markerOutlineColor, mvColor markerFillColor)
+			: mvSeries(name, points_x, points_y), m_marker(marker), m_markerSize(markerSize), m_markerWeight(markerWeight),
+			m_markerOutlineColor(markerOutlineColor), m_markerFillColor(markerFillColor)
+		{
+		}
+
 		mvSeriesType getSeriesType() override { return mvSeriesType::Scatter; }
 
 		void draw() override

--- a/DearPyGui/src/Core/PythonCommands/mvPlotInterface.cpp
+++ b/DearPyGui/src/Core/PythonCommands/mvPlotInterface.cpp
@@ -197,6 +197,7 @@ namespace Marvel {
 			{mvPythonDataType::FloatList, "color"},
 			{mvPythonDataType::Float, "weight"},
 			{mvPythonDataType::Bool, "update_bounds"},
+			{mvPythonDataType::Bool, "xy_data_format"},
 		}, "Adds a line series to a plot.", "None", "Plotting") });
 
 		parsers->insert({ "add_error_series", mvPythonParser({
@@ -245,6 +246,7 @@ namespace Marvel {
 			{mvPythonDataType::FloatList, "outline"},
 			{mvPythonDataType::FloatList, "fill"},
 			{mvPythonDataType::Bool, "update_bounds"},
+			{mvPythonDataType::Bool, "xy_data_format"},
 		}, "Adds a scatter series to a plot.", "None", "Plotting") });
 
 		parsers->insert({ "add_stem_series", mvPythonParser({
@@ -1160,9 +1162,10 @@ namespace Marvel {
 		PyTuple_SetItem(color, 2, PyLong_FromLong(0));
 		PyTuple_SetItem(color, 3, PyLong_FromLong(255));
 		int update_bounds = true;
+		bool xy_data_format = false;
 
 		if (!(*mvApp::GetApp()->getParsers())["add_line_series"].parse(args, kwargs, __FUNCTION__, 
-			&plot, &name, &data, &color, &weight, &update_bounds))
+			&plot, &name, &data, &color, &weight, &update_bounds, &xy_data_format))
 			return GetPyNone();
 
 		if (!PyList_Check(data))
@@ -1190,14 +1193,25 @@ namespace Marvel {
 
 		mvPlot* graph = static_cast<mvPlot*>(aplot);
 
-		auto datapoints = ToVectVec2(data);
-
 		auto mcolor = ToColor(color);
 
-		if (datapoints.size() == 0)
-			return GetPyNone();
+		mvLineSeries* series;
+		
+		if (xy_data_format) {
+			auto datapoints = ToPairVec(data);
+			
+			if (datapoints.first.size() == 0 || datapoints.first.size() != datapoints.second.size())
+				return GetPyNone();
 
-		auto series = new mvLineSeries(name, datapoints, mcolor);
+			series = new mvLineSeries(name, datapoints.first, datapoints.second, mcolor);
+		} else {
+			auto datapoints = ToVectVec2(data);
+
+			if (datapoints.size() == 0)
+				return GetPyNone();
+
+			series = new mvLineSeries(name, datapoints, mcolor);
+		}
 		series->setWeight(weight);
 		graph->updateSeries(series, update_bounds);
 
@@ -1336,9 +1350,10 @@ namespace Marvel {
 		PyTuple_SetItem(fill, 2, PyLong_FromLong(0));
 		PyTuple_SetItem(fill, 3, PyLong_FromLong(255));
 		int update_bounds = true;
+		bool xy_data_format = false;
 
 		if (!(*mvApp::GetApp()->getParsers())["add_scatter_series"].parse(args, kwargs, __FUNCTION__, &plot, &name, &data, &marker,
-			&size, &weight, &outline, &fill, &update_bounds))
+			&size, &weight, &outline, &fill, &update_bounds, &xy_data_format))
 			return GetPyNone();
 
 		if (!PyList_Check(data))
@@ -1366,17 +1381,31 @@ namespace Marvel {
 
 		mvPlot* graph = static_cast<mvPlot*>(aplot);
 
-		auto datapoints = ToVectVec2(data);
+		mvScatterSeries* series;
 
 		auto mmarkerOutlineColor = ToColor(outline);
 
 		auto mmarkerFillColor = ToColor(fill);
 
-		if (datapoints.size() == 0)
-			return GetPyNone();
+		auto datapoints = ToVectVec2(data);
 
-		graph->updateSeries(new mvScatterSeries(name, datapoints, marker, size, weight, mmarkerOutlineColor,
-			mmarkerFillColor), update_bounds);
+		if (xy_data_format) {
+			auto datapoints = ToPairVec(data);
+			
+			if (datapoints.first.size() == 0 || datapoints.first.size() != datapoints.second.size())
+				return GetPyNone();
+
+			series = new mvScatterSeries(name, datapoints.first, datapoints.second, marker, size, 
+				weight, mmarkerOutlineColor, mmarkerFillColor);
+		} else {
+			if (datapoints.size() == 0)
+				return GetPyNone();
+				
+			series = new mvScatterSeries(name, datapoints, marker, size, weight, mmarkerOutlineColor,
+				mmarkerFillColor);
+		}
+		
+		graph->updateSeries(series, update_bounds);
 
 		return GetPyNone();
 	}

--- a/DearPyGui/src/Core/PythonCommands/mvPlotInterface.cpp
+++ b/DearPyGui/src/Core/PythonCommands/mvPlotInterface.cpp
@@ -1162,7 +1162,7 @@ namespace Marvel {
 		PyTuple_SetItem(color, 2, PyLong_FromLong(0));
 		PyTuple_SetItem(color, 3, PyLong_FromLong(255));
 		int update_bounds = true;
-		bool xy_data_format = false;
+		int xy_data_format = false;
 
 		if (!(*mvApp::GetApp()->getParsers())["add_line_series"].parse(args, kwargs, __FUNCTION__, 
 			&plot, &name, &data, &color, &weight, &update_bounds, &xy_data_format))
@@ -1197,14 +1197,20 @@ namespace Marvel {
 
 		mvLineSeries* series;
 		
-		if (xy_data_format) {
+		if (xy_data_format) 
+		{
 			auto datapoints = ToPairVec(data);
 			
 			if (datapoints.first.size() == 0 || datapoints.first.size() != datapoints.second.size())
+			{
+				ThrowPythonException(std::string(plot) + " data format incorrect");
 				return GetPyNone();
+			}
 
 			series = new mvLineSeries(name, datapoints.first, datapoints.second, mcolor);
-		} else {
+		}
+		else 
+		{
 			auto datapoints = ToVectVec2(data);
 
 			if (datapoints.size() == 0)
@@ -1212,6 +1218,7 @@ namespace Marvel {
 
 			series = new mvLineSeries(name, datapoints, mcolor);
 		}
+
 		series->setWeight(weight);
 		graph->updateSeries(series, update_bounds);
 
@@ -1350,7 +1357,7 @@ namespace Marvel {
 		PyTuple_SetItem(fill, 2, PyLong_FromLong(0));
 		PyTuple_SetItem(fill, 3, PyLong_FromLong(255));
 		int update_bounds = true;
-		bool xy_data_format = false;
+		int xy_data_format = false;
 
 		if (!(*mvApp::GetApp()->getParsers())["add_scatter_series"].parse(args, kwargs, __FUNCTION__, &plot, &name, &data, &marker,
 			&size, &weight, &outline, &fill, &update_bounds, &xy_data_format))
@@ -1389,15 +1396,21 @@ namespace Marvel {
 
 		auto datapoints = ToVectVec2(data);
 
-		if (xy_data_format) {
+		if (xy_data_format) 
+		{
 			auto datapoints = ToPairVec(data);
 			
 			if (datapoints.first.size() == 0 || datapoints.first.size() != datapoints.second.size())
+			{
+				ThrowPythonException(std::string(plot) + " data format incorrect");
 				return GetPyNone();
+			}
 
 			series = new mvScatterSeries(name, datapoints.first, datapoints.second, marker, size, 
 				weight, mmarkerOutlineColor, mmarkerFillColor);
-		} else {
+		} 
+		else 
+		{
 			if (datapoints.size() == 0)
 				return GetPyNone();
 				

--- a/DearPyGui/src/Core/mvPythonTranslator.cpp
+++ b/DearPyGui/src/Core/mvPythonTranslator.cpp
@@ -604,6 +604,32 @@ namespace Marvel {
 		return items;
 	}
 
+	std::pair<std::vector<float>, std::vector<float>> ToPairVec(PyObject* value, const std::string& message)
+	{
+		std::pair<std::vector<float>, std::vector<float>> items;
+		if (value == nullptr)
+			return items;
+		mvGlobalIntepreterLock gil;
+
+		if (PyTuple_Check(value))
+		{
+			if (PyTuple_Size(value) != 2) ThrowPythonException(message);
+			items.first = ToFloatVect(PyTuple_GetItem(value, 0), message);
+			items.second = ToFloatVect(PyTuple_GetItem(value, 1), message);
+		}
+		else if (PyList_Check(value))
+		{
+			if (PyList_Size(value) != 2) ThrowPythonException(message);
+			items.first = ToFloatVect(PyList_GetItem(value, 0), message);
+			items.second = ToFloatVect(PyList_GetItem(value, 1), message);
+		}
+
+		else
+			ThrowPythonException(message);
+
+		return items;
+	}
+
 	std::vector<mvVec4> ToVectVec4(PyObject* value, const std::string& message)
 	{
 		std::vector<mvVec4> items;


### PR DESCRIPTION
if xy_data_format is true then the data needs to be formatted as [[x1, x2, x3, .... xn], [y1,y2, y3,....,yn]] and not as [[x1, y1], [x2, y2], .... [xn, yn]]
There are still a lot of data copies that can perhaps be avoided.