### PR TITLE
removing hide override for window

### DIFF
--- a/DearPyGui/src/core/AppItems/containers/mvWindowAppItem.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvWindowAppItem.cpp
@@ -437,7 +437,13 @@ namespace Marvel {
 		_collapsed = ImGui::IsWindowCollapsed();
 
 		if (!_show)
-			hide();
+		{
+			_state.setHovered(false);
+			_state.setFocused(false);
+			_state.setActivated(false);
+			_state.setVisible(false);
+			mvApp::GetApp()->getCallbackRegistry().addCallback(_on_close, _uuid, nullptr, _user_data);
+		}
 
 		// event handlers
 		for (auto& item : _children[3])
@@ -453,19 +459,6 @@ namespace Marvel {
 	{
 		_show = true;
 		_popupInit = true;
-	}
-
-	void mvWindowAppItem::hide()
-	{
-		// shouldn't have to do this but do. Fix later
-		_show = false;
-		_state.setHovered(false);
-		_state.setFocused(false);
-		_state.setActivated(false);
-		_state.setVisible(false);
-
-		mvApp::GetApp()->getCallbackRegistry().addCallback(_on_close, _uuid, nullptr, _user_data);
-
 	}
 
 	void mvWindowAppItem::handleSpecificKeywordArgs(PyObject* dict)

--- a/DearPyGui/src/core/AppItems/containers/mvWindowAppItem.cpp
+++ b/DearPyGui/src/core/AppItems/containers/mvWindowAppItem.cpp
@@ -278,7 +278,16 @@ namespace Marvel {
 			{
 				if (_mainWindow)
 					ImGui::PopStyleVar();
-				hide();
+
+				// shouldn't have to do this but do. Fix later
+				_show = false;
+				_state.setHovered(false);
+				_state.setFocused(false);
+				_state.setActivated(false);
+				_state.setVisible(false);
+
+				mvApp::GetApp()->getCallbackRegistry().addCallback(_on_close, _uuid, nullptr, _user_data);
+				
 				return;
 			}
 		}

--- a/DearPyGui/src/core/AppItems/containers/mvWindowAppItem.h
+++ b/DearPyGui/src/core/AppItems/containers/mvWindowAppItem.h
@@ -57,7 +57,6 @@ namespace Marvel {
 		bool getWindowAsMainStatus() const { return _mainWindow; }
 
 		void show() override;
-		void hide() override;
 		void onChildAdd(mvRef<mvAppItem> item) override;
 		void onChildRemoved(mvRef<mvAppItem> item) override;
 		void handleSpecificKeywordArgs(PyObject* dict) override;


### PR DESCRIPTION
**Description:**
fixes #1149 
hide functionality moved inside draw because it was specific to only when the widget was turned to hidden after being drawn
otherwise the override for hide was being called every frame the widget was hidden.
this was submitting close callback every frame and also updated the few states we only need to update if the window was going from shown to hidden. 
