### PR TITLE
Improve linux build process

### DIFF
--- a/Scripts/BuildLocalWheelLinux.sh
+++ b/Scripts/BuildLocalWheelLinux.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Allow user to set number of jobs when compiling
-while getopts 'j:' OPT; do
+while getopts 'j:' OPTION; do
     case "$OPTION" in
         j)
             jobs="-j $OPTARG"

--- a/Scripts/BuildLocalWheelLinux.sh
+++ b/Scripts/BuildLocalWheelLinux.sh
@@ -29,6 +29,11 @@ fi
 
     cmake .. -DMVDIST_ONLY=True -DMVPY_VERSION=0 -DMVDPG_VERSION=local_build
     cd ..
+
+    # Hack to enable linking the freetype static library to the dynamicly linked core.so
+    sed -i 's|C_FLAGS = -fvisibility|C_FLAGS = -fpic -fvisibility|g' \
+        cmake-build-local/Dependencies/freetype/CMakeFiles/freetype.dir/flags.make
+
     cmake --build cmake-build-local --config Release $jobs
 )
 

--- a/Scripts/BuildLocalWheelLinux.sh
+++ b/Scripts/BuildLocalWheelLinux.sh
@@ -28,7 +28,8 @@ fi
     cd cmake-build-local
 
     cmake .. -DMVDIST_ONLY=True -DMVPY_VERSION=0 -DMVDPG_VERSION=local_build
-    make $jobs
+    cd ..
+    cmake --build cmake-build-local --config Release $jobs
 )
 
 (

--- a/Scripts/BuildLocalWheelLinux.sh
+++ b/Scripts/BuildLocalWheelLinux.sh
@@ -17,7 +17,7 @@ cd $(dirname $0) # Make sure we start in the Scripts directory
 
 # Build python first if it hasn't been already
 if [ ! -f ../Dependencies/cpython/debug/python ]; then
-    ./BuildPythonForLinux.sh
+    ./BuildPythonForLinux.sh $jobs
 fi
 
 # Use subshell for other build steps so directory changes stay contained

--- a/Scripts/BuildLocalWheelLinux.sh
+++ b/Scripts/BuildLocalWheelLinux.sh
@@ -38,8 +38,7 @@ fi
 )
 
 (
-    mkdir -p Distribution
-    cd Distribution
+    cd ../Distribution
     python3 BuildPythonWheel.py ../cmake-build-local/DearPyGui/core.so 0
     python3 -m ensurepip
     python3 -m pip install --upgrade pip

--- a/Scripts/BuildLocalWheelLinux.sh
+++ b/Scripts/BuildLocalWheelLinux.sh
@@ -1,28 +1,43 @@
 #!/bin/sh
 set -e
 
-cd ../Dependencies/cpython
-mkdir debug
-cd debug
-../configure --with-pydebug --enable-shared
-make
-cd ../../..
+# Allow user to set number of jobs when compiling
+while getopts 'j:' OPT; do
+    case "$OPTION" in
+        j)
+            jobs="-j $OPTARG"
+            ;;
+        ?)
+            exit 1
+            ;;
+    esac
+done
 
-cd ..
-rm -rf cmake-build-local
-mkdir cmake-build-local
-cd cmake-build-local
+cd $(dirname $0) # Make sure we start in the Scripts directory
 
-cmake .. -DMVDIST_ONLY=True -DMVPY_VERSION=0 -DMVDPG_VERSION=local_build
-make -j
-cd ..
+# Build python first if it hasn't been already
+if [ ! -f ../Dependencies/cpython/debug/python ]; then
+    ./BuildPythonForLinux.sh
+fi
 
-cd Distribution
-python3 BuildPythonWheel.py ../cmake-build-local/DearPyGui/core.so 0
-python3 -m ensurepip
-python3 -m pip install --upgrade pip
-python3 -m pip install twine --upgrade
-python3 -m pip install wheel
-python3 -m setup bdist_wheel --plat-name manylinux1_x86_64 --dist-dir ../dist
-cd ..
-cd Scripts
+# Use subshell for other build steps so directory changes stay contained
+(
+    cd ..
+    rm -rf cmake-build-local
+    mkdir cmake-build-local
+    cd cmake-build-local
+
+    cmake .. -DMVDIST_ONLY=True -DMVPY_VERSION=0 -DMVDPG_VERSION=local_build
+    make $jobs
+)
+
+(
+    mkdir -p Distribution
+    cd Distribution
+    python3 BuildPythonWheel.py ../cmake-build-local/DearPyGui/core.so 0
+    python3 -m ensurepip
+    python3 -m pip install --upgrade pip
+    python3 -m pip install twine --upgrade
+    python3 -m pip install wheel
+    python3 -m setup bdist_wheel --plat-name manylinux1_x86_64 --dist-dir ../dist
+)

--- a/Scripts/BuildPythonForLinux.sh
+++ b/Scripts/BuildPythonForLinux.sh
@@ -15,7 +15,18 @@ done
 
 cd $(dirname $0) # Make sure we start in the Scripts directory
 cd ../Dependencies/cpython
-mkdir -p debug
-cd debug
-../configure --with-pydebug --enable-shared
-make $jobs
+
+# Run `./BuildPythonForLinux.sh clean` to clean up the build directory
+if [ "$1" = "clean" ]; then
+    rm -r debug
+else
+    mkdir -p debug
+    cd debug
+
+    # Reconfiguring is time-consuming. Skip if it's already been done
+    if [ ! -f Makefile ]; then
+        ../configure --with-pydebug --enable-shared
+    fi
+
+    make $jobs
+fi

--- a/Scripts/BuildPythonForLinux.sh
+++ b/Scripts/BuildPythonForLinux.sh
@@ -7,6 +7,9 @@ while getopts 'j:' OPTION; do
         j)
             jobs="-j $OPTARG"
             ;;
+        ?)
+            exit 1
+            ;;
     esac
 done
 

--- a/Scripts/BuildPythonForLinux.sh
+++ b/Scripts/BuildPythonForLinux.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
 set -e
 
+# Allow user to set number of jobs when compiling
+while getopts 'j:' OPTION; do
+    case "$OPTION" in
+        j)
+            jobs="-j $OPTARG"
+            ;;
+    esac
+done
+
 cd ../Dependencies/cpython
 mkdir -p debug
 cd debug
 ../configure --with-pydebug --enable-shared
-make 
+make $jobs

--- a/Scripts/BuildPythonForLinux.sh
+++ b/Scripts/BuildPythonForLinux.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd ../Dependencies/cpython
-mkdir debug
+mkdir -p debug
 cd debug
 ../configure --with-pydebug --enable-shared
 make 

--- a/Scripts/BuildPythonForLinux.sh
+++ b/Scripts/BuildPythonForLinux.sh
@@ -10,6 +10,7 @@ while getopts 'j:' OPTION; do
     esac
 done
 
+cd $(dirname $0) # Make sure we start in the Scripts directory
 cd ../Dependencies/cpython
 mkdir -p debug
 cd debug

--- a/Scripts/BuildSandboxLinux.sh
+++ b/Scripts/BuildSandboxLinux.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+# Allow user to set number of jobs when compiling
+while getopts 'j:' OPTION; do
+    case "$OPTION" in
+        j)
+            jobs="-j $OPTARG"
+            ;;
+        ?)
+            exit 1
+            ;;
+    esac
+done
+
+cd $(dirname $0) # Make sure we start in the Scripts directory
+
+if [ "$1" = "clean" ]; then
+    rm -r ../cmake-build-debug
+    exit 0
+fi
+
+# Build python first if it hasn't been already
+if [ ! -f ../Dependencies/cpython/debug/python ]; then
+    ./BuildPythonForLinux.sh
+fi
+
+cd ..
+mkdir -p cmake-build-debug
+cd cmake-build-debug
+cmake ..
+cd ..
+cmake --build cmake-build-debug --config Debug $jobs

--- a/Scripts/BuildSandboxLinux.sh
+++ b/Scripts/BuildSandboxLinux.sh
@@ -22,7 +22,7 @@ fi
 
 # Build python first if it hasn't been already
 if [ ! -f ../Dependencies/cpython/debug/python ]; then
-    ./BuildPythonForLinux.sh
+    ./BuildPythonForLinux.sh $jobs
 fi
 
 cd ..


### PR DESCRIPTION
---
name: Improve the linux build process
about: Update the scripts for building on Linux to make the process smoother. And to actually work in the first place.
title: 'Improve the linux build procss'
assignees: '@hoffstadt @Jah-On '

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
The current build process on Linux doesn't produce reliable output and is slow. This PR is a first stab at solving that. Features:
- Make all builds actually succeed
- Make builds more robust
- Add a build script for compiling the DearSandbox
- Enable setting the job number for all build scripts to decrease build time using the `-j` argument
- Allow re-building python using the `clean` argument
- Enable running the build scripts from the project root

**Concerning Areas:**

1. We should find a better way to properly compile freetype for linking it inside `core.so`. The current hack with `sed` works, put it would be nicer to somehow specify the `-fpic` argument to gcc through the `CMakeLists.txt` or some repeatable way similar to it.
2. The final wheel can only be imported with the self-compiled debug version of python. It seems the core.so somehow relies on some definitions that are only available in a debug build of python.
3. Should we consolidate the build scripts? Right now there are three separate scripts with quite a bit of code duplication that partly even call each other, so maybe having them as one script that you run like `./Scripts/build.sh python`, `./Scripts/build.sh wheel` or `./Scripts/build.sh sandbox` would be a better and more flexible option.