### PR TITLE
backport pr#589 to 0.6.x, fix version conflict when building Local Wheel & Sandbox under Linux

### DIFF
--- a/DearPyGui/cmake/linux_runner.cmake
+++ b/DearPyGui/cmake/linux_runner.cmake
@@ -100,4 +100,29 @@ elseif(MVPY_VERSION EQUAL 39)
 			python3.9
 	)
 
+elseif(MVPY_VERSION EQUAL 0)
+	find_package (Python COMPONENTS Development)
+	if(NOT Python_Development_FOUND)
+		message(FATAL_ERROR "The python3 development librarie from your distribution repo need to be installed first!")
+	endif()
+	target_include_directories(core 
+		PRIVATE 
+			${MARVEL_INCLUDE_DIR}
+			${Python_INCLUDE_DIRS}
+	)
+
+	target_link_directories(core 
+		PRIVATE 
+			"/usr/lib"
+			${Python_LIBRARY_DIRS}
+	)
+
+	target_link_libraries(core 
+		PRIVATE 
+			"-fPIC -lcrypt -lpthread -ldl  -lutil -lm"
+			GL
+			glfw
+			${Python_LIBRARIES}
+	)
+	
 endif()

--- a/Scripts/BuildLocalSandboxLinux.sh
+++ b/Scripts/BuildLocalSandboxLinux.sh
@@ -1,0 +1,15 @@
+cd ../Dependencies/cpython
+mkdir -p debug	
+cd debug	
+../configure --with-pydebug --enable-shared	
+make -j 	
+
+cd ../../../
+mkdir -p cmake-build-release
+cd cmake-build-release
+rm -rf *
+cmake .. -DMVPY_VERSION=38 -DMVDPG_VERSION=local_build
+make -j
+cd ..
+
+cd Scripts

--- a/Scripts/BuildLocalWheelLinux.sh
+++ b/Scripts/BuildLocalWheelLinux.sh
@@ -1,23 +1,17 @@
-cd ../Dependencies/cpython
-mkdir -p debug
-cd debug
-../configure --with-pydebug --enable-shared
-make -j 
-
-cd ../../../
+cd ..
 mkdir -p cmake-build-release
 cd cmake-build-release
 rm -rf *
-cmake .. -DMVDIST_ONLY=True -DMVPY_VERSION=39 -DMVDPG_VERSION=local_build
+cmake .. -DMVDIST_ONLY=True -DMVPY_VERSION=0 -DMVDPG_VERSION=local_build
 make -j
 cd ..
 
 cd Distribution
-"../Dependencies/cpython/debug/python" BuildPythonWheel.py ../cmake-build-release/DearPyGui/core.so 0
-"../Dependencies/cpython/debug/python" -m ensurepip
-"../Dependencies/cpython/debug/python" -m pip install --upgrade pip
-"../Dependencies/cpython/debug/python" -m pip install twine --upgrade
-"../Dependencies/cpython/debug/python" -m pip install wheel
-"../Dependencies/cpython/debug/python" -m setup bdist_wheel --plat-name manylinux1_x86_64 --dist-dir ../dist
+python3 BuildPythonWheel.py ../cmake-build-release/DearPyGui/core.so 0
+python3 -m ensurepip
+python3 -m pip install --upgrade pip
+python3 -m pip install twine --upgrade
+python3 -m pip install wheel
+python3 -m setup bdist_wheel --plat-name manylinux1_x86_64 --dist-dir ../dist
 cd ..
 cd Scripts


### PR DESCRIPTION
---
name: BuildLocalWheelLinux.sh
about: Build Local Wheel in Linux
title: 'Build Local Wheel Linux'
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->
backport https://github.com/hoffstadt/DearPyGui/pull/589 to 0.6.x.
Almost every Linux distribution have python3-dev package, let use local python3-dev package in their own repo to aviod version conflictions.

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
Build Local Wheel in Linux