### PR TITLE
Added an introduction at the beginning of the DPG landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,9 @@
 </head>
 
 <body>
+    <img src="https://raw.githubusercontent.com/hoffstadt/DearPyGui/assets/newlogo.jpg" alt="Dear PyGui logo" height="150">
 <header>
-    <h1><a href="index.html">Dear PyGui</a></h1>
+    <h1><a href="index.html">Dear PyGui - A fast, easy-to-use and powerful GPU-based GUI for Python</a></h1>
 </header>
 <hr>
 <main id="content">
@@ -33,10 +34,22 @@
         <h2>Welcome</h2>
         <hr>
         <h4>
-Last Updated: 2020-12-07
+Last Updated: 2020-12-10
         </h4>
         <p>
-            If your ready to start using <i>Dear PyGui</i> visit the <a href="getting_started.html">Getting Started</a> and follow with the <a href="tutorial.html">Tutorials</a> as you learn there are more advanced and detailed topics covered in <a href="DPG-Reference/reference-home.html">Dear PyGui Reference</a>. If you would like to see Dear PyGui in action checkout the <a href="examples.html">Examples</a> on the github.
+            Dear PyGui is an easy-to-use, flexible and powerful graphical user interface (GUI) framework for Python. Based on <a href="https://github.com/ocornut/imgui">ImGui>/a>, Dear PyGui is fast as it is 
+            mostly written in C++ and uses the GPU for incredible performance. Features include the traditional GUI elements to display text, images and lots
+            of controls, such as buttons, radio buttons and menu's and various methods to create a functional and beautiful layout. Additionally, it offers incredibly dynamic 
+            <a href="https://github.com/hoffstadt/DearPyGui#plottinggraphing">charts</a>, fast handling of tables, 
+            <a href="https://github.com/hoffstadt/DearPyGui/#canvas">drawing</a> and tools for app development, such as built-in documentation, logging, and 
+            source viewer. 
+        </p>
+        <p>
+            As a GUI, it is equally suitable for creating simple user interfaces for wrapping a basic command line interface. yet it can also be used for science, 
+            engineering, games, data science and other applications that require fast and interactive interfaces.
+        </p>
+        <p>
+            If your ready to start using <i>Dear PyGui</i> visit the <a href="getting_started.html">Getting Started</a> and follow with the <a href="tutorial.html">Tutorials</a> as you learn there are more advanced and detailed topics covered in <a href="DPG-Reference/reference-home.html">Dear PyGui Reference</a>. If you would like to see Dear PyGui in action checkout the <a href="examples.html">Examples</a> on the <a href="https://github.com/hoffstadt/DearPyGui/">Dear PyGUI github</a>.
         </p>
         <p>
             If you Enjoy <i>Dear PyGui</i> please consider becoming a <a href="https://github.com/sponsors/hoffstadt">Sponsor</a>.

--- a/index.html
+++ b/index.html
@@ -37,19 +37,23 @@
 Last Updated: 2020-12-10
         </h4>
         <p>
-            Dear PyGui is an easy-to-use, flexible and powerful graphical user interface (GUI) framework for Python. Based on <a href="https://github.com/ocornut/imgui">ImGui>/a>, Dear PyGui is fast as it is 
-            mostly written in C++ and uses the GPU for incredible performance. Features include the traditional GUI elements to display text, images and lots
-            of controls, such as buttons, radio buttons and menu's and various methods to create a functional and beautiful layout. Additionally, it offers incredibly dynamic 
-            <a href="https://github.com/hoffstadt/DearPyGui#plottinggraphing">charts</a>, fast handling of tables, 
-            <a href="https://github.com/hoffstadt/DearPyGui/#canvas">drawing</a> and tools for app development, such as built-in documentation, logging, and 
-            source viewer. 
+            <i>Dear PyGui</i> is an easy-to-use, flexible, powerful graphical user interface (GUI) framework for Python. As an extended wrapping of <a href="https://github.com/ocornut/imgui">ImGui>/a>, 
+            <i>Dear PyGui</i> is higly performant.
+            It is written primarily in C/C++ and uses your GPU for renderering. Features include traditional GUI elements to display text, images and various controls, 
+            such as buttons, radio buttons, and menus and various methods to create a functional and beautiful layout. Additionally, it offers incredibly dynamic 
+            <a href="https://github.com/hoffstadt/DearPyGui#plottinggraphing">charts</a>, tables, 
+            <a href="https://github.com/hoffstadt/DearPyGui/#canvas">drawings</a> and tools for application development, such as built-in documentation, logging, and 
+            debugger. 
         </p>
         <p>
-            As a GUI, it is equally suitable for creating simple user interfaces for wrapping a basic command line interface. yet it can also be used for science, 
+            As a GUI toolkit, it is equally suitable for creating simple user interfaces for wrapping a basic command line interface. It can also be used for science, 
             engineering, games, data science and other applications that require fast and interactive interfaces.
         </p>
         <p>
-            If your ready to start using <i>Dear PyGui</i> visit the <a href="getting_started.html">Getting Started</a> and follow with the <a href="tutorial.html">Tutorials</a> as you learn there are more advanced and detailed topics covered in <a href="DPG-Reference/reference-home.html">Dear PyGui Reference</a>. If you would like to see Dear PyGui in action checkout the <a href="examples.html">Examples</a> on the <a href="https://github.com/hoffstadt/DearPyGui/">Dear PyGUI github</a>.
+            If your ready to start using <i>Dear PyGui</i> visit the <a href="getting_started.html">Getting Started</a> and 
+            follow with the <a href="tutorial.html">Tutorials</a>. As you learn there are more advanced and detailed topics covered 
+            in <a href="DPG-Reference/reference-home.html">Dear PyGui Reference</a>. If you would like to see <i>Dear PyGui</i> in action checkout 
+            the <a href="examples.html">Examples</a> on the <a href="https://github.com/hoffstadt/DearPyGui/"><i>Dear PyGui</i> github</a>.
         </p>
         <p>
             If you Enjoy <i>Dear PyGui</i> please consider becoming a <a href="https://github.com/sponsors/hoffstadt">Sponsor</a>.


### PR DESCRIPTION
This landing page deserves a little introduction about dearpygui, both for the visitor, but equally for search engines (Github, google, etc.). I have noticed that the term 'Python' is not mentioned anywhere on this page (and some other pages as well). I believe it would aid the visibility of DPG if you keep repeating the important search criteria in all online postings, e.g. github, youtube videos descriptions, reddit, etc.. These search criteria would include at least Python, GUI, graphical user interface, GPU-based, possibly also fast, easy, simple and powerful.

-- discord_testpilot

---
name: Pull Request
about: Create a pull request to help us improve
title: ''
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
