### PR TITLE
Adding set_logger_window_title(str)

### DIFF
--- a/DearPyGui/dearpygui/core.pyi
+++ b/DearPyGui/dearpygui/core.pyi
@@ -1302,6 +1302,10 @@ def show_logger() -> None:
 	"""Shows the logging window. The Default log level is Trace"""
 	...
 
+def set_logger_window_title(title: str) -> None:
+	"""Sets the title of the logger window."""
+	...
+
 def start_dearpygui(*, primary_window: str = '') -> None:
 	"""Starts DearPyGui."""
 	...

--- a/DearPyGui/src/core/PythonCommands/mvAppInterface.cpp
+++ b/DearPyGui/src/core/PythonCommands/mvAppInterface.cpp
@@ -51,6 +51,10 @@ namespace Marvel {
 			{mvPythonDataType::String, "title"}
 		}, "Sets the title of the main window.") });
 
+		parsers->insert({ "set_logger_window_title", mvPythonParser({
+			{mvPythonDataType::String, "title"}
+		}, "Sets the title of the logger window.") });
+
 		parsers->insert({ "set_main_window_resizable", mvPythonParser({
 			{mvPythonDataType::Bool, "resizable"}
 		}, "Sets the main window to be resizable.") });
@@ -874,6 +878,19 @@ namespace Marvel {
 	PyObject* show_logger(PyObject* self, PyObject* args)
 	{
 		mvAppLog::Show();
+		return GetPyNone();
+	}
+
+	PyObject* set_logger_window_title(PyObject* self, PyObject* args, PyObject* kwargs)
+	{
+		const char* title;
+
+		if (!(*mvApp::GetApp()->getParsers())["set_logger_window_title"].parse(args, kwargs, __FUNCTION__,
+			&title))
+			return GetPyNone();
+
+		mvAppLog::setTitle(title);
+
 		return GetPyNone();
 	}
 

--- a/DearPyGui/src/core/PythonCommands/mvAppInterface.h
+++ b/DearPyGui/src/core/PythonCommands/mvAppInterface.h
@@ -61,6 +61,7 @@ namespace Marvel {
 
 	// standard windows
 	PyObject* show_logger                    (PyObject* self, PyObject* args);
+	PyObject* set_logger_window_title        (PyObject* self, PyObject* args, PyObject* kwargs);
 	PyObject* select_directory_dialog        (PyObject* self, PyObject* args, PyObject* kwargs);
 	PyObject* open_file_dialog               (PyObject* self, PyObject* args, PyObject* kwargs);
 }

--- a/DearPyGui/src/core/mvAppLog.cpp
+++ b/DearPyGui/src/core/mvAppLog.cpp
@@ -26,6 +26,7 @@ namespace Marvel {
 	int             mvAppLog::s_loglevel = 1;
 	unsigned mvAppLog::s_width = 500;
 	unsigned mvAppLog::s_height = 500;
+	std::string mvAppLog::s_title = "Dear PyGui Logger";
 	ImGuiWindowFlags mvAppLog::s_flags = ImGuiWindowFlags_NoSavedSettings;
 	int  mvAppLog::s_xpos = 200;
 	int  mvAppLog::s_ypos = 200;
@@ -169,7 +170,7 @@ namespace Marvel {
 			s_focus = false;
 		}
 
-		if (!ImGui::Begin("Dear PyGui Logger", &show, s_flags))
+		if (!ImGui::Begin(s_title.c_str(), &show, s_flags))
 		{
 			ImGui::End();
 			return;

--- a/DearPyGui/src/core/mvAppLog.h
+++ b/DearPyGui/src/core/mvAppLog.h
@@ -36,7 +36,8 @@ namespace Marvel {
 		static void                   SetConfigDict(PyObject* dict);
 		static void                   GetConfigDict(PyObject* dict);
 		static void                   Focus          ();
-
+		static void                   setTitle       (const std::string& title) { s_title = title; }
+		
 	private:
 
 		mvAppLog() = default;
@@ -59,6 +60,7 @@ namespace Marvel {
 		static bool             s_dirty_pos;
 		static bool             s_dirty_size;
 		static bool             s_focus;
+		static std::string      s_title;
 
 #if defined (_WIN32)
         static std::chrono::steady_clock::time_point s_start;

--- a/DearPyGui/src/core/mvMarvel.cpp
+++ b/DearPyGui/src/core/mvMarvel.cpp
@@ -590,6 +590,7 @@ namespace Marvel {
 		ADD_PYTHON_FUNCTION(get_log_level)
 		ADD_PYTHON_FUNCTION(clear_log)
 		ADD_PYTHON_FUNCTION(show_logger)
+		ADD_PYTHON_FUNCTION(set_logger_window_title)
 		ADD_PYTHON_FUNCTION(set_log_level)
 		ADD_PYTHON_FUNCTION(log)
 		ADD_PYTHON_FUNCTION(log_debug)


### PR DESCRIPTION
---
name: added set_logger_window_title
about: Allow users changing the title of logger window
title: 'added set_logger_window_title(str)'
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->
The logger window has a fixed title text of Dear PyGui Logger. This PR adds a set_logger_window_title(str) function to enable users changing the title of  the logger window,

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
The logger window