### PR TITLE
fixes issue 512 set_color_map crash

### DIFF
--- a/DearPyGui/src/core/AppItems/plots/mvPlot.cpp
+++ b/DearPyGui/src/core/AppItems/plots/mvPlot.cpp
@@ -569,8 +569,11 @@ namespace Marvel {
 
 	void mvPlot::SetColorMap(ImPlotColormap colormap)
 	{
-		m_colormap = colormap;
-		m_dirty = true;
+		if (colormap < ImPlotColormap_COUNT)
+		{
+			m_colormap = colormap;
+			m_dirty = true;
+		}
 	}
 
 	void mvPlot::resetXTicks()


### PR DESCRIPTION
**Description:**
fixed set_color_map() crash when int was larger than imPlot's color map default count
