### PR TITLE
Fix Sandbox build on Linux

### DIFF
--- a/DearSandbox/main_linux.cpp
+++ b/DearSandbox/main_linux.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
       nullptr);
 #else
   wchar_t *deco = Py_DecodeLocale(
-      "../../Dependencies/cpython/debug/build/lib.linux-x86_64-3.8-pydebug/:../"
+      "../../Dependencies/cpython/debug/build/lib.linux-x86_64-3.9-pydebug/:../"
       "../Dependencies/cpython/Lib/:../../DearPyGui:../../DearSandbox",
       nullptr);
 #endif


### PR DESCRIPTION
---
name: Fix Sandbox build on Linux
about: Build of Sandbox could not be executed after building on Linux
title: 'Fix Sandbox build on Linux'
assignees: ''

---

**Description:**
After building on Linux, executing the Sandbox was not possible, as I got weird errors about built-in modules missing:

```
$ ./DearSandbox
Could not find platform independent libraries <prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Traceback (most recent call last):
  File "../../DearSandbox/sandbox.py", line 3, in <module>
    from dearpygui.demo import show_demo
  File "../../DearPyGui/dearpygui/demo.py", line 5, in <module>
    from math import sin, cos
ModuleNotFoundError: No module named 'math'
```

The reason was that the Sandbox was still searching for python3.8. This is now fixed.

**Concerning Areas:**
No other components will be affected by this.
