### PR TITLE
Fixed plotting example

### DIFF
--- a/tutorial.html
+++ b/tutorial.html
@@ -717,7 +717,7 @@ def plot_callback(sender, data):
 
     add_line_series("Plot", "Cos", data1, weight=2, color=[0, 0, 255, 100])
     add_shade_series("Plot", "Cos", data1, weight=2, fill=[255, 0, 0, 100])
-    add_scatter_series("Plot", "Sin", data2, color=[0, 255, 0, 100])
+    add_scatter_series("Plot", "Sin", data2, outline=[0, 255, 0, 100])
 
 with window("Tutorial"):
     add_button("Plot data", callback=plot_callback)


### PR DESCRIPTION
Replaced "color" keyword argumento with "outline" in add_scatter_series().
The original code produced `TypeError: 'color' is an invalid keyword argument for this function`.

---
name: Pull Request
about: Create a pull request to help us improve
title: ''
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
