### PR TITLE
Avoid clashing with other pre-installed Python interpreters on OSX

### DIFF
--- a/DearSandbox/CMakeLists.txt
+++ b/DearSandbox/CMakeLists.txt
@@ -9,7 +9,7 @@ if(APPLE)
 endif()
 
 target_sources(DearSandbox
-	
+
 	PRIVATE
 
 		"$<$<PLATFORM_ID:Windows>:main.cpp>"
@@ -72,21 +72,13 @@ elseif(APPLE)
 
 	set_property(TARGET DearSandbox APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -arch x86_64 -g")
 
-	target_link_directories(DearSandbox PRIVATE ../Dependencies/cpython/debug)
-
-	add_custom_command(TARGET DearSandbox POST_BUILD
-			COMMAND install_name_tool -id @loader_path/../../Dependencies/cpython/debug/libpython3.8d.dylib libpython3.8d.dylib
-			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Dependencies/cpython/debug
-			COMMENT "Changing python lib id"
-			)
-
-	add_custom_command(TARGET DearSandbox POST_BUILD
-			COMMAND install_name_tool -change /usr/local/lib/libpython3.8d.dylib @loader_path/../../Dependencies/cpython/debug/libpython3.8d.dylib DearSandbox
-			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/cmake-build-debug/DearSandbox
-			COMMENT "Changing python lib load path")
+    target_link_directories(DearSandbox PRIVATE ../Dependencies/cpython/debug/lib)
 
 	target_link_libraries(DearSandbox PUBLIC coreemb -ldl "-framework CoreFoundation" "python3.8d")
 
+	file(GLOB PYTHON_LIBS_PATH "../Dependencies/cpython/debug/lib/python*")
+
+	add_compile_definitions(PYTHON_LIBS_PATH="${PYTHON_LIBS_PATH}")
 
 else() # Linux
 

--- a/DearSandbox/main_linux.cpp
+++ b/DearSandbox/main_linux.cpp
@@ -2,9 +2,7 @@
 #include <Python.h>
 #include "mvStdOutput.h"
 #include "mvMarvel.h"
-#include "mvApp.h"
 #include <iostream>
-#include <fstream>
 
 using namespace Marvel;
 
@@ -20,10 +18,18 @@ int main(int argc, char* argv[])
 
 	// set path and start the interpreter
 #if defined(__APPLE__)
-    Py_SetPythonHome(L".");
-    wchar_t* deco = Py_DecodeLocale("../../Dependencies/cpython/debug/build/lib.macosx-10.15-x86_64-3.8-pydebug/:../../Dependencies/cpython/Lib/:../../DearPyGui:../../DearSandbox", nullptr);
+  wchar_t *deco = Py_DecodeLocale(
+      PYTHON_LIBS_PATH":"
+      PYTHON_LIBS_PATH"/lib-dynload:"
+      PYTHON_LIBS_PATH"/site-packages:"
+      "../../DearPyGui:"
+      "../../DearSandbox",
+      nullptr);
 #else
-    wchar_t* deco = Py_DecodeLocale("../../Dependencies/cpython/debug/build/lib.linux-x86_64-3.8-pydebug/:../../Dependencies/cpython/Lib/:../../DearPyGui:../../DearSandbox", nullptr);
+  wchar_t *deco = Py_DecodeLocale(
+      "../../Dependencies/cpython/debug/build/lib.linux-x86_64-3.8-pydebug/:../"
+      "../Dependencies/cpython/Lib/:../../DearPyGui:../../DearSandbox",
+      nullptr);
 #endif
 
     Py_SetPath(deco);

--- a/Scripts/BuildPythonForMac.sh
+++ b/Scripts/BuildPythonForMac.sh
@@ -1,5 +1,6 @@
 cd ../Dependencies/cpython
 mkdir debug
 cd debug
-../configure --with-pydebug --enable-shared
+../configure --with-pydebug --enable-shared --prefix=$(pwd) LDFLAGS=-Wl,-rpath,$(pwd)
 make
+make install


### PR DESCRIPTION
**Description:**
Explicitly set search paths for Python libraries for DearSandbox on OSX.

**Concerning Areas:**
Without setting the search path the compiled Python cannot discover the standard library modules written in C.
