### PR TITLE
backport PR#447 chinese & japanese, etc. IME-aware features to v0.6.x

### DIFF
--- a/DearPyGui/src/platform/Windows/mvWindowsWindow.cpp
+++ b/DearPyGui/src/platform/Windows/mvWindowsWindow.cpp
@@ -44,6 +44,9 @@ namespace Marvel {
 			CleanupDeviceD3D();
 			::UnregisterClass(m_wc.lpszClassName, m_wc.hInstance);
 		}
+		previous_ime_char=0;
+		HKL hkl=GetKeyboardLayout(0);		
+		lang_id=LOWORD(hkl);		
 
 	}
 
@@ -339,6 +342,48 @@ namespace Marvel {
 			mvApp::s_started = false;
 			::PostQuitMessage(0);
 			return 0;
+		case WM_INPUTLANGCHANGE:
+			lang_id=LOWORD(lParam);			
+			break;
+        case WM_IME_CHAR:
+			if (lang_id==0x0412)
+				break;
+			auto& io = ImGui::GetIO();
+			DWORD wChar = wParam;
+			if (wChar <= 127)
+			{
+				io.AddInputCharacter(wChar);
+				return 0;
+			}
+			else if(wChar<0xFF){
+			//GBK also supports Traditional Chinese, Japanese, English, Russian and (partially) Greek.
+			//When input Japanese with MS Japanese IME under CP936, dual bytes of one Japanese char are send within one or two wParam in succession.
+				if (previous_ime_char==0){ 
+					previous_ime_char=(BYTE)(wChar & 0x00FF);
+					return 0;
+				}
+				else{
+					BYTE b2=(BYTE)(wChar & 0x00FF);
+					wChar = MAKEWORD( previous_ime_char,b2);
+					previous_ime_char=0;
+				}
+			}
+			else
+			{
+				// swap lower and upper part.
+				BYTE low = (BYTE)(wChar & 0x00FF);
+				BYTE high = (BYTE)((wChar & 0xFF00) >> 8);
+				if (previous_ime_char==0)
+					wChar = MAKEWORD(high, low);
+				else{
+					wChar = MAKEWORD(previous_ime_char, high, low);
+					previous_ime_char=low;
+				}
+			}
+			wchar_t ch[6];
+			MultiByteToWideChar(CP_OEMCP, 0, (LPCSTR)&wChar, 4, ch, 3);
+			io.AddInputCharacter(ch[0]);			
+			return 0;			
 		}
 		return ::DefWindowProc(hWnd, msg, wParam, lParam);
 	}

--- a/DearPyGui/src/platform/Windows/mvWindowsWindow.h
+++ b/DearPyGui/src/platform/Windows/mvWindowsWindow.h
@@ -62,7 +62,8 @@ namespace Marvel {
 		static ID3D11DeviceContext* s_pd3dDeviceContext;
 		static IDXGISwapChain* s_pSwapChain;
 		static ID3D11RenderTargetView* s_mainRenderTargetView;
-
+		BYTE previous_ime_char;
+		WORD lang_id;
 	};
 
 }


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: 'backport PR#447 chinese & japanese, etc. IME-aware features to v0.6.x'
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->
An identical PR of https://github.com/hoffstadt/DearPyGui/pull/447 to the 0.6.x branch. 
It allowed add_input_text to get chinese & japanese, etc. text from IME in Windows. When input Japanese with MS Japanese IME under CP936, dual bytes of one Japanese char are send within one or two wParam in succession. 

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
add_input_text