### PR TITLE
Add a table func hide_headers

### DIFF
--- a/DearPyGui/src/core/AppItems/composite/mvTable.cpp
+++ b/DearPyGui/src/core/AppItems/composite/mvTable.cpp
@@ -17,6 +17,7 @@ namespace Marvel {
 			{mvPythonDataType::String, "before","This item will be displayed before the specified item in the parent. (runtime adding)", "''"},
 			{mvPythonDataType::Integer, "width","", "0"},
 			{mvPythonDataType::Integer, "height","", "200"},
+			{mvPythonDataType::Bool, "hide_headers", "Hide headers of the table", "False"},
 			{mvPythonDataType::Bool, "show","Attempt to render", "True"}
 		}, "Adds table.", "None", "Tables") });
 	}
@@ -27,6 +28,23 @@ namespace Marvel {
 		m_core_config.height = 200;
 		m_headers = headers;
 		m_columns = headers.size();
+		hide_headers = false;
+	}
+
+	void mvTable::setExtraConfigDict(PyObject* dict)
+	{
+		if (dict == nullptr)
+			return;
+
+		if (PyObject* item = PyDict_GetItemString(dict, "hide_headers")) hide_headers = ToBool(item);
+	}
+
+	void mvTable::getExtraConfigDict(PyObject* dict)
+	{
+		if (dict == nullptr)
+			return;
+
+		PyDict_SetItemString(dict, "hide_headers", ToPyBool(hide_headers));
 	}
 
 	bool mvTable::isIndexValid(int row, int column) const
@@ -507,13 +525,15 @@ namespace Marvel {
 		ImGui::Separator();
 		if(m_columns > 0)
 			ImGui::Columns((int)m_columns, nullptr, true);
-
-		for (auto& header : m_headers)
-		{
-			ImGui::Text("%s", header.c_str());
-			ImGui::NextColumn();
+		
+		if (!hide_headers) {
+			for (auto& header : m_headers)
+			{
+				ImGui::Text("%s", header.c_str());
+				ImGui::NextColumn();
+			}
+			ImGui::Separator();
 		}
-		ImGui::Separator();
 
 		ImVec4 alt_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_Header));
 		alt_color.w = 0.10f;
@@ -563,10 +583,11 @@ namespace Marvel {
 		int width = 0;
 		int height = 0;
 		int show = true;
+		bool hide_headers = false;
 
 		if (!(*mvApp::GetApp()->getParsers())["add_table"].parse(args, kwargs, __FUNCTION__,
 			&name, &headers, &callback, &callback_data, &parent,
-			&before, &width, &height, &show))
+			&before, &width, &height, &show, &hide_headers))
 			return ToPyBool(false);
 
 		auto item = CreateRef<mvTable>(name, ToStringVect(headers));

--- a/DearPyGui/src/core/AppItems/composite/mvTable.h
+++ b/DearPyGui/src/core/AppItems/composite/mvTable.h
@@ -58,6 +58,8 @@ namespace Marvel {
 		void deleteColumn  (int column);
 		void clearTable    ();
 		int  getColumnCount() const { return (int)m_columns; }
+		void setExtraConfigDict(PyObject* dict) override;
+		void getExtraConfigDict(PyObject* dict) override;
 
 		[[nodiscard]] std::string getTableItem (int row, int column) const;
 		[[nodiscard]] PyObject*   getSelections() const;
@@ -78,6 +80,7 @@ namespace Marvel {
 		std::vector<std::vector<std::string>> m_hashValues;
 		std::vector<std::vector<std::string>> m_values;
 		size_t                                m_columns;
+		bool                                  hide_headers;
 
 	};
 

--- a/DearPyGui/src/core/PythonCommands/mvTableInterface.h
+++ b/DearPyGui/src/core/PythonCommands/mvTableInterface.h
@@ -8,7 +8,7 @@ namespace Marvel {
 	// table
 	PyObject* set_table_data      (PyObject * self, PyObject * args, PyObject * kwargs);
 	PyObject* get_table_data      (PyObject * self, PyObject * args, PyObject * kwargs);
-	PyObject* set_headers         (PyObject * self, PyObject * args, PyObject * kwargs);
+	PyObject* set_headers         (PyObject * self, PyObject * args, PyObject * kwargs);	
 	PyObject* clear_table         (PyObject * self, PyObject * args, PyObject * kwargs);
 	PyObject* get_table_item      (PyObject * self, PyObject * args, PyObject * kwargs);
 	PyObject* set_table_item      (PyObject * self, PyObject * args, PyObject * kwargs);

--- a/Scripts/BuildLocalWheelLinux.sh
+++ b/Scripts/BuildLocalWheelLinux.sh
@@ -1,0 +1,23 @@
+cd ../Dependencies/cpython
+mkdir -p debug
+cd debug
+../configure --with-pydebug --enable-shared
+make -j 
+
+cd ../../../
+mkdir -p cmake-build-release
+cd cmake-build-release
+rm -rf *
+cmake .. -DMVDIST_ONLY=True -DMVPY_VERSION=39 -DMVDPG_VERSION=local_build
+make -j
+cd ..
+
+cd Distribution
+"../Dependencies/cpython/debug/python" BuildPythonWheel.py ../cmake-build-release/DearPyGui/core.so 0
+"../Dependencies/cpython/debug/python" -m ensurepip
+"../Dependencies/cpython/debug/python" -m pip install --upgrade pip
+"../Dependencies/cpython/debug/python" -m pip install twine --upgrade
+"../Dependencies/cpython/debug/python" -m pip install wheel
+"../Dependencies/cpython/debug/python" -m setup bdist_wheel --plat-name manylinux1_x86_64 --dist-dir ../dist
+cd ..
+cd Scripts

--- a/Scripts/BuildPythonForLinux.sh
+++ b/Scripts/BuildPythonForLinux.sh
@@ -2,4 +2,4 @@ cd ../Dependencies/cpython
 mkdir debug
 cd debug
 ../configure --with-pydebug --enable-shared
-make
+make 


### PR DESCRIPTION
---
name: Use hide_headers to hide table headers
about: table
title: 'Use hide_headers to hide table headers'
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->
![image](https://user-images.githubusercontent.com/8097683/107523000-3ece5f00-6bef-11eb-9404-f80df2b158d0.png)
```python
add_table("k_ij_table",["h1","h2"])
hide_headers("k_ij_table",True)
add_row("k_ij_table", ["?", "?"])
add_row("k_ij_table", ["?", "?"])   
```
=========================
Update: 2021.2.14:
Instead of adding a new function, the new commit used ```configure_item("Table id", hide_headers=True)``` to hide headers of the table. Or you can setup it when add_table by using 
```python
add_table("k_ij_table",["1","2"],callback=table_printer,hide_headers=True)
```

![image](https://user-images.githubusercontent.com/8097683/107522495-bb147280-6bee-11eb-8aea-20c95c104322.png)

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
table