### PR TITLE
disable color theme

### DIFF
--- a/DearPyGui/dearpygui/demo.py
+++ b/DearPyGui/dearpygui/demo.py
@@ -177,6 +177,9 @@ def show_demo():
         set_key_release_callback(None)
         set_accelerator_callback(None)
 
+    def log_callback(sender, data):
+        log_debug(f"{sender} ran a callback its value is {get_value(sender)}")
+
     with window("Dear PyGui Demo", x_pos=100, y_pos=100, width=800, height=800, on_close=on_demo_close):
 
         with menu_bar("MenuBar##demo"):
@@ -192,14 +195,14 @@ def show_demo():
                 add_menu_item("Save As..#demo")
                 add_separator()
                 with menu("Options##demomenu"):
-                    add_menu_item("Enabled##demo", check=True)
+                    add_checkbox("Toggle Enabled##demomenu", default_value=True, callback=lambda sender: configure_item("Enabled##demo", enabled=get_value(sender)))
+                    add_menu_item("Enabled##demo", check=True, callback=log_callback)
                     with child("childmenu##demo", height=60, autosize_x=True):
                         for i in range(0, 10):
                             add_text(f"Scrolling Text {i}")
                     add_slider_float("Value##demomenu")
                     add_input_float("Input##demomenu")
                     add_combo("Combo##demomenu", items=["Yes", "No", "Maybe"])
-                    add_checkbox("Some Option##demomenu")
 
             with menu("Tools##demo"):
                 add_menu_item("Show Logger##demo", callback=show_logger)
@@ -230,8 +233,6 @@ def show_demo():
         with collapsing_header("Widgets##demo"):
 
             with tree_node("Basic##demo"):
-                def log_callback(sender, data):
-                    log_debug(f"{sender} ran a callback its value is {get_value(sender)}")
                 def toggle_config(sender, data):
                     config_dict = {}
                     for kwarg in data['kwargs']:
@@ -244,7 +245,7 @@ def show_demo():
                     ,"combo##demo","listbox##demo","input text##demo","input text (w/ hint)##demo"
                     ,"input int##demo", "input float##demo", "input scientific##demo", "input float3##example##demo"
                     ,"drag int", "drag int 0..100##demo", "drag float##demo", "drag small float##demo"
-                    ,"slider int##demo", "slider float##demo", "slider angle##demo"]
+                    ,"slider int##demo", "slider float##demo", "slider angle##demo", "color 1##demo", "color 2##demo"]
                 add_checkbox("Enable-Disable##basic", default_value=True, callback=toggle_config, callback_data={'kwargs': ['enabled'], 'items': disable_items})
                 helpmarker('This will toggle the keyword "enable" for the widgets below that can be enabled & disabled')
                 with group("buttons##demo", horizontal=True):
@@ -306,13 +307,13 @@ def show_demo():
                 helpmarker("CTRL+click to enter value.")
                 add_slider_float("slider float##demo", max_value=1.0, format="ratio = %.3f", callback=log_callback)
                 add_slider_int("slider angle##demo", min_value=-360, max_value=360, format="%d deg", callback=log_callback)
-                add_color_edit3("color 1##demo", default_value=[255, 0, 51])
+                add_color_edit3("color 1##demo", default_value=[255, 0, 51], callback=log_callback)
                 helpmarker(
                         "Click on the colored square to open a color picker.\n"
                         "Click and hold to use drag and drop.\n"
                         "Right-click on the colored square to show options.\n"
                         "CTRL+click on individual component to input value.\n")
-                add_color_edit4("color 2##demo", default_value=[102, 179, 0, 128])
+                add_color_edit4("color 2##demo", default_value=[102, 179, 0, 128], callback=log_callback)
                 add_listbox("listbox##demo", items=["Apple", "Banana", "Cherry", "Kiwi", "Mango", "Orange", "Pineapple", "Strawberry", "Watermelon"]
                             , num_items=4, callback=log_callback)
 
@@ -334,8 +335,10 @@ def show_demo():
             with tree_node("Images##demo"):
                 add_text("Below we are displaying the font texture (which is the only texture we have access to in this demo).")
                 add_image("image##demo", "INTERNAL_DPG_FONT_ATLAS")
+                disable_items = ["__image##button1", "__image##button2"]
+                add_checkbox("Enable-Disable##images", default_value=True, callback=toggle_config, callback_data={'kwargs': ['enabled'], 'items': disable_items})
                 add_text("Here is an image button using a portion of the font atlas")
-                add_image_button("#image##button1", "INTERNAL_DPG_FONT_ATLAS", uv_max=[0.1, 0.1])
+                add_image_button("__image##button1", "INTERNAL_DPG_FONT_ATLAS", uv_max=[0.1, 0.1], callback=log_callback)
                 add_same_line()
                 textdata = []
                 for i in range(0, 10000):
@@ -344,7 +347,7 @@ def show_demo():
                     textdata.append(255)
                     textdata.append(255)
                 add_texture("#cooltexture", textdata, 100, 100, format=mvTEX_RGBA_INT)
-                add_image_button("#image##button2", "#cooltexture")
+                add_image_button("__image##button2", "#cooltexture", callback=log_callback)
 
             with tree_node("Text Input##demo"):
                 disable_items = ["##multiline##demo","default##demo", "decimal##demo", "hexdecimal##demo", 
@@ -400,6 +403,10 @@ def show_demo():
                     for name in names:
                         configure_item(name, **kwargs)
                 color_edit_names = ["MyColor##1", "MyColor##2"]
+                
+                disable_items = ["MyColor##1", "MyColor##2", "Color Edit 4##2", "Color Edit 4 (with custom popup)", "custom picker",
+                                 "Color Button", "Color Picker 4", "Color Edit 4 (float values)", "Color Edit 4 (ints value)"]
+                add_checkbox("Enable-Disable##color_widgets", default_value=True, callback=toggle_config, callback_data={'kwargs': ['enabled'], 'items': disable_items})
 
                 with managed_columns("##demowidgetscolor", 3, border=False):
                     add_checkbox("With Alpha Preview", callback=lambda sender, data: configure_items(color_edit_names, alpha_preview = get_value(sender)))
@@ -428,11 +435,11 @@ def show_demo():
                            "click the color edit preview will reveal the color picker.")
                 add_color_edit4("Color Edit 4##2", source=color_edit_names[0], no_inputs=True, no_label=True)
                 
-                add_text("Color button with Custom Picker Popup:")
-                add_color_edit4("Color Edit 4 (with custom popup)", source=color_edit_names[0], no_inputs=True, no_picker=True)
+                add_text("Custom Picker Popup (a color edit with no options)")
+                add_color_edit4("Color Edit 4 (with custom popup)", source=color_edit_names[0], no_inputs=True, no_picker=True, callback=log_callback)
                 helpmarker("we can override the popup with our own custom popup that includes a color pallet")
                 with popup("Color Edit 4 (with custom popup)", "custom picker popup", mousebutton=0):
-                    add_color_picker4("custom picker", no_tooltip=True, picker_hue_wheel=True)
+                    add_color_picker4("custom picker", no_tooltip=True, picker_hue_wheel=True, callback=log_callback)
                     add_text("Color Pallet")
                     for i in range(30):
                         add_color_button(f"color button {i}", hsv_to_rgb(i/30,1,1))
@@ -442,7 +449,7 @@ def show_demo():
                 
                 add_text("Color button only:")
                 add_checkbox("no_border", callback=lambda sender, data: configure_item("Color Button", no_border=get_value(sender)))
-                add_color_button("Color Button", (255, 50, 255, 0), width=50, height=50)
+                add_color_button("Color Button", (255, 50, 255, 0), width=50, height=50, callback=log_callback)
                 with managed_columns("##demowidgetscolor2", 2, border=False):
                     add_checkbox("With Alpha", default_value=True, callback=lambda sender, data: configure_item("Color Picker 4", alpha_preview = get_value(sender)))
                     add_checkbox("With Alpha Bar", default_value=True, callback=lambda sender, data: configure_item("Color Picker 4", alpha_bar = get_value(sender)))
@@ -457,7 +464,7 @@ def show_demo():
                     elif(get_value(sender) == 1): 
                         configure_item("Color Picker 4", picker_hue_wheel = True)
                 add_radio_button("Display Type", items=["Hue Bar", "Hue Wheel"], callback=apply_hue)
-                add_color_picker4("Color Picker 4", source=color_edit_names[0], alpha_preview= True, alpha_bar=True)
+                add_color_picker4("Color Picker 4", source=color_edit_names[0], alpha_preview= True, alpha_bar=True, callback=log_callback)
                 add_color_edit4("Color Edit 4 (float values)", alpha_preview= True, floats=True, callback=lambda sender, data: configure_item("float_values", label=f"{get_value('list_color_value')}", color=hsv_to_rgb(get_value('list_color_value')[0],get_value('list_color_value')[1],get_value('list_color_value')[2])))
                 helpmarker("Color item values given to the widget as a list will cause the \n"
                            "color item to store and return colors as scalar floats from 0.0-1.0.\n"

--- a/DearPyGui/src/core/AppItems/basic/mvButton.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvButton.cpp
@@ -86,16 +86,6 @@ namespace Marvel {
 		ScopedID id;
 		mvImGuiThemeScope scope(this);
 
-		if (!m_core_config.enabled)
-		{
-			//auto disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-			//disabled_color.w = 0.392f;
-			//styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_ButtonHovered, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_ButtonActive, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-		}
-
 		if (m_config.small_button)
 		{
 			if (ImGui::SmallButton(m_label.c_str()))

--- a/DearPyGui/src/core/AppItems/basic/mvButton.h
+++ b/DearPyGui/src/core/AppItems/basic/mvButton.h
@@ -45,12 +45,12 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_Button_PaddingY	, 10L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Text,         mvColor(255, 255, 255, 255), mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Bg,           mvColor( 41,  74, 122, 138), mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Hovered,      mvColor( 66, 150, 250, 102), mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Active,       mvColor( 66, 150, 250, 171), mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Border,       mvColor(110, 110, 128, 128), mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(255, 255, 255, 255)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Hovered,      mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Active,       mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvButton.h
+++ b/DearPyGui/src/core/AppItems/basic/mvButton.h
@@ -45,12 +45,12 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_Button_PaddingY	, 10L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Button_Text,         mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Button_Bg,           mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Button_Hovered,      mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Button_Active,       mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Button_Border,       mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Button_BorderShadow, mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Text,         mvColor(255, 255, 255, 255), mvColor(255, 255, 255, 255)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Bg,           mvColor( 41,  74, 122, 138), mvColor(255, 255, 255, 255)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Hovered,      mvColor( 66, 150, 250, 102), mvColor(255, 255, 255, 255)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Active,       mvColor( 66, 150, 250, 171), mvColor(255, 255, 255, 255)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_Border,       mvColor(110, 110, 128, 128), mvColor(255, 255, 255, 255)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Button_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(255, 255, 255, 255)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvCheckbox.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvCheckbox.cpp
@@ -46,17 +46,7 @@ namespace Marvel {
 		ScopedID id;
 		mvImGuiThemeScope scope(this);
 
-		if (!m_core_config.enabled)
-		{
-			//ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-			//disabled_color.w = 0.392f;
-			//styleManager.addColorStyle(ImGuiCol_CheckMark, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-			//m_disabled_value = *m_value;
-		}
+		if (!m_core_config.enabled) m_disabled_value = *m_value;
 
 		if (ImGui::Checkbox(m_label.c_str(), m_core_config.enabled ? m_value.get() : &m_disabled_value))
 			mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);

--- a/DearPyGui/src/core/AppItems/basic/mvCheckbox.h
+++ b/DearPyGui/src/core/AppItems/basic/mvCheckbox.h
@@ -44,12 +44,12 @@ namespace Marvel {
 
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_CheckBox_Text,			mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_CheckBox_Bg,				mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_CheckBox_BgHovered,		mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_CheckBox_BgActive,		mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_CheckBox_Border,			mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_CheckBox_BorderShadow,	mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_CheckBox_Text,			mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_CheckBox_Bg,			mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_CheckBox_BgHovered,		mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_CheckBox_BgActive,		mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_CheckBox_Border,		mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_CheckBox_BorderShadow,	mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvColorButton.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvColorButton.cpp
@@ -22,6 +22,7 @@ namespace Marvel {
 			{mvPythonDataType::Bool, "no_alpha", "ignore Alpha component", "False"},
 			{mvPythonDataType::Bool, "no_border", "disable border (which is enforced by default)", "False"},
 			{mvPythonDataType::Bool, "no_drag_drop", "disable display of inline text label", "False"},
+			{mvPythonDataType::Bool, "enabled", "", "True"},
 		}, "Adds a color button.", "None", "Adding Widgets") });
 	}
 
@@ -30,6 +31,7 @@ namespace Marvel {
 		mvAppItem(name),
 		m_color(color.toVec4())
 	{
+		m_description.disableAllowed = true;
 		m_config.color = color;
 	}
 
@@ -39,6 +41,7 @@ namespace Marvel {
 		m_color(config.color.toVec4()),
 		m_config(config)
 	{
+		m_description.disableAllowed = true;
 		m_config.name = name;
 		updateConfig(&m_config);
 	}
@@ -49,7 +52,7 @@ namespace Marvel {
 		mvImGuiThemeScope scope(this);
 
 		if (ImGui::ColorButton(m_label.c_str(), m_color, m_flags, ImVec2((float)m_core_config.width, (float)m_core_config.height)))
-			mvApp::GetApp()->getCallbackRegistry().addCallback(m_core_config.callback, m_core_config.name, m_core_config.callback_data);
+			mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
 
 	}
 
@@ -142,10 +145,11 @@ namespace Marvel {
 		int no_alpha = false;
 		int no_border = false;
 		int no_drag_drop = false;
+		int enabled = true;
 
 		if (!(mvApp::GetApp()->getParsers())["add_color_button"].parse(args, kwargs, __FUNCTION__,
 			&name, &color, &callback, &callback_data, &parent, &before, &width, &height,
-			&show, &no_alpha, &no_border, &no_drag_drop))
+			&show, &no_alpha, &no_border, &no_drag_drop, &enabled))
 			return ToPyBool(false);
 
 		auto item = CreateRef<mvColorButton>(name, ToColor(color));

--- a/DearPyGui/src/core/AppItems/basic/mvColorButton.h
+++ b/DearPyGui/src/core/AppItems/basic/mvColorButton.h
@@ -48,11 +48,11 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_ColorButton_PopupPaddingY,   1L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorButton_Text,         mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorButton_Separator,    mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorButton_PopupBg,      mvColor( 20,  20,  20, 240)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorButton_Border,       mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorButton_BorderShadow, mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorButton_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorButton_Separator,    mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorButton_PopupBg,      mvColor( 20,  20,  20, 240), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorButton_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorButton_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvColorEdit.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvColorEdit.cpp
@@ -22,6 +22,7 @@ namespace Marvel {
 			{mvPythonDataType::Integer, "height", "", "0"},
 			{mvPythonDataType::String, "label", "", "''"},
 			{mvPythonDataType::Bool, "show", "Attempt to render", "True"},
+			{mvPythonDataType::Bool, "enabled", "", "True"},
 			{mvPythonDataType::Bool, "no_alpha", "ignore Alpha component", "False"},
 			{mvPythonDataType::Bool, "no_picker", "disable picker when clicking on colored square.", "False"},
 			{mvPythonDataType::Bool, "no_options", " disable toggling options menu when right-clicking on inputs/small preview.", "False"},
@@ -59,6 +60,7 @@ namespace Marvel {
 			{mvPythonDataType::Integer, "height", "", "0"},
 			{mvPythonDataType::String, "label", "", "''"},
 			{mvPythonDataType::Bool, "show", "Attempt to render", "True"},
+			{mvPythonDataType::Bool, "enabled", "", "True"},
 			{mvPythonDataType::Bool, "no_alpha", "ignore Alpha component", "False"},
 			{mvPythonDataType::Bool, "no_picker", "disable picker when clicking on colored square.", "False"},
 			{mvPythonDataType::Bool, "no_options", " disable toggling options menu when right-clicking on inputs/small preview.", "False"},
@@ -85,6 +87,7 @@ namespace Marvel {
 		: 
 		mvColorPtrBase(name, color)
 	{
+		m_description.disableAllowed;
 		m_config = {};
 	}
 
@@ -93,6 +96,7 @@ namespace Marvel {
 		mvColorPtrBase(name, config.default_value.data()),
 		m_config(config)
 	{
+		m_description.disableAllowed;
 		m_config.name = name;
 		updateConfig(&m_config);
 	}
@@ -102,9 +106,10 @@ namespace Marvel {
 		ScopedID id;
 		mvImGuiThemeScope scope(this);
 
-		if (ImGui::ColorEdit3(m_label.c_str(), m_value->data(), m_flags))
-			mvApp::GetApp()->getCallbackRegistry().addCallback(m_core_config.callback, m_core_config.name, m_core_config.callback_data);
+		if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 3, m_disabled_value);
 
+		if (ImGui::ColorEdit3(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_flags))
+			mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
 	}
 
 	void mvColorEdit3::updateConfig(mvAppItemConfig* config)
@@ -134,6 +139,7 @@ namespace Marvel {
 		: 
 		mvColorPtrBase(name, color)
 	{
+		m_description.disableAllowed;
 		m_config = {};
 	}
 
@@ -142,6 +148,7 @@ namespace Marvel {
 		mvColorPtrBase(name, config.default_value.data()),
 		m_config(config)
 	{
+		m_description.disableAllowed;
 		m_config.name = name;
 		updateConfig(&m_config);
 	}
@@ -151,8 +158,10 @@ namespace Marvel {
 		ScopedID id;
 		mvImGuiThemeScope scope(this);
 
-		if (ImGui::ColorEdit4(m_label.c_str(), m_value->data(), m_flags))
-			mvApp::GetApp()->getCallbackRegistry().addCallback(m_core_config.callback, m_core_config.name, m_core_config.callback_data);
+		if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 4, m_disabled_value);
+
+		if (ImGui::ColorEdit4(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_flags))
+			mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
 
 	}
 
@@ -298,6 +307,7 @@ namespace Marvel {
 		const char* source = "";
 		const char* label = "";
 		int show = true;
+		int enabled = true;
 		int no_alpha = false;
 		int no_picker = false;
 		int no_options = false;
@@ -320,7 +330,7 @@ namespace Marvel {
 
 		if (!(mvApp::GetApp()->getParsers())["add_color_edit3"].parse(args, kwargs, __FUNCTION__, &name,
 			&default_value, &callback, &callback_data, &parent, &before, &source, &width, &height,
-			&label, &show, &no_alpha, &no_picker, &no_options, &no_small_preview, &no_inputs, &no_tooltip, &no_label, &no_drag_drop,
+			&label, &show, &enabled, &no_alpha, &no_picker, &no_options, &no_small_preview, &no_inputs, &no_tooltip, &no_label, &no_drag_drop,
 			&alpha_bar, &alpha_preview, &alpha_preview_half, &display_rgb, &display_hsv, &display_hex, &unit8, &floats, &input_rgb, &input_hsv))
 			return ToPyBool(false);
 
@@ -450,6 +460,7 @@ namespace Marvel {
 		const char* source = "";
 		const char* label = "";
 		int show = true;
+		int enabled = true;
 		int no_alpha = false;
 		int no_picker = false;
 		int no_options = false;
@@ -470,7 +481,7 @@ namespace Marvel {
 		int input_hsv = false;
 
 		if (!(mvApp::GetApp()->getParsers())["add_color_edit4"].parse(args, kwargs, __FUNCTION__, &name, &default_value,
-			&callback, &callback_data, &parent, &before, &source, &width, &height, &label, &show,
+			&callback, &callback_data, &parent, &before, &source, &width, &height, &label, &show, &enabled,
 			&no_alpha, &no_picker, &no_options, &no_small_preview, &no_inputs, &no_tooltip, &no_label, &no_drag_drop,
 			&alpha_bar, &alpha_preview, &alpha_preview_half, &display_rgb, &display_hsv, &display_hex, &unit8, &floats, &input_rgb, &input_hsv))
 			return ToPyBool(false);

--- a/DearPyGui/src/core/AppItems/basic/mvColorEdit.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvColorEdit.cpp
@@ -87,7 +87,7 @@ namespace Marvel {
 		: 
 		mvColorPtrBase(name, color)
 	{
-		m_description.disableAllowed;
+		m_description.disableAllowed = true;
 		m_config = {};
 	}
 
@@ -96,7 +96,7 @@ namespace Marvel {
 		mvColorPtrBase(name, config.default_value.data()),
 		m_config(config)
 	{
-		m_description.disableAllowed;
+		m_description.disableAllowed = true;
 		m_config.name = name;
 		updateConfig(&m_config);
 	}
@@ -139,7 +139,7 @@ namespace Marvel {
 		: 
 		mvColorPtrBase(name, color)
 	{
-		m_description.disableAllowed;
+		m_description.disableAllowed = true;
 		m_config = {};
 	}
 
@@ -148,7 +148,7 @@ namespace Marvel {
 		mvColorPtrBase(name, config.default_value.data()),
 		m_config(config)
 	{
-		m_description.disableAllowed;
+		m_description.disableAllowed = true;
 		m_config.name = name;
 		updateConfig(&m_config);
 	}

--- a/DearPyGui/src/core/AppItems/basic/mvColorEdit.h
+++ b/DearPyGui/src/core/AppItems/basic/mvColorEdit.h
@@ -73,14 +73,14 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_ColorEdit3_PaddingY			, 10L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit3_Text,          mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit3_TextHighlight, mvColor( 66, 150, 250,  89)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit3_Bg,            mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit3_BgHovered,     mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit3_BgActive,      mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit3_PopupBg,       mvColor( 20,  20,  20, 240)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit3_Border,        mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit3_BorderShadow,  mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit3_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit3_TextHighlight, mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit3_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit3_BgHovered,     mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit3_BgActive,      mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit3_PopupBg,       mvColor( 20,  20,  20, 240), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit3_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit3_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS
@@ -121,7 +121,6 @@ namespace Marvel {
 
 		ImGuiColorEditFlags m_flags = ImGuiColorEditFlags_None;
 		mvColorEditConfig   m_config;
-
 	};
 
 	//-----------------------------------------------------------------------------
@@ -154,14 +153,14 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_ColorEdit4_PaddingY			, 10L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit4_Text,          mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit4_TextHighlight, mvColor( 66, 150, 250,  89)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit4_Bg,            mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit4_BgHovered,     mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit4_BgActive,      mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit4_PopupBg,       mvColor( 20,  20,  20, 240)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit4_Border,        mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorEdit4_BorderShadow,  mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit4_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit4_TextHighlight, mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit4_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit4_BgHovered,     mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit4_BgActive,      mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit4_PopupBg,       mvColor( 20,  20,  20, 240), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit4_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorEdit4_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvColorPicker.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvColorPicker.cpp
@@ -22,6 +22,7 @@ namespace Marvel {
 			{mvPythonDataType::Integer, "height", "", "0"},
 			{mvPythonDataType::String, "label", "", "''"},
 			{mvPythonDataType::Bool, "show", "Attempt to render", "True"},
+			{mvPythonDataType::Bool, "enabled", "", "True"},
 			{mvPythonDataType::Bool, "no_alpha", "ignore Alpha component", "False"},
 			{mvPythonDataType::Bool, "no_small_preview", "disable colored square preview next to the inputs. (e.g. to show only the inputs). This only displays if the side preview is not shown.", "False"},
 			{mvPythonDataType::Bool, "no_inputs", "disable inputs sliders/text widgets (e.g. to show only the small preview colored square)", "False"},
@@ -59,6 +60,7 @@ namespace Marvel {
 			{mvPythonDataType::Integer, "height", "", "0"},
 			{mvPythonDataType::String, "label", "", "''"},
 			{mvPythonDataType::Bool, "show", "Attempt to render", "True"},
+			{mvPythonDataType::Bool, "enabled", "", "True"},
 			{mvPythonDataType::Bool, "no_alpha", "ignore Alpha component", "False"},
 			{mvPythonDataType::Bool, "no_small_preview", "disable colored square preview next to the inputs. (e.g. to show only the inputs). This only displays if the side preview is not shown.", "False"},
 			{mvPythonDataType::Bool, "no_inputs", "disable inputs sliders/text widgets (e.g. to show only the small preview colored square)", "False"},
@@ -84,6 +86,7 @@ namespace Marvel {
 		: 
 		mvColorPtrBase(name, color)
 	{
+		m_description.disableAllowed = true;
 		m_config = {};
 	}
 
@@ -92,6 +95,7 @@ namespace Marvel {
 		mvColorPtrBase(name, config.default_value.data()),
 		m_config(config)
 	{
+		m_description.disableAllowed = true;
 		m_config.name = name;
 		updateConfig(&m_config);
 	}
@@ -124,8 +128,10 @@ namespace Marvel {
 		ScopedID id;
 		mvImGuiThemeScope scope(this);
 
-		if (ImGui::ColorPicker3(m_label.c_str(), m_value->data(), m_flags))
-			mvApp::GetApp()->getCallbackRegistry().addCallback(m_core_config.callback, m_core_config.name, m_core_config.callback_data);
+		if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 3, m_disabled_value);
+
+		if (ImGui::ColorPicker3(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_flags))
+			mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
 
 	}
 
@@ -133,6 +139,7 @@ namespace Marvel {
 		: 
 		mvColorPtrBase(name, color)
 	{
+		m_description.disableAllowed = true;
 		m_config = {};
 	}
 
@@ -141,6 +148,7 @@ namespace Marvel {
 		mvColorPtrBase(name, config.default_value.data()),
 		m_config(config)
 	{
+		m_description.disableAllowed = true;
 		m_config.name = name;
 		updateConfig(&m_config);
 	}
@@ -173,8 +181,10 @@ namespace Marvel {
 		ScopedID id;
 		mvImGuiThemeScope scope(this);
 
-		if (ImGui::ColorPicker4(m_label.c_str(), m_value->data(), m_flags))
-			mvApp::GetApp()->getCallbackRegistry().addCallback(m_core_config.callback, m_core_config.name, m_core_config.callback_data);
+		if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 4, m_disabled_value);
+
+		if (ImGui::ColorPicker4(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_flags))
+			mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
 
 	}
 
@@ -298,6 +308,7 @@ namespace Marvel {
 		const char* source = "";
 		const char* label = "";
 		int show = true;
+		int enabled = true;
 		int no_alpha = false;
 		int no_small_preview = false;
 		int no_inputs = false;
@@ -319,7 +330,7 @@ namespace Marvel {
 
 
 		if (!(mvApp::GetApp()->getParsers())["add_color_picker3"].parse(args, kwargs, __FUNCTION__, &name, &default_value,
-			&callback, &callback_data, &parent, &before, &source, &width, &height, &label, &show,
+			&callback, &callback_data, &parent, &before, &source, &width, &height, &label, &show, &enabled,
 			&no_alpha, &no_small_preview, &no_inputs, &no_tooltip, &no_label, &no_side_preview, &alpha_bar,
 			&alpha_preview, &alpha_preview_half, &display_rgb, &display_hsv, &display_hex, &uint8, &floats, &picker_hue_bar,
 			&picker_hue_wheel, &input_rgb, &input_hsv))
@@ -450,6 +461,7 @@ namespace Marvel {
 		const char* source = "";
 		const char* label = "";
 		int show = true;
+		int enabled = true;
 		int no_alpha = false;
 		int no_small_preview = false;
 		int no_inputs = false;
@@ -471,7 +483,7 @@ namespace Marvel {
 
 		if (!(mvApp::GetApp()->getParsers())["add_color_picker4"].parse(args, kwargs, __FUNCTION__, &name,
 			&default_value, &callback, &callback_data, &parent, &before, &source, &width, &height,
-			&label, &show, &no_alpha, &no_small_preview, &no_inputs, &no_tooltip, &no_label, &no_side_preview, &alpha_bar,
+			&label, &show, &enabled, &no_alpha, &no_small_preview, &no_inputs, &no_tooltip, &no_label, &no_side_preview, &alpha_bar,
 			&alpha_preview, &alpha_preview_half, &display_rgb, &display_hsv, &display_hex, &uint8, &floats, &picker_hue_bar,
 			&picker_hue_wheel, &input_rgb, &input_hsv))
 			return ToPyBool(false);

--- a/DearPyGui/src/core/AppItems/basic/mvColorPicker.h
+++ b/DearPyGui/src/core/AppItems/basic/mvColorPicker.h
@@ -74,12 +74,12 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_ColorPicker3_PaddingY,       10L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker3_Text,         mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker3_Bg,           mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker3_BgHovered,    mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker3_BgActive,     mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker3_Border,       mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker3_BorderShadow, mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker3_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker3_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker3_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker3_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker3_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker3_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS
@@ -150,12 +150,12 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_ColorPicker4_PaddingY,       10L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker4_Text,         mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker4_Bg,           mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker4_BgHovered,    mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker4_BgActive,     mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker4_Border,       mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ColorPicker4_BorderShadow, mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker4_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker4_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker4_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker4_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker4_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ColorPicker4_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvCombo.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvCombo.cpp
@@ -57,20 +57,6 @@ namespace Marvel {
 		mvImGuiThemeScope scope(this);
 
 		static std::vector<std::string> disabled_items{};
-		if (!m_core_config.enabled)
-		{
-			//ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-			//disabled_color.w = 0.392f;
-			//styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_ButtonHovered, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_ButtonActive, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_PopupBg, { 0.0f, 0.0f, 0.0f, 0.0f });
-			//styleManager.addColorStyle(ImGuiCol_Border, { 0.0f, 0.0f, 0.0f, 0.0f });
-			//styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-		}
 
 		// The second parameter is the label previewed before opening the combo.
 		if (ImGui::BeginCombo(m_label.c_str(), m_value->c_str(), m_flags)) 

--- a/DearPyGui/src/core/AppItems/basic/mvCombo.h
+++ b/DearPyGui/src/core/AppItems/basic/mvCombo.h
@@ -64,21 +64,21 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_Combo_TextAlignY,         23L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_Text,                 mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_Selected,             mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_Hovered,              mvColor( 41,  74,  74, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_Active,               mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_Bg,                   mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_BgHovered,            mvColor( 41,  74,  74, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_DropBg,               mvColor( 20,  20,  20, 240)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_DropButtonBg,         mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_DropButtonHovered,    mvColor( 66, 150, 250, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_Scrollbar,            mvColor(  5,   5,   5, 135)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_ScrollbarGrab,        mvColor( 79,  79,  79, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_ScrollbarGrabHovered, mvColor(105, 105, 105, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_ScrollbarGrabActive,  mvColor(130, 130, 130, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_Border,               mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Combo_BorderShadow,         mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_Text,                 mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_Selected,             mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_Hovered,              mvColor( 41,  74,  74, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_Active,               mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_Bg,                   mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_BgHovered,            mvColor( 41,  74,  74, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_DropBg,               mvColor( 20,  20,  20, 240), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_DropButtonBg,         mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_DropButtonHovered,    mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_Scrollbar,            mvColor(  5,   5,   5, 135), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_ScrollbarGrab,        mvColor( 79,  79,  79, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_ScrollbarGrabHovered, mvColor(105, 105, 105, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_ScrollbarGrabActive,  mvColor(130, 130, 130, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_Border,               mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Combo_BorderShadow,         mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvDragItems.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvDragItems.cpp
@@ -232,18 +232,7 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //m_disabled_value = *m_value;
-        }
-
+        if (!m_core_config.enabled) m_disabled_value = *m_value;
 
         if (ImGui::DragFloat(m_label.c_str(), m_core_config.enabled ? m_value.get() : &m_disabled_value, m_speed, m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
@@ -301,17 +290,7 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 2, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 2, m_disabled_value);
 
         if (ImGui::DragFloat2(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_speed, m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
@@ -367,21 +346,10 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 3, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 3, m_disabled_value);
 
         if (ImGui::DragFloat3(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_speed, m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
     }
 
     void mvDragFloat3::updateConfig(mvAppItemConfig* config)
@@ -434,21 +402,10 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 4, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 4, m_disabled_value);
 
         if (ImGui::DragFloat4(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_speed, m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
     }
 
     void mvDragFloat4::updateConfig(mvAppItemConfig* config)
@@ -501,21 +458,10 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //m_disabled_value = *m_value;
-        }
+        if (!m_core_config.enabled) m_disabled_value = *m_value;
 
         if (ImGui::DragInt(m_label.c_str(), m_core_config.enabled ? m_value.get() : &m_disabled_value, m_speed, m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
     }
 
     void mvDragInt::updateConfig(mvAppItemConfig* config)
@@ -568,21 +514,10 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 2, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 2, m_disabled_value);
 
         if (ImGui::DragInt2(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_speed, m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
     }
 
     void mvDragInt2::updateConfig(mvAppItemConfig* config)
@@ -610,7 +545,7 @@ namespace Marvel {
     mvDragInt3::mvDragInt3(const std::string& name, int* default_value, const std::string& dataSource)
         : mvInt3PtrBase(name, default_value)
     {
-        // empty constructor
+        m_description.disableAllowed = true;
     }
 
     void mvDragInt3::setEnabled(bool value)
@@ -635,21 +570,10 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 3, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 3, m_disabled_value);
 
         if (ImGui::DragInt3(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_speed, m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
     }
 
     void mvDragInt3::updateConfig(mvAppItemConfig* config)
@@ -702,21 +626,10 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 4, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 4, m_disabled_value);
 
         if (ImGui::DragInt4(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_speed, m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
     }
 
     void mvDragInt4::updateConfig(mvAppItemConfig* config)

--- a/DearPyGui/src/core/AppItems/basic/mvDragItems.h
+++ b/DearPyGui/src/core/AppItems/basic/mvDragItems.h
@@ -69,12 +69,12 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_DragFloat_InnerSpacingY , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -156,12 +156,12 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_DragFloat2_InnerSpacingY   , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat2_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat2_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat2_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat2_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat2_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat2_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat2_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat2_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat2_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat2_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat2_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat2_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -228,12 +228,12 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_DragFloat3_InnerSpacingY   , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat3_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat3_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat3_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat3_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat3_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat3_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat3_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat3_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat3_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat3_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat3_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat3_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -301,12 +301,12 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_DragFloat4_InnerSpacingY   , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat4_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat4_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat4_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat4_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat4_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragFloat4_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat4_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat4_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat4_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat4_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat4_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragFloat4_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -385,12 +385,12 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_DragInt_InnerSpacingY , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -469,12 +469,12 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_DragInt2_InnerSpacingY   , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt2_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt2_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt2_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt2_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt2_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt2_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt2_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt2_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt2_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt2_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt2_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt2_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -541,12 +541,12 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_DragInt3_InnerSpacingY   , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt3_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt3_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt3_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt3_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt3_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt3_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt3_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt3_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt3_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt3_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt3_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt3_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -613,12 +613,12 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_DragInt4_InnerSpacingY   , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt4_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt4_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt4_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt4_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt4_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_DragInt4_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt4_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt4_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt4_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt4_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt4_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_DragInt4_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvImageButton.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvImageButton.cpp
@@ -24,6 +24,7 @@ namespace Marvel {
 			{mvPythonDataType::FloatList, "uv_min", "normalized texture coordinates", "(0.0, 0.0)"},
 			{mvPythonDataType::FloatList, "uv_max", "normalized texture coordinates", "(1.0, 1.0)"},
 			{mvPythonDataType::Bool, "show", "Attempt to render", "True"},
+			{mvPythonDataType::Bool, "enabled", "", "True"},
 		}, "Adds an image button."
 		"uv_min and uv_max represent the normalized texture coordinates of the original image that will be shown."
 		"Using(0,0)->(1,1) texture coordinates will generally display the entire texture", "None", "Adding Widgets") });
@@ -33,6 +34,7 @@ namespace Marvel {
 		: mvAppItem(name), m_value(std::move(default_value))
 	{
 		m_description.ignoreSizeUpdate = true;
+		m_description.disableAllowed = true;
 		mvEventBus::Subscribe(this, mvEVT_DELETE_TEXTURE);
 	}
 
@@ -106,7 +108,7 @@ namespace Marvel {
 			if (ImGui::ImageButton(m_texture, ImVec2((float)m_core_config.width, (float)m_core_config.height),
 				ImVec2(m_uv_min.x, m_uv_min.y), ImVec2(m_uv_max.x, m_uv_max.y), m_framePadding,
 				m_backgroundColor, m_tintColor))
-				mvApp::GetApp()->getCallbackRegistry().addCallback(m_core_config.callback, m_core_config.name, m_core_config.callback_data);
+				mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
 			ImGui::PopID();
 		}
 
@@ -195,10 +197,11 @@ namespace Marvel {
 		PyTuple_SetItem(uv_max, 0, PyFloat_FromDouble(1));
 		PyTuple_SetItem(uv_max, 1, PyFloat_FromDouble(1));
 		int show = true;
+		int enabled = true;
 
 		if (!(mvApp::GetApp()->getParsers())["add_image_button"].parse(args, kwargs, __FUNCTION__,
 			&name, &value, &callback, &callback_data, &tintcolor, &backgroundColor, &parent,
-			&before, &width, &height, &frame_padding, &uv_min, &uv_max, &show))
+			&before, &width, &height, &frame_padding, &uv_min, &uv_max, &show, &enabled))
 			return ToPyBool(false);
 
 		auto item = CreateRef<mvImageButton>(name, value);

--- a/DearPyGui/src/core/AppItems/basic/mvImageButton.h
+++ b/DearPyGui/src/core/AppItems/basic/mvImageButton.h
@@ -34,11 +34,11 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_ImageButton_PaddingY		, 10L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ImageButton_Bg,           mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ImageButton_BgHovered,    mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ImageButton_BgActive,     mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ImageButton_Border,       mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_ImageButton_BorderShadow, mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ImageButton_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ImageButton_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ImageButton_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ImageButton_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_ImageButton_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvInputItems.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvInputItems.cpp
@@ -239,17 +239,6 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-        }
-
         if (ImGui::InputInt(m_label.c_str(), m_value.get(), m_step, m_step_fast, m_flags))
         {
             // determines clamped cases
@@ -326,17 +315,6 @@ namespace Marvel {
     {
         ScopedID id;
         mvImGuiThemeScope scope(this);
-
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-        }
 
         if (ImGui::InputInt2(m_label.c_str(), m_value->data(), m_flags))
         {
@@ -423,17 +401,6 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-        }
-
         if (ImGui::InputInt3(m_label.c_str(), m_value->data(), m_flags))
         {
             // determines clamped cases
@@ -518,17 +485,6 @@ namespace Marvel {
     {
         ScopedID id;
         mvImGuiThemeScope scope(this);
-
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-        }
 
         if (ImGui::InputInt4(m_label.c_str(), m_value->data(), m_flags))
         {
@@ -615,17 +571,6 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-        }
-
         if (ImGui::InputFloat(m_label.c_str(), m_value.get(), m_step, m_step_fast, m_format.c_str(), m_flags))
         {
             // determines clamped cases
@@ -701,17 +646,6 @@ namespace Marvel {
     {
         ScopedID id;
         mvImGuiThemeScope scope(this);
-
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-        }
 
         if (ImGui::InputFloat2(m_label.c_str(), m_value->data(), m_format.c_str(), m_flags))
         {
@@ -798,17 +732,6 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-        }
-
         if (ImGui::InputFloat3(m_label.c_str(), m_value->data(), m_format.c_str(), m_flags))
         {
             // determines clamped cases
@@ -893,17 +816,6 @@ namespace Marvel {
     {
         ScopedID id;
         mvImGuiThemeScope scope(this);
-
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-        }
 
         if (ImGui::InputFloat4(m_label.c_str(), m_value->data(), m_format.c_str(), m_flags))
         {

--- a/DearPyGui/src/core/AppItems/basic/mvInputItems.h
+++ b/DearPyGui/src/core/AppItems/basic/mvInputItems.h
@@ -79,14 +79,14 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_InputInt_ButtonTextAlignY, 22L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt_Text,               mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt_TextHighlight,      mvColor( 66, 150, 250,  89)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt_Bg,                 mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt_ButtonBg,           mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt_ButtonBgHovered,    mvColor( 66, 150, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt_ButtonBgActive,     mvColor( 15, 135, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt_Border,             mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt_BorderShadow,       mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt_Text,               mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt_TextHighlight,      mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt_Bg,                 mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt_ButtonBg,           mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt_ButtonBgHovered,    mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt_ButtonBgActive,     mvColor( 15, 135, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt_Border,             mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt_BorderShadow,       mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -170,11 +170,11 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_InputInt2_InnerSpacingY , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt2_Text,          mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt2_TextHighlight, mvColor( 66, 150, 250,  89)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt2_Bg,            mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt2_Border,        mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt2_BorderShadow,  mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt2_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt2_TextHighlight, mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt2_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt2_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt2_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -241,11 +241,11 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_InputInt3_InnerSpacingY , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt3_Text,          mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt3_TextHighlight, mvColor( 66, 150, 250,  89)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt3_Bg,            mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt3_Border,        mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt3_BorderShadow,  mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt3_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt3_TextHighlight, mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt3_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt3_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt3_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -313,11 +313,11 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_InputInt4_InnerSpacingY , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt4_Text,          mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt4_TextHighlight, mvColor( 66, 150, 250,  89)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt4_Bg,            mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt4_Border,        mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputInt4_BorderShadow,  mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt4_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt4_TextHighlight, mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt4_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt4_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputInt4_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -404,14 +404,14 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_InputFloat_ButtonTextAlignY, 22L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat_Text,               mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat_TextHighlight,      mvColor( 66, 150, 250,  89)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat_Bg,                 mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat_ButtonBg,           mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat_ButtonBgHovered,    mvColor( 66, 150, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat_ButtonBgActive,     mvColor( 15, 135, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat_Border,             mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat_BorderShadow,       mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat_Text,               mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat_TextHighlight,      mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat_Bg,                 mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat_ButtonBg,           mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat_ButtonBgHovered,    mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat_ButtonBgActive,     mvColor( 15, 135, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat_Border,             mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat_BorderShadow,       mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -496,11 +496,11 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_InputFloat2_InnerSpacingY , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat2_Text,          mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat2_TextHighlight, mvColor( 66, 150, 250,  89)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat2_Bg,            mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat2_Border,        mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat2_BorderShadow,  mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat2_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat2_TextHighlight, mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat2_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat2_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat2_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -568,11 +568,11 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_InputFloat3_InnerSpacingY , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat3_Text,          mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat3_TextHighlight, mvColor( 66, 150, 250,  89)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat3_Bg,            mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat3_Border,        mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat3_BorderShadow,  mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat3_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat3_TextHighlight, mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat3_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat3_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat3_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -640,11 +640,11 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_InputFloat4_InnerSpacingY , 14L, 1L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat4_Text,          mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat4_TextHighlight, mvColor( 66, 150, 250,  89)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat4_Bg,            mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat4_Border,        mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputFloat4_BorderShadow,  mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat4_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat4_TextHighlight, mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat4_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat4_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputFloat4_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvInputText.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvInputText.cpp
@@ -63,16 +63,6 @@ namespace Marvel {
 		ScopedID id;
 		mvImGuiThemeScope scope(this);
 
-		if (!m_core_config.enabled)
-		{
-			//ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-			//disabled_color.w = 0.392f;
-			//styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-		}
-
 		if (m_multiline)
 			m_hint = "";
 

--- a/DearPyGui/src/core/AppItems/basic/mvInputText.h
+++ b/DearPyGui/src/core/AppItems/basic/mvInputText.h
@@ -43,12 +43,12 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_InputText_InnerSpacingY, 14L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputText_Text,			mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputText_TextHighlight,	mvColor( 66, 150, 250,  89)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputText_Bg,			mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputText_Hint,			mvColor(128, 128, 128, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputText_Border,		mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_InputText_BorderShadow,	mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputText_Text,			mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputText_TextHighlight,mvColor( 66, 150, 250,  89), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputText_Bg,			mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputText_Hint,			mvColor(128, 128, 128, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputText_Border,		mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_InputText_BorderShadow,	mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvListbox.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvListbox.cpp
@@ -37,27 +37,10 @@ namespace Marvel {
 		ScopedID id;
 		mvImGuiThemeScope scope(this);
 
-		if (!m_core_config.enabled)
-		{
-			//ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-			//disabled_color.w = 0.392f;
-			//styleManager.addColorStyle(ImGuiCol_Header, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_HeaderHovered, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_HeaderActive, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_ScrollbarBg, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_ScrollbarGrab, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_ScrollbarGrabHovered, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_ScrollbarGrabActive, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-			//m_disabled_value = *m_value;
-		}
+		if (!m_core_config.enabled) m_disabled_value = *m_value;
 
 		if (ImGui::ListBox(m_label.c_str(), m_core_config.enabled ? m_value.get() : &m_disabled_value, m_charNames.data(), (int)m_names.size(), m_itemsHeight))
 			mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
 	}
 
 	void mvListbox::updateConfig(mvAppItemConfig* config)

--- a/DearPyGui/src/core/AppItems/basic/mvListbox.h
+++ b/DearPyGui/src/core/AppItems/basic/mvListbox.h
@@ -44,16 +44,16 @@ namespace Marvel {
 
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Listbox_Text,					mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Listbox_Selected,				mvColor( 60, 150, 250,  79)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Listbox_Hovered,					mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Listbox_Active,					mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Listbox_Bg,						mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Listbox_Border,					mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Listbox_Scrollbar,				mvColor(  5,   5,   5, 135)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Listbox_ScrollbarGrab,			mvColor( 79,  79,  79, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Listbox_ScrollbarGrabHovered,	mvColor(105, 105, 105, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Listbox_ScrollbarGrabActive,		mvColor(130, 130, 130, 255)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Listbox_Text,					mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Listbox_Selected,				mvColor( 60, 150, 250,  79), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Listbox_Hovered,				mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Listbox_Active,					mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Listbox_Bg,						mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Listbox_Border,					mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Listbox_Scrollbar,				mvColor(  5,   5,   5, 135), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Listbox_ScrollbarGrab,			mvColor( 79,  79,  79, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Listbox_ScrollbarGrabHovered,	mvColor(105, 105, 105, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Listbox_ScrollbarGrabActive,	mvColor(130, 130, 130, 255), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvMenuItem.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvMenuItem.cpp
@@ -23,7 +23,10 @@ namespace Marvel {
 	}
 
 	mvMenuItem::mvMenuItem(const std::string& name)
-		: mvBoolPtrBase(name, false) {}
+		: mvBoolPtrBase(name, false) 
+	{
+		m_description.disableAllowed = true;
+	}
 
 	void mvMenuItem::draw()
 	{
@@ -31,7 +34,7 @@ namespace Marvel {
 		mvImGuiThemeScope scope(this);
 
 		// create menuitem and see if its selected
-		if (ImGui::MenuItem(m_label.c_str(), m_shortcut.c_str(), m_check ? m_value.get() : nullptr, m_core_config.enabled))
+		if (ImGui::MenuItem(m_label.c_str(), m_shortcut.c_str(), m_check ? m_value.get() : nullptr))
 		{
 
 			// set other menuitems's value false on same level
@@ -44,7 +47,7 @@ namespace Marvel {
 
 			*m_value = true;
 
-			mvApp::GetApp()->getCallbackRegistry().addCallback(m_core_config.callback, m_core_config.name, m_core_config.callback_data);
+			mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
 
 		}
 

--- a/DearPyGui/src/core/AppItems/basic/mvMenuItem.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvMenuItem.cpp
@@ -34,9 +34,8 @@ namespace Marvel {
 		mvImGuiThemeScope scope(this);
 
 		// create menuitem and see if its selected
-		if (ImGui::MenuItem(m_label.c_str(), m_shortcut.c_str(), m_check ? m_value.get() : nullptr))
+		if (ImGui::MenuItem(m_label.c_str(), m_shortcut.c_str(), m_check ? m_value.get() : nullptr, m_core_config.enabled))
 		{
-
 			// set other menuitems's value false on same level
 			for (auto sibling : m_parent->m_children)
 			{
@@ -47,7 +46,7 @@ namespace Marvel {
 
 			*m_value = true;
 
-			mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
+			mvApp::GetApp()->getCallbackRegistry().addCallback(m_core_config.callback, m_core_config.name, m_core_config.callback_data);
 
 		}
 

--- a/DearPyGui/src/core/AppItems/basic/mvMenuItem.h
+++ b/DearPyGui/src/core/AppItems/basic/mvMenuItem.h
@@ -26,8 +26,8 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(ImGuiStyleVar_MenuItem_TextAlignY	, 23L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_MenuItem_Text,		mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_MenuItem_BgHovered,	mvColor( 66, 150, 250, 240)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_MenuItem_Text,		mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_MenuItem_BgHovered,	mvColor( 66, 150, 250, 240), mvColor(128, 128, 128, 0)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvRadioButton.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvRadioButton.cpp
@@ -37,17 +37,8 @@ namespace Marvel {
 		ScopedID id;
 		mvImGuiThemeScope scope(this);
 
-		if (!m_core_config.enabled)
-		{
-			//ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-			//disabled_color.w = 0.392f;
-			//styleManager.addColorStyle(ImGuiCol_CheckMark, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-			//styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-			//m_disabled_value = *m_value;
-		}
+		if (!m_core_config.enabled) m_disabled_value = *m_value;
+
 		for (size_t i = 0; i < m_itemnames.size(); i++)
 		{
 			if (m_horizontal && i != 0)

--- a/DearPyGui/src/core/AppItems/basic/mvRadioButton.h
+++ b/DearPyGui/src/core/AppItems/basic/mvRadioButton.h
@@ -32,12 +32,12 @@ namespace Marvel {
 		MV_CREATE_THEME_CONSTANT(mvThemeStyle_RadioButton_InnerSpacingY, 14L, 1L);
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_RadioButton_Text,			mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_RadioButton_Bg,				mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_RadioButton_BgHovered,		mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_RadioButton_BgActive,		mvColor( 66, 150, 250, 171)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_RadioButton_Border,			mvColor(110, 110, 128, 128)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_RadioButton_BorderShadow,	mvColor(  0,   0,   0,   0)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_RadioButton_Text,			mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_RadioButton_Bg,				mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_RadioButton_BgHovered,		mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_RadioButton_BgActive,		mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_RadioButton_Border,			mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_RadioButton_BorderShadow,	mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/basic/mvSelectable.h
+++ b/DearPyGui/src/core/AppItems/basic/mvSelectable.h
@@ -27,15 +27,15 @@ namespace Marvel {
 
 
 		MV_START_COLOR_CONSTANTS
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Selectable_Text,			mvColor(255, 255, 255, 255)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Selectable_Bg,			mvColor( 41,  74, 122, 138)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Selectable_BgHovered,	mvColor( 66, 150, 250, 102)),
-			MV_CREATE_CONSTANT_PAIR(mvThemeCol_Selectable_BgActive,		mvColor( 66, 150, 250, 171)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Selectable_Text,			mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Selectable_Bg,				mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Selectable_BgHovered,		mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeCol_Selectable_BgActive,		mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
 		MV_END_COLOR_CONSTANTS
 
 		MV_START_STYLE_CONSTANTS
-				MV_CREATE_CONSTANT_TUPLE(mvThemeStyle_Selectable_TextAlignX, 0, 20),
-				MV_CREATE_CONSTANT_TUPLE(mvThemeStyle_Selectable_TextAlignY, 0, 20),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeStyle_Selectable_TextAlignX, 0, 20),
+			MV_CREATE_CONSTANT_TUPLE(mvThemeStyle_Selectable_TextAlignY, 0, 20),
 		MV_END_STYLE_CONSTANTS
 
 	public:

--- a/DearPyGui/src/core/AppItems/basic/mvSliderItems.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvSliderItems.cpp
@@ -234,19 +234,7 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrab, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrabActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //m_disabled_value = *m_value;
-        }
+        if (!m_core_config.enabled) m_disabled_value = *m_value;
 
         if (m_vertical)
         {
@@ -265,7 +253,6 @@ namespace Marvel {
                 mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
 
         }
-
     }
 
     void mvSliderFloat::updateConfig(mvAppItemConfig* config)
@@ -319,23 +306,10 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrab, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrabActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 2, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 2, m_disabled_value);
 
         if (ImGui::SliderFloat2(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
     }
 
     void mvSliderFloat2::updateConfig(mvAppItemConfig* config)
@@ -388,23 +362,10 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrab, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrabActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 3, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 3, m_disabled_value);
 
         if (ImGui::SliderFloat3(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
     }
 
     void mvSliderFloat3::updateConfig(mvAppItemConfig* config)
@@ -457,23 +418,10 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrab, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrabActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 4, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 4, m_disabled_value);
 
         if (ImGui::SliderFloat4(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
     }
 
     void mvSliderFloat4::updateConfig(mvAppItemConfig* config)
@@ -526,19 +474,7 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrab, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrabActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //m_disabled_value = *m_value;
-        }
+        if (!m_core_config.enabled) m_disabled_value = *m_value;
 
         if (m_vertical)
         {
@@ -556,7 +492,6 @@ namespace Marvel {
                 mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
 
         }
-
     }
 
     void mvSliderInt::updateConfig(mvAppItemConfig* config)
@@ -610,19 +545,7 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrab, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrabActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 2, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 2, m_disabled_value);
 
         if (ImGui::SliderInt2(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
@@ -678,23 +601,10 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrab, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrabActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 3, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 3, m_disabled_value);
 
         if (ImGui::SliderInt3(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);
-
     }
 
     void mvSliderInt3::updateConfig(mvAppItemConfig* config)
@@ -747,19 +657,7 @@ namespace Marvel {
         ScopedID id;
         mvImGuiThemeScope scope(this);
 
-        if (!m_core_config.enabled)
-        {
-            //ImVec4 disabled_color = ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-            //disabled_color.w = 0.392f;
-            //styleManager.addColorStyle(ImGuiCol_FrameBg, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgHovered, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_FrameBgActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Button, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrab, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_SliderGrabActive, disabled_color);
-            //styleManager.addColorStyle(ImGuiCol_Text, ImVec4(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)));
-            //std::copy(m_value->data(), m_value->data() + 4, m_disabled_value);
-        }
+        if (!m_core_config.enabled) std::copy(m_value->data(), m_value->data() + 4, m_disabled_value);
 
         if (ImGui::SliderInt4(m_label.c_str(), m_core_config.enabled ? m_value->data() : &m_disabled_value[0], m_min, m_max, m_format.c_str(), m_flags))
             mvApp::GetApp()->getCallbackRegistry().addCallback(getCallback(false), m_core_config.name, m_core_config.callback_data);

--- a/DearPyGui/src/core/AppItems/basic/mvSliderItems.h
+++ b/DearPyGui/src/core/AppItems/basic/mvSliderItems.h
@@ -71,14 +71,14 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_SliderFloat_GrabRounding      , 20L, 0L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat_Text,            mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat_Bg,				mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat_BgHovered,		mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat_BgActive,		mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat_Grab,            mvColor( 61, 133, 224, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat_GrabActive,      mvColor( 66, 150, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat_Border,			mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat_BorderShadow,	mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat_Text,           mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat_Bg,             mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat_BgHovered,      mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat_BgActive,		mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat_Grab,           mvColor( 61, 133, 224, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat_GrabActive,     mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat_Border,         mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat_BorderShadow,   mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -162,14 +162,14 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_SliderFloat2_GrabRounding    , 20L, 0L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat2_Text,           mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat2_Bg,				mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat2_BgHovered,		mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat2_BgActive,		mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat2_Grab,           mvColor( 61, 133, 224, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat2_GrabActive,     mvColor( 66, 150, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat2_Border,         mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat2_BorderShadow,   mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat2_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat2_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat2_BgHovered,		mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat2_BgActive,		mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat2_Grab,          mvColor( 61, 133, 224, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat2_GrabActive,    mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat2_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat2_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -242,14 +242,14 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_SliderFloat3_GrabRounding    , 20L, 0L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat3_Text,           mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat3_Bg,				mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat3_BgHovered,		mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat3_BgActive,		mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat3_Grab,           mvColor( 61, 133, 224, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat3_GrabActive,     mvColor( 66, 150, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat3_Border,         mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat3_BorderShadow,   mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat3_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat3_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat3_BgHovered,		mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat3_BgActive,		mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat3_Grab,          mvColor( 61, 133, 224, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat3_GrabActive,    mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat3_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat3_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -321,14 +321,14 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_SliderFloat4_GrabRounding  , 20L, 0L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat4_Text,           mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat4_Bg,				mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat4_BgHovered,		mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat4_BgActive,		mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat4_Grab,           mvColor( 61, 133, 224, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat4_GrabActive,     mvColor( 66, 150, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat4_Border,         mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderFloat4_BorderShadow,   mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat4_Text,          mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat4_Bg,            mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat4_BgHovered,     mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat4_BgActive,      mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat4_Grab,          mvColor( 61, 133, 224, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat4_GrabActive,    mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat4_Border,        mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderFloat4_BorderShadow,  mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -413,14 +413,14 @@ namespace Marvel {
 
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt_Text,          mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt_Bg,             mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt_BgHovered,		mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt_BgActive,      mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt_Grab,          mvColor( 61, 133, 224, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt_GrabActive,    mvColor( 66, 150, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt_Border,        mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt_BorderShadow,  mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt_Text,             mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt_Bg,               mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt_BgHovered,        mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt_BgActive,         mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt_Grab,             mvColor( 61, 133, 224, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt_GrabActive,       mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt_Border,           mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt_BorderShadow,     mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -504,14 +504,14 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_SliderInt2_GrabRounding    , 20L, 0L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt2_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt2_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt2_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt2_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt2_Grab,         mvColor( 61, 133, 224, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt2_GrabActive,   mvColor( 66, 150, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt2_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt2_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt2_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt2_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt2_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt2_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt2_Grab,         mvColor( 61, 133, 224, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt2_GrabActive,   mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt2_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt2_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -583,14 +583,14 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_SliderInt3_GrabRounding    , 20L, 0L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt3_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt3_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt3_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt3_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt3_Grab,         mvColor( 61, 133, 224, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt3_GrabActive,   mvColor( 66, 150, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt3_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt3_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt3_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt3_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt3_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt3_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt3_Grab,         mvColor( 61, 133, 224, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt3_GrabActive,   mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt3_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt3_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS
@@ -662,14 +662,14 @@ namespace Marvel {
         MV_CREATE_THEME_CONSTANT(mvThemeStyle_SliderInt4_GrabRounding    , 20L, 0L);
 
         MV_START_COLOR_CONSTANTS
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt4_Text,         mvColor(255, 255, 255, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt4_Bg,           mvColor( 41,  74, 122, 138)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt4_BgHovered,    mvColor( 66, 150, 250, 102)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt4_BgActive,     mvColor( 66, 150, 250, 171)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt4_Grab,         mvColor( 61, 133, 224, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt4_GrabActive,   mvColor( 66, 150, 250, 255)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt4_Border,       mvColor(110, 110, 128, 128)),
-            MV_CREATE_CONSTANT_PAIR(mvThemeCol_SliderInt4_BorderShadow, mvColor(  0,   0,   0,   0)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt4_Text,         mvColor(255, 255, 255, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt4_Bg,           mvColor( 41,  74, 122, 138), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt4_BgHovered,    mvColor( 66, 150, 250, 102), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt4_BgActive,     mvColor( 66, 150, 250, 171), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt4_Grab,         mvColor( 61, 133, 224, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt4_GrabActive,   mvColor( 66, 150, 250, 255), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt4_Border,       mvColor(110, 110, 128, 128), mvColor(128, 128, 128, 63)),
+            MV_CREATE_CONSTANT_TUPLE(mvThemeCol_SliderInt4_BorderShadow, mvColor(  0,   0,   0,   0), mvColor(128, 128, 128, 63)),
         MV_END_COLOR_CONSTANTS
 
         MV_START_STYLE_CONSTANTS

--- a/DearPyGui/src/core/AppItems/composite/mvStyleWindow.cpp
+++ b/DearPyGui/src/core/AppItems/composite/mvStyleWindow.cpp
@@ -150,6 +150,47 @@ namespace Marvel {
 
                 ImGui::EndTabItem();
             }
+            if (ImGui::BeginTabItem("Colors (disabled)"))
+            {
+
+                HelpMarker(
+                    "Export saves commands to your clipboard. Paste into your file.");
+                ImGui::SameLine();
+                if (ImGui::Button("Export Colors (disabled)"))
+                {
+
+                    ImGui::LogToClipboard();
+
+                    for (auto item : mvThemeManager::GetColorsPtr())
+                    {
+                        // Uncomment and replace with new command
+
+                        //ImGui::LogText("set_theme_item(mvGuiCol_%s, %i, %i, %i, %i)\r\n",
+                        //    name, (int)(round(col.x * 255.0f)), (int)(round(col.y * 255.0f)), (int)(round(col.z * 255.0f)),
+                        //    (int)(round(col.w * 255.0f)));
+                    }
+                    ImGui::LogFinish();
+                }
+
+                static ImGuiTextFilter filter3;
+                filter3.Draw("Filter Colors##(disabled)", ImGui::GetFontSize() * 16);
+
+                ImGui::Separator();
+
+                for (auto& item : mvThemeManager::GetColorsPtr())
+                {
+                    if (!filter3.PassFilter(std::get<0>(item).c_str()))
+                        continue;
+
+                    ImGui::PushID(&item);
+                    ImGui::ColorEdit4("##color(disable)", *std::get<3>(item), ImGuiColorEditFlags_AlphaBar);
+                    ImGui::SameLine();
+                    ImGui::TextUnformatted(std::get<0>(item).c_str());
+                    ImGui::PopID();
+                }
+
+                ImGui::EndTabItem();
+            }
 
         }
 

--- a/DearPyGui/src/core/AppItems/mvTypeBases.h
+++ b/DearPyGui/src/core/AppItems/mvTypeBases.h
@@ -192,6 +192,7 @@ namespace Marvel {
 	protected:
 
 		mvRef<std::array<float, 4>> m_value;
+		float  m_disabled_value[4]{};
 	};
 
 	//-----------------------------------------------------------------------------

--- a/DearPyGui/src/core/Modules/mvModule_Core.cpp
+++ b/DearPyGui/src/core/Modules/mvModule_Core.cpp
@@ -350,10 +350,12 @@ namespace Marvel {
 						long mvThemeConstant = std::get<1>(item);
 						decodeType(mvThemeConstant, &type);
 						mvColor color = std::get<2>(item);
+						mvColor color_disable = std::get<3>(item);
 						const std::string& name = std::get<0>(item);
 
-						mvThemeManager::GetColors()[type][mvThemeConstant] = color;
-						mvThemeManager::GetColorsPtr().push_back({name, mvThemeConstant, &mvThemeManager::GetColors()[type][mvThemeConstant] });
+						mvThemeManager::GetColors()[type][mvThemeConstant].first = color;
+						mvThemeManager::GetColors()[type][mvThemeConstant].second = color_disable;
+						mvThemeManager::GetColorsPtr().push_back({name, mvThemeConstant, &mvThemeManager::GetColors()[type][mvThemeConstant].first, &mvThemeManager::GetColors()[type][mvThemeConstant].first });
 
 					}
 

--- a/DearPyGui/src/core/Modules/mvModule_Core.cpp
+++ b/DearPyGui/src/core/Modules/mvModule_Core.cpp
@@ -355,7 +355,7 @@ namespace Marvel {
 
 						mvThemeManager::GetColors()[type][mvThemeConstant].first = color;
 						mvThemeManager::GetColors()[type][mvThemeConstant].second = color_disable;
-						mvThemeManager::GetColorsPtr().push_back({name, mvThemeConstant, &mvThemeManager::GetColors()[type][mvThemeConstant].first, &mvThemeManager::GetColors()[type][mvThemeConstant].first });
+						mvThemeManager::GetColorsPtr().push_back({name, mvThemeConstant, &mvThemeManager::GetColors()[type][mvThemeConstant].first, &mvThemeManager::GetColors()[type][mvThemeConstant].second });
 
 					}
 

--- a/DearPyGui/src/core/Theming/mvImNodesThemeScope.h
+++ b/DearPyGui/src/core/Theming/mvImNodesThemeScope.h
@@ -20,7 +20,7 @@ namespace Marvel {
 
 			// this is messy and disgusting. Needs to be cleaned up and optimized
 
-			const std::vector<std::tuple<std::string, long, mvColor>>& color_constants = T::GetColorConstants();
+			const std::vector<std::tuple<std::string, long, mvColor, mvColor>>& color_constants = T::GetColorConstants();
 			const std::vector<std::tuple<std::string, long, float, float>>& style_constants = T::GetStyleConstants();
 
 			mvThemeColors colors;
@@ -111,7 +111,7 @@ namespace Marvel {
 			for (auto& color : colors)
 			{
 				mvThemeManager::decodelibID(color.first, &imColorID);
-				imnodes::PushColorStyle((imnodes::ColorStyle)imColorID, color.second);
+				imnodes::PushColorStyle((imnodes::ColorStyle)imColorID, color.second.first);
 			}
 
 			StyleIDCount = styles.size();

--- a/DearPyGui/src/core/Theming/mvImPlotThemeScope.h
+++ b/DearPyGui/src/core/Theming/mvImPlotThemeScope.h
@@ -19,7 +19,7 @@ namespace Marvel {
 
 			// this is messy and disgusting. Needs to be cleaned up and optimized
 
-			const std::vector<std::tuple<std::string, long, mvColor>>& color_constants = T::GetColorConstants();
+			const std::vector<std::tuple<std::string, long, mvColor, mvColor>>& color_constants = T::GetColorConstants();
 			const std::vector<std::tuple<std::string, long, float, float>>& style_constants = T::GetStyleConstants();
 
 			mvThemeColors colors;
@@ -121,7 +121,7 @@ namespace Marvel {
 			for (const auto& color : colors)
 			{
 				mvThemeManager::decodelibID(color.first, &imColorID);
-				ImPlot::PushStyleColor(imColorID, color.second.toVec4());
+				ImPlot::PushStyleColor(imColorID, color.second.first.toVec4());
 			}
 
 			StyleIDCount = styles.size();

--- a/DearPyGui/src/core/Theming/mvThemeManager.cpp
+++ b/DearPyGui/src/core/Theming/mvThemeManager.cpp
@@ -6,10 +6,10 @@
 
 namespace Marvel {
 
-	std::vector<std::tuple<std::string, long, mvColor*>>      mvThemeManager::s_acolors;
-	std::vector<std::tuple<std::string, long, float*, float>> mvThemeManager::s_astyles;
-	std::unordered_map<mvAppItemType, mvThemeColors>          mvThemeManager::s_colors;
-	std::unordered_map<mvAppItemType, mvThemeStyles>          mvThemeManager::s_styles;
+	std::vector<std::tuple<std::string, long, mvColor*, mvColor*>>      mvThemeManager::s_acolors;
+	std::vector<std::tuple<std::string, long, float*, float>>			mvThemeManager::s_astyles;
+	std::unordered_map<mvAppItemType, mvThemeColors>					mvThemeManager::s_colors;
+	std::unordered_map<mvAppItemType, mvThemeStyles>					mvThemeManager::s_styles;
 
 	void mvThemeManager::decodeType(long encoded_constant, mvAppItemType* type)
 	{
@@ -54,14 +54,14 @@ namespace Marvel {
 		//fills out the app's root theme if no item was given
 		if (widget.empty())
 		{
-			GetColors()[type][mvThemeConstant] = color;
+			GetColors()[type][mvThemeConstant].first = color;
 			return true;
 		}
 
 		//check widget can take color and apply
 		mvRef<mvAppItem> item = mvApp::GetApp()->getItemRegistry().getItem(widget);
 		if (item->getDescription().container || item->getType() == type)
-			item->getColors()[type][mvThemeConstant] = color;
+			item->getColors()[type][mvThemeConstant].first = color;
 		else
 		{
 			mvApp::GetApp()->getCallbackRegistry().submitCallback([=]()

--- a/DearPyGui/src/core/Theming/mvThemeManager.h
+++ b/DearPyGui/src/core/Theming/mvThemeManager.h
@@ -16,7 +16,7 @@ namespace Marvel {
 		static void decodelibID(long encoded_constant, int* libID);
 		static int decodeIndex(long encoded_constant);
 
-		static std::vector<std::tuple<std::string, long, mvColor*>>& GetColorsPtr() { return s_acolors; }
+		static std::vector<std::tuple<std::string, long, mvColor*, mvColor*>>& GetColorsPtr() { return s_acolors; }
 		static std::vector<std::tuple<std::string, long, float*, float>>& GetStylesPtr() { return s_astyles; }
 		static std::unordered_map<mvAppItemType, mvThemeColors>& GetColors() { return s_colors; }
 		static std::unordered_map<mvAppItemType, mvThemeStyles>& GetStyles() { return s_styles; }
@@ -32,7 +32,7 @@ namespace Marvel {
 		bool add_color(mvEvent& event);
 		bool add_style(mvEvent& event);
 
-		static std::vector<std::tuple<std::string, long, mvColor*>> s_acolors;
+		static std::vector<std::tuple<std::string, long, mvColor*, mvColor*>> s_acolors;
 		static std::vector<std::tuple<std::string, long, float*, float>>   s_astyles;
 		static std::unordered_map<mvAppItemType, mvThemeColors>     s_colors;
 		static std::unordered_map<mvAppItemType, mvThemeStyles>     s_styles;

--- a/DearPyGui/src/core/cpp.hint
+++ b/DearPyGui/src/core/cpp.hint
@@ -11,12 +11,12 @@ mvAppItemType getType() const override { return x; }\
 std::string getStringType() const override { return std::string(#x); }\
 std::string getParserCommand() const override { return parser; }
 
-#define MV_START_COLOR_CONSTANTS public: static const std::vector<std::tuple<std::string, long, mvColor>>& GetColorConstants()\
-        {static std::vector<std::tuple<std::string, long, mvColor>> constants ={
+#define MV_START_COLOR_CONSTANTS public: static const std::vector<std::tuple<std::string, long, mvColor, mvColor>>& GetColorConstants()\
+        {static std::vector<std::tuple<std::string, long, mvColor, mvColor>> constants ={
 #define MV_END_COLOR_CONSTANTS };return constants;}
 #define MV_START_STYLE_CONSTANTS public: static const std::vector<std::tuple<std::string, long, float, float>>& GetStyleConstants()\
         {static std::vector<std::tuple<std::string, long, float, float>> constants ={
 #define MV_END_STYLE_CONSTANTS };return constants;}
-#define MV_CREATE_CONSTANT_PAIR(x, y) {#x, x, y}
+#define MV_CREATE_CONSTANT_PAIR(x, y) {#x, x, y, y}
 #define MV_CREATE_CONSTANT_TUPLE(x, y, z) {#x, x, y, z}
 #define MV_CREATE_THEME_CONSTANT(y, z, i) static constexpr const long y = s_internal_type*1000L+z*10L+i;

--- a/DearPyGui/src/core/mvCore.h
+++ b/DearPyGui/src/core/mvCore.h
@@ -184,7 +184,7 @@ namespace Marvel {
 		}
 	}
 
-	typedef std::unordered_map<long, mvColor> mvThemeColors;
+	typedef std::unordered_map<long, std::pair<mvColor, mvColor>> mvThemeColors;
 	typedef std::unordered_map<long, float> mvThemeStyles;
 }
 


### PR DESCRIPTION
first attempt at disable colors for widgets that can have disable, we did not use the index digit of the color constants because we don't actually want to create another constant. creating another constant (or creating an invisible constant) would make the colors vector larger and more to loop through.

here we edited the color theme object to just hold one more color . when tree searching we only store a vector of themeColor objects, so this should be a minimal impact on searching. 

when we go to push to imgui we check if its disable or not and push all the disable/enabled colors in the themeColors vect, this only adds one if check per widget to decide to push vect as disabled or not 

