### PR TITLE
Callback data

### DIFF
--- a/DearPyGui/dearpygui/core.pyi
+++ b/DearPyGui/dearpygui/core.pyi
@@ -566,6 +566,10 @@ def get_global_font_scale() -> float:
 	"""Returns the global font scale."""
 	...
 
+def get_hovered_item() -> str:
+	"""Returns the hovered item by name."""
+	...
+
 def get_item_callback(item: str) -> Callable:
 	"""Returns an item' callback"""
 	...

--- a/DearPyGui/dearpygui/demo.py
+++ b/DearPyGui/dearpygui/demo.py
@@ -23,7 +23,10 @@ def hsv_to_rgb(h: float, s: float, v: float) -> (float, float, float):
     if i == 5: return (255*v, 255*p, 255*q)
 
 def demo_main_callback(sender, data):
+
+    #testing hover command
     log_debug(get_hovered_item())
+
     set_value("Mouse Position##demo", str(get_mouse_pos()))
 
     # keys

--- a/DearPyGui/dearpygui/demo.py
+++ b/DearPyGui/dearpygui/demo.py
@@ -23,7 +23,7 @@ def hsv_to_rgb(h: float, s: float, v: float) -> (float, float, float):
     if i == 5: return (255*v, 255*p, 255*q)
 
 def demo_main_callback(sender, data):
-
+    log_debug(get_hovered_item())
     set_value("Mouse Position##demo", str(get_mouse_pos()))
 
     # keys

--- a/DearPyGui/src/core/AppItems/composite/mvTable.cpp
+++ b/DearPyGui/src/core/AppItems/composite/mvTable.cpp
@@ -199,8 +199,6 @@ namespace Marvel {
 
 	void mvTable::addColumn(const std::string& name, const std::vector<std::string>& column)
 	{
-		m_headers.push_back(name);
-
 		if (column.size() > m_values.size())
 		{
 			for (unsigned i = 0; i < column.size(); i++)
@@ -537,6 +535,11 @@ namespace Marvel {
 		auto styleManager = m_styleManager.getScopedStyleManager();
 
 		ImGui::BeginChild(m_name.c_str(), ImVec2((float)m_width, (float)m_height));
+
+		// updating hovered item
+		if (ImGui::IsWindowHovered() || ImGui::IsItemHovered())
+			mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+
 		ImGui::Separator();
 		if(m_columns > 0)
 			ImGui::Columns((int)m_columns, nullptr, true);
@@ -572,6 +575,8 @@ namespace Marvel {
 					m_selections[{i, j}] = !m_selections[{i, j}];
 					mvApp::GetApp()->getCallbackRegistry().runCallback(m_callback, m_name);
 				}
+				if (ImGui::IsItemHovered())
+					mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
 				ImGui::NextColumn();
 				index++;
 			}

--- a/DearPyGui/src/core/AppItems/containers/mvChild.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvChild.cpp
@@ -50,6 +50,10 @@ namespace Marvel {
 
 		ImGui::BeginChild(m_label.c_str(), ImVec2(m_autosize_x ? 0 : (float)m_width, m_autosize_y ? 0 : (float)m_height), m_border, m_windowflags);
 
+		// updating hovered item
+		if (ImGui::IsWindowHovered())
+			mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+
 		for (auto item : m_children)
 		{
 			// skip item if it's not shown
@@ -67,6 +71,10 @@ namespace Marvel {
 				ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 			item->getState().update();
+
+			// updating hovered item
+			if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 		}
 
 		// TODO check if these work for child

--- a/DearPyGui/src/core/AppItems/containers/mvCollapsingHeader.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvCollapsingHeader.cpp
@@ -49,6 +49,10 @@ namespace Marvel {
 			if (!m_tip.empty() && ImGui::IsItemHovered())
 				ImGui::SetTooltip("%s", m_tip.c_str());
 
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+
 			for (auto& item : m_children)
 			{
 				// skip item if it's not shown
@@ -66,6 +70,10 @@ namespace Marvel {
 					ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 				item->getState().update();
+
+				// updating hovered item
+				if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+					mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 			}
 		}
 
@@ -74,6 +82,10 @@ namespace Marvel {
 			// Regular Tooltip (simple)
 			if (!m_tip.empty() && ImGui::IsItemHovered())
 				ImGui::SetTooltip("%s", m_tip.c_str());
+
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
 		}
 	}
 

--- a/DearPyGui/src/core/AppItems/containers/mvColumns.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvColumns.cpp
@@ -81,6 +81,7 @@ namespace Marvel {
 		ScopedID id;
 
 		ImGui::Columns(m_columns, m_name.c_str(), m_border);
+
 		for (auto& item : m_children)
 		{
 			// skip item if it's not shown
@@ -100,6 +101,10 @@ namespace Marvel {
 				ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 			item->getState().update();
+
+			// updating hovered item
+			if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 
 			int index = ImGui::GetColumnIndex();
 

--- a/DearPyGui/src/core/AppItems/containers/mvGroup.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvGroup.cpp
@@ -61,6 +61,10 @@ namespace Marvel {
 				ImGui::SameLine(0.0, m_hspacing);
 
 			item->getState().update();
+
+			// updating hovered item
+			if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 		}
 
 		if (m_width != 0)

--- a/DearPyGui/src/core/AppItems/containers/mvMenu.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvMenu.cpp
@@ -34,6 +34,9 @@ namespace Marvel {
 		// create menu and see if its selected
 		if (ImGui::BeginMenu(m_label.c_str(), m_enabled))
 		{
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
 
 			// set other menus's value false on same level
 			for (auto sibling : m_parent->m_children)
@@ -63,11 +66,21 @@ namespace Marvel {
 					ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 				item->getState().update();
+
+				// updating hovered item
+				if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+					mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 			}
 
 			registerWindowFocusing();
 
 			ImGui::EndMenu();
+		}
+		else 
+		{
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
 		}
 
 	}

--- a/DearPyGui/src/core/AppItems/containers/mvMenuBar.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvMenuBar.cpp
@@ -35,6 +35,10 @@ namespace Marvel {
 
 		if (ImGui::BeginMenuBar())
 		{
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+
 			for (auto& item : m_children)
 			{
 				// skip item if it's not shown
@@ -52,8 +56,18 @@ namespace Marvel {
 					ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 				item->getState().update();
+
+				// updating hovered item
+				if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+					mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 			}
 			ImGui::EndMenuBar();
+		}
+		else
+		{
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
 		}
 	}
 

--- a/DearPyGui/src/core/AppItems/containers/mvPopup.h
+++ b/DearPyGui/src/core/AppItems/containers/mvPopup.h
@@ -39,6 +39,10 @@ namespace Marvel {
 						m_close = false;
 					}
 
+					// updating hovered item
+					if (ImGui::IsItemHovered())
+						mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+
 					for (mvRef<mvAppItem> item : m_children)
 					{
 						// skip item if it's not shown
@@ -56,6 +60,10 @@ namespace Marvel {
 							ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 						item->getState().update();
+
+						// updating hovered item
+						if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+							mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 					}
 
 					ImGui::EndPopup();
@@ -66,6 +74,9 @@ namespace Marvel {
 			{
 				if (ImGui::BeginPopupContextItem(m_name.c_str(), m_button))
 				{
+					// updating hovered item
+					if (ImGui::IsWindowHovered())
+						mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
 
 					for (mvRef<mvAppItem> item : m_children)
 					{
@@ -80,12 +91,22 @@ namespace Marvel {
 						item->draw();
 
 						item->getState().update();
+
+						// updating hovered item
+						if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+							mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 					}
 
 					// allows this item to have a render callback
 					registerWindowFocusing();
 
 					ImGui::EndPopup();
+				}
+				else 
+				{
+					// updating hovered item
+					if (ImGui::IsItemHovered())
+						mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
 				}
 			}
 		}

--- a/DearPyGui/src/core/AppItems/containers/mvTab.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvTab.cpp
@@ -49,6 +49,10 @@ namespace Marvel {
 		// create tab item and see if it is selected
 		if (ImGui::BeginTabItem(m_label.c_str(), m_closable ? &m_show : nullptr, m_flags))
 		{
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+
 			// Regular Tooltip (simple)
 			if (!m_tip.empty() && ImGui::IsItemHovered())
 				ImGui::SetTooltip("%s", m_tip.c_str());
@@ -86,6 +90,10 @@ namespace Marvel {
 					ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 				item->getState().update();
+
+				// updating hovered item
+				if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+					mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 			}
 
 			ImGui::EndTabItem();

--- a/DearPyGui/src/core/AppItems/containers/mvTabBar.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvTabBar.cpp
@@ -44,6 +44,10 @@ namespace Marvel {
 
 		if (ImGui::BeginTabBar(m_label.c_str(), m_flags))
 		{
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+
 			for (auto& item : m_children)
 			{
 				// skip item if it's not shown
@@ -61,9 +65,19 @@ namespace Marvel {
 					ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 				item->getState().update();
+
+				// updating hovered item
+				if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+					mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 			}
 
 			ImGui::EndTabBar();
+		}
+		else
+		{
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
 		}
 
 		ImGui::EndGroup();

--- a/DearPyGui/src/core/AppItems/containers/mvTooltip.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvTooltip.cpp
@@ -33,6 +33,10 @@ namespace Marvel {
 	{
 		if (ImGui::IsItemHovered())
 		{
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+
 			auto styleManager = m_styleManager.getScopedStyleManager();
 			ImGui::BeginTooltip();
 			for (auto& item : m_children)
@@ -52,6 +56,11 @@ namespace Marvel {
 					ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 				item->getState().update();
+
+				// updating hovered item
+				if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+					mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
+
 			}
 
 			ImGui::EndTooltip();

--- a/DearPyGui/src/core/AppItems/containers/mvTreeNode.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvTreeNode.cpp
@@ -37,7 +37,12 @@ namespace Marvel {
 		ImGui::BeginGroup();
 		if (ImGui::TreeNodeEx(m_label.c_str(), m_flags))
 		{
-
+			// updating hovered item
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+			// Regular Tooltip (simple)
+			if (!m_tip.empty() && ImGui::IsItemHovered())
+				ImGui::SetTooltip("%s", m_tip.c_str());
 			for (auto& item : m_children)
 			{
 				// skip item if it's not shown
@@ -55,13 +60,23 @@ namespace Marvel {
 					ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 				item->getState().update();
+
+				// updating hovered item
+				if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
+					mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
 			}
 			ImGui::TreePop();
-		}
 
-		// Regular Tooltip (simple)
-		if (!m_tip.empty() && ImGui::IsItemHovered())
-			ImGui::SetTooltip("%s", m_tip.c_str());
+		}
+		// updating hovered item
+		else
+		{
+			if (ImGui::IsItemHovered())
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+			// Regular Tooltip (simple)
+			if (!m_tip.empty() && ImGui::IsItemHovered())
+				ImGui::SetTooltip("%s", m_tip.c_str());
+		}
 
 		ImGui::EndGroup();
 	}

--- a/DearPyGui/src/core/AppItems/containers/mvWindowAppItem.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvWindowAppItem.cpp
@@ -182,6 +182,11 @@ namespace Marvel {
 		if (m_mainWindow)
 			ImGui::PopStyleVar();
 
+		if (ImGui::IsWindowHovered())
+			mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+		if (ImGui::IsItemHovered())
+			mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", m_name) });
+
 		for (auto& item : m_children)
 		{
 			// skip item if it's not shown
@@ -199,12 +204,10 @@ namespace Marvel {
 				ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 			item->getState().update();
-			
-			//updating hovered item
-			if (item->getState().isItemHovered())
-			{
+
+			// updating hovered item
+			if (item->getState().isItemHovered() && !item->m_description.container && item->getType() != mvAppItemType::SameLine && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent && item->getType() != mvAppItemType::Indent && item->getType() != mvAppItemType::Unindent)
 				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
-			}
 		}
 
 		m_state.setVisible(true);

--- a/DearPyGui/src/core/AppItems/containers/mvWindowAppItem.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvWindowAppItem.cpp
@@ -199,7 +199,12 @@ namespace Marvel {
 				ImGui::SetTooltip("%s", item->m_tip.c_str());
 
 			item->getState().update();
-
+			
+			//updating hovered item
+			if (item->getState().isItemHovered())
+			{
+				mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", item->m_name) });
+			}
 		}
 
 		m_state.setVisible(true);

--- a/DearPyGui/src/core/AppItems/mvItemRegistry.cpp
+++ b/DearPyGui/src/core/AppItems/mvItemRegistry.cpp
@@ -46,6 +46,7 @@ namespace Marvel {
 		dispatcher.dispatch(BIND_EVENT_METH(mvItemRegistry::onPreRenderReset), mvEVT_PRE_RENDER_RESET);
 		dispatcher.dispatch(BIND_EVENT_METH(mvItemRegistry::onRender), mvEVT_RENDER);
 		dispatcher.dispatch(BIND_EVENT_METH(mvItemRegistry::onActiveWindow), mvEVT_ACTIVE_WINDOW);
+		dispatcher.dispatch(BIND_EVENT_METH(mvItemRegistry::onHoveredItem), mvEVT_HOVERED_ITEM);
 
 		return event.handled;
 	}
@@ -98,6 +99,14 @@ namespace Marvel {
 	{
 
 		m_activeWindow = GetEString(event, "WINDOW");
+
+		return false;
+	}
+
+	bool mvItemRegistry::onHoveredItem(mvEvent& event)
+	{
+
+		m_hoveredItem = GetEString(event, "ITEM");
 
 		return false;
 	}

--- a/DearPyGui/src/core/AppItems/mvItemRegistry.cpp
+++ b/DearPyGui/src/core/AppItems/mvItemRegistry.cpp
@@ -76,6 +76,9 @@ namespace Marvel {
 		for (auto window : m_backWindows)
 			window->resetState();
 
+		//reset item hovered state
+		mvEventBus::Publish(mvEVT_CATEGORY_ITEM, mvEVT_HOVERED_ITEM, { CreateEventArgument("ITEM", std::string("NONE")) });
+
 		return false;
 	}
 

--- a/DearPyGui/src/core/AppItems/mvItemRegistry.h
+++ b/DearPyGui/src/core/AppItems/mvItemRegistry.h
@@ -59,6 +59,7 @@ namespace Marvel {
         bool                     onRender        (mvEvent& event);
         bool                     onPreRenderReset(mvEvent& event);                     
         bool                     onActiveWindow  (mvEvent& event);                     
+        bool                     onHoveredItem   (mvEvent& event);                  
 
         //-----------------------------------------------------------------------------
         // AppItem Operations
@@ -75,6 +76,7 @@ namespace Marvel {
         std::vector<mvRef<mvAppItem>>& getFrontWindows   () { return m_frontWindows; }
         std::vector<mvRef<mvAppItem>>& getBackWindows    () { return m_backWindows; }
         const std::string&             getActiveWindow() const { return m_activeWindow; }
+        const std::string&             getHoveredItem() const { return m_hoveredItem; }
         bool                           addItemWithRuntimeChecks(mvRef<mvAppItem> item, const char* parent, const char* before);
         
         // called by python interface
@@ -107,6 +109,7 @@ namespace Marvel {
 		std::vector<mvRef<mvAppItem>> m_frontWindows;
 		std::vector<mvRef<mvAppItem>> m_backWindows;
         std::string                   m_activeWindow;
+        std::string                   m_hoveredItem;
 
         // runtime widget modifications
         std::vector<std::string>    m_deleteChildrenQueue;

--- a/DearPyGui/src/core/PythonCommands/mvAppInterface.cpp
+++ b/DearPyGui/src/core/PythonCommands/mvAppInterface.cpp
@@ -142,6 +142,9 @@ namespace Marvel {
 		parsers->insert({ "get_active_window", mvPythonParser({
 		}, "Returns the active window name.", "str") });
 
+		parsers->insert({ "get_hovered_item", mvPythonParser({
+		}, "Returns the hovered item by name.", "str") });
+
 		parsers->insert({ "get_dearpygui_version", mvPythonParser({
 		}, "Returns the current version of Dear PyGui.", "str") });
 
@@ -613,6 +616,11 @@ namespace Marvel {
 	PyObject* get_active_window(PyObject* self, PyObject* args, PyObject* kwargs)
 	{
 		return ToPyString(mvApp::GetApp()->getItemRegistry().getActiveWindow());
+	}
+
+	PyObject* get_hovered_item(PyObject* self, PyObject* args, PyObject* kwargs)
+	{
+		return ToPyString(mvApp::GetApp()->getItemRegistry().getHoveredItem());
 	}
 
 	PyObject* get_dearpygui_version(PyObject* self, PyObject* args, PyObject* kwargs)

--- a/DearPyGui/src/core/PythonCommands/mvAppInterface.h
+++ b/DearPyGui/src/core/PythonCommands/mvAppInterface.h
@@ -23,6 +23,7 @@ namespace Marvel {
 	PyObject* set_vsync                      (PyObject* self, PyObject* args, PyObject* kwargs);
 	PyObject* get_dearpygui_version          (PyObject* self, PyObject* args, PyObject* kwargs);
 	PyObject* get_active_window              (PyObject* self, PyObject* args, PyObject* kwargs);
+	PyObject* get_hovered_item				 (PyObject* self, PyObject* args, PyObject* kwargs);
 	PyObject* add_character_remap            (PyObject* self, PyObject* args, PyObject* kwargs);
 
 	// docking

--- a/DearPyGui/src/core/mvEventMacros.h
+++ b/DearPyGui/src/core/mvEventMacros.h
@@ -46,6 +46,7 @@
 #define mvEVT_MOVE_ITEM_DOWN    SID("MOVE_ITEM_DOWN")
 #define mvEVT_DELETE_ITEM       SID("DELETE_ITEM")
 #define mvEVT_ACTIVE_WINDOW     SID("ACTIVE_WINDOW_CHANGE")
+#define mvEVT_HOVERED_ITEM      SID("HOVERED_ITEM_CHANGE")
 
 // mvEVT_CATEGORY_TEXTURE Events
 //-----------------------------------------------------------------------------

--- a/DearPyGui/src/core/mvMarvel.cpp
+++ b/DearPyGui/src/core/mvMarvel.cpp
@@ -569,6 +569,7 @@ namespace Marvel {
 		ADD_PYTHON_FUNCTION(is_threadpool_high_performance)
 		ADD_PYTHON_FUNCTION(get_threadpool_timeout)
 		ADD_PYTHON_FUNCTION(get_active_window)
+		ADD_PYTHON_FUNCTION(get_hovered_item)
 		ADD_PYTHON_FUNCTION(get_dearpygui_version)
 		ADD_PYTHON_FUNCTION(get_main_window_size)
 		ADD_PYTHON_FUNCTION(setup_dearpygui)

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -28,6 +28,9 @@ HOW TO UPDATE?
 
 Decorated log: https://github.com/hoffstadt/DearPyGui/releases/tag/v0.7.x
 
+New Commands:
+- get_hovered_item:   returns the currently hovered item by the mouse
+
 New Keywords:
 - add_input_text:               Added "tab_input" keyword
 


### PR DESCRIPTION
**Description:**
This adds the command get_hovered_item, previously the only way to find out what was hovered is to loop all items on the python side and check is item hovered, this can be costly if there are may items. 

Here we added a member for hovered item and during the render loop after the item state is update we see if the item hovered is true for that item. If so we post an event and let the app item registry handle updating the member (similar to the active window), this shouldn't cause any notable speed decreased because were already looping all the items to draw them.

if the hovered item is an empty container it will reply with the container 


**Concerning Areas:**
Since the active window and hovered window events are currently and probably always going to be used only by the appItemRegistry we could combine the event or the event category to keep from growing

after doing this we could add in the description of all the layout items that they are layout items so you can check if an item is a layout item and ignore it in some situations such as indent, unindent, group, columns, sameline
