### PR TITLE
fixed collapsible header value issue

### DIFF
--- a/DearPyGui/dearpygui/demo.py
+++ b/DearPyGui/dearpygui/demo.py
@@ -217,7 +217,7 @@ def show_demo():
         add_text(f'Dear PyGui says hello. ({get_dearpygui_version()})')
         add_text("This demo is not complete but will continue to be added to throughout the 0.6.x releases!")
 
-        with collapsing_header("Window options##demo", default_open=True):
+        with collapsing_header("Window options##demo", default_open=True, closable = True):
             with managed_columns("Window Options Col##demo", 3, border=False):
                 add_checkbox("No titlebar##demo", callback=lambda sender, data: configure_item("Dear PyGui Demo", no_title_bar=get_value(sender)))
                 add_checkbox("No scrollbar##demo", callback=lambda sender, data: configure_item("Dear PyGui Demo", no_scrollbar=get_value(sender)))

--- a/DearPyGui/src/core/AppItems/containers/mvCollapsingHeader.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvCollapsingHeader.cpp
@@ -2,6 +2,7 @@
 #include "mvInput.h"
 #include "mvPythonTranslator.h"
 #include "mvGlobalIntepreterLock.h"
+#include "mvValueStorage.h"
 
 namespace Marvel {
 
@@ -18,9 +19,9 @@ namespace Marvel {
 
 		bool* toggle = nullptr;
 		if (m_closable)
-			toggle = m_value;
-
-		if (ImGui::CollapsingHeader(m_label.c_str(), toggle, m_flags))
+			toggle = &m_show;
+		*m_value = ImGui::CollapsingHeader(m_label.c_str(), toggle, m_flags);
+		if (*m_value)
 		{
 
 			// Regular Tooltip (simple)
@@ -53,7 +54,6 @@ namespace Marvel {
 			if (!m_tip.empty() && ImGui::IsItemHovered())
 				ImGui::SetTooltip("%s", m_tip.c_str());
 		}
-
 	}
 
 	void mvCollapsingHeader::setExtraConfigDict(PyObject* dict)


### PR DESCRIPTION
**Description:**
previously if a collapsible header was closed it was un recoverable, now closing just hides so it can be recovered
also now similarly to ImGui the value from the constructor is if the item is open or not, setting the value does nothing because it is overwritten each draw call by imGui

if we like it this will need to be applied to the tree node also 
