### PR TITLE
fext text/label_text horizontal align

### DIFF
--- a/DearPyGui/src/core/AppItems/basic/mvText.cpp
+++ b/DearPyGui/src/core/AppItems/basic/mvText.cpp
@@ -62,6 +62,7 @@ namespace Marvel {
 		mvImGuiThemeScope scope(this);
 		mvFontScope fscope(this);
 
+		ImGui::AlignTextToFramePadding();
 		if (m_color.r > 0.0f)
 			ImGui::PushStyleColor(ImGuiCol_Text, m_color.toVec4());
 
@@ -93,6 +94,7 @@ namespace Marvel {
 
 		if (m_color.r > 0.0f)
 		{
+			ImGui::AlignTextToFramePadding();
 			ImGui::PushStyleColor(ImGuiCol_Text, m_color.toVec4());
 
 			ImGui::TextUnformatted(m_value->c_str());


### PR DESCRIPTION
**Description:**
fixes add_text and add_label_text horizontal center alignment when adding aframed item after the text item
