### PR TITLE
DOC: fix minor typos - add missing list item, corrrect function name

### DIFF
--- a/docs/source/tutorials/dpg-structure.rst
+++ b/docs/source/tutorials/dpg-structure.rst
@@ -6,6 +6,7 @@ DPG Structure Overview
 
 A DPG app will have an overall structure as follows:
     * Setup
+    * Context
     * Viewport
     * Render Loop
     * Items
@@ -104,7 +105,7 @@ Such as per-frame ticker or counter update functions.
 
     dpg.destroy_context()
 
-.. warning:: The manual render loop must be created after :py:func:`start_dearpygui <dearpygui.dearpygui.start_dearpygui>`
+.. warning:: The manual render loop must be created after :py:func:`setup_dearpygui <dearpygui.dearpygui.setup_dearpygui>`
 
 .. seealso:: For more information on the render loop :doc:`../documentation/render-loop`
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: ''
assignees: ''

---

**Description:**
Trivial typo fixes in latest docs:
1.  Added a missing list item.
The list is subsequenlly expanded on as items 2.1 to 2.6. Inserted missing item 2.2 into the list. 
2. Corrected a function name
The manual render loop OR `start_dearpygui` can be used - either one must be preceded by a call to `setup_dearypygui`. 

**Concerning Areas:**
None.
