### PR TITLE
[issue 521] set_color_map above implotcolor range fix

### DIFF
--- a/DearPyGui/src/core/AppItems/plots/mvPlot.cpp
+++ b/DearPyGui/src/core/AppItems/plots/mvPlot.cpp
@@ -564,8 +564,11 @@ namespace Marvel {
 
 	void mvPlot::SetColorMap(ImPlotColormap colormap)
 	{
-		m_colormap = colormap;
-		m_dirty = true;
+		if (colormap < ImPlotColormap_COUNT)
+		{
+			m_colormap = colormap;
+			m_dirty = true;
+		}
 	}
 
 	void mvPlot::resetXTicks()


### PR DESCRIPTION
**Description:**
fixed inside setColorMap and not on python interface side because python interface should be using constants and not ints so no python exception is necessary, also we dont have access to the plots color maps constants inside the python interface atm
