### PR TITLE
Changed link to examples page on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 Last Updated: 2020-11-20
         </h4>
         <p>
-            If your ready to start using <i>Dear PyGui</i> visit the <a href="getting_started.html">Getting Started</a> and follow with the <a href="tutorial.html">Tutorials</a> as you learn there are more advanced and detailed topics covered in <a href="DPG-Reference/reference-home.html">Dear PyGui Reference</a>. If you would like to see Dear PyGui in action checkout the <a href="https://github.com/RaylockLLC/DearPyGui/tree/master/Examples" target="_blank">Examples</a> on the github.
+            If your ready to start using <i>Dear PyGui</i> visit the <a href="getting_started.html">Getting Started</a> and follow with the <a href="tutorial.html">Tutorials</a> as you learn there are more advanced and detailed topics covered in <a href="DPG-Reference/reference-home.html">Dear PyGui Reference</a>. If you would like to see Dear PyGui in action checkout the <a href="https://github.com/Pcothren/DearPyGui-Examples" target="_blank">Examples</a> on the github.
         </p>
         <p>
             If you Enjoy <i>Dear PyGui</i> please consider becoming a <a href="https://github.com/sponsors/hoffstadt">Sponsor</a>.


### PR DESCRIPTION
On the index page, the link to the examples resulted in a 404 (page not found) error. As discussed on Discord, I am submitting this pull request to replace the link to the examples page.

OLD LINK:   https://github.com/RaylockLLC/DearPyGui/tree/master/Examples
NEW LINK:  https://github.com/Pcothren/DearPyGui-Examples

---
name: discord_testpilot
about: Create a pull request to help us improve
title: Changed link to examples page on index page'
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->
