### PR TITLE
related to issue #289

### DIFF
--- a/DearPyGui/src/Core/PythonCommands/mvAppInterface.cpp
+++ b/DearPyGui/src/Core/PythonCommands/mvAppInterface.cpp
@@ -323,6 +323,11 @@ namespace Marvel {
 
 		if (!(*mvApp::GetApp()->getParsers())["start_dearpygui"].parse(args, kwargs, __FUNCTION__, &primary_window))
 			return GetPyNone();
+		if (mvApp::IsAppStarted())
+		{
+			ThrowPythonException("Cannot call \"start_dearpygui\" while a Dear PyGUI app is already running on this thread.");
+			return GetPyNone();
+		}
 
 		mvApp::GetApp()->precheck();
 		mvApp::SetAppStarted();

--- a/DearPyGui/src/Core/PythonCommands/mvAppInterface.cpp
+++ b/DearPyGui/src/Core/PythonCommands/mvAppInterface.cpp
@@ -325,7 +325,7 @@ namespace Marvel {
 			return GetPyNone();
 		if (mvApp::IsAppStarted())
 		{
-			ThrowPythonException("Cannot call \"start_dearpygui\" while a Dear PyGUI app is already running on this thread.");
+			ThrowPythonException("Cannot call \"start_dearpygui\" while a Dear PyGUI app is already running.");
 			return GetPyNone();
 		}
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -29,8 +29,11 @@ HOW TO UPDATE?
 Decorated log: https://github.com/hoffstadt/DearPyGui/releases/tag/v0.5.x
 
 Updates:
-- ImGui:           Upgraded to v1.79
-- ImGuiFileDialog: Upgraded to v0.5.1
+- ImGui:           	Upgraded to v1.79
+- ImGuiFileDialog: 	Upgraded to v0.5.1
+
+Fixes:
+- start_dearpygui:     	Is now protected from trying to create a new dearpygui instance before closing the last one issue#289
 
 -----------------------------------------------------------------------
  VERSION 0.5.0 (10/20/2020)


### PR DESCRIPTION
**Description:**
the assert from Dear ImGui when start_dearpygui() is called while DPG already is running on the thread:
"Forgot to call Render() or EndFrame() at the end of the previous frame?"

- adding a check to the function `start_dearpygui()` for isAppStarted throwing an exception and returning an empty python object works here

- in the example #289 it will just create the normal imgui window on the primary viewport

**Concerning Areas:**
I'm not exactly satisficed with the wording in the DPG python exception.
