### PR TITLE
Fix incorrect display of logger without filter

### DIFF
--- a/DearPyGui/src/core/AppItems/composite/mvLogger.cpp
+++ b/DearPyGui/src/core/AppItems/composite/mvLogger.cpp
@@ -118,7 +118,7 @@ namespace Marvel {
 		ImGui::BeginGroup();
 
 		ImGui::PushID(this);
-		
+
 		// auto scroll button
 		if (m_autoScrollButton)
 		{
@@ -140,9 +140,13 @@ namespace Marvel {
 			ImGui::SameLine();
 		}
 
+		// Add a new line after the buttons only if required
+		if (m_autoScrollButton | m_clearButton | m_copyButton){
+			ImGui::NewLine();
+		}
+
 		if (m_filter)
 		{
-			ImGui::NewLine();
 			Filter.Draw("Filter", m_width-100.0f);
 		}
 


### PR DESCRIPTION
Closes #873

---
name: Fix incorrect display of logger without filter
about: Logger was displayed incorrectly when added with `filter=False`, see #873
title: 'Fix incorrect display of logger without filter'
assignees: ''

---

**Description:**
See #873

**Concerning Areas:**
I don't think anything else could break because of this. The change is very localized, and I tested all combinations of buttons and the filter being visible or invisible:

![image](https://user-images.githubusercontent.com/9742635/118195964-7ba72d80-b44c-11eb-8b2b-5aa43299484a.png)

