### PR TITLE
Fix dangerous scripts on Linux

### DIFF
--- a/Scripts/BuildLocalWheelLinux.sh
+++ b/Scripts/BuildLocalWheelLinux.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 cd ../Dependencies/cpython
 mkdir debug
 cd debug
@@ -6,9 +9,10 @@ make
 cd ../../..
 
 cd ..
-mkdir -p cmake-build-local
+rm -rf cmake-build-local
+mkdir cmake-build-local
 cd cmake-build-local
-rm -rf *
+
 cmake .. -DMVDIST_ONLY=True -DMVPY_VERSION=0 -DMVDPG_VERSION=local_build
 make -j
 cd ..

--- a/Scripts/BuildLocalWheelRPi.sh
+++ b/Scripts/BuildLocalWheelRPi.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 cd ../Dependencies/cpython
 mkdir debug
 cd debug
@@ -5,9 +8,10 @@ cd debug
 make
 cd ../../..
 
-mkdir -p cmake-build-local
+rm -rf cmake-build-local
+mkdir cmake-build-local
 cd cmake-build-local
-rm -rf *
+
 cmake .. -DMVDIST_ONLY=True -DMVPY_VERSION=0 -DMVDPG_VERSION=local_build
 make -j3
 cd ..

--- a/Scripts/BuildPythonForLinux.sh
+++ b/Scripts/BuildPythonForLinux.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 cd ../Dependencies/cpython
 mkdir debug
 cd debug


### PR DESCRIPTION
Fixes #796 

We add set -e to make sure the script will exit if any command fails.
Additionally, all rm -rf calls now only delete the desired directory by
name, not by using *.
