### PR TITLE
fixes issue #1300

### DIFF
--- a/DearPyGui/src/core/AppItems/mvAppItem.cpp
+++ b/DearPyGui/src/core/AppItems/mvAppItem.cpp
@@ -49,8 +49,8 @@ namespace Marvel {
         // in case item registry is destroyed
         if (GContext->started)
         {
-            CleanUpItem(*GContext->itemRegistry, _uuid);
             RemoveAlias(*GContext->itemRegistry, _alias, true);
+            CleanUpItem(*GContext->itemRegistry, _uuid);
         }
     }
 


### PR DESCRIPTION
changing order of deletion in appItem destructor

when the item was cleaned up before the alias was deleted it was resulting in an assert when trying to access the alias's item description
