### PR TITLE
fix (mvPlotLegend): fixed "location" kwarg arg being ignored #1339

### DIFF
--- a/DearPyGui/src/core/AppItems/plots/mvPlotLegend.cpp
+++ b/DearPyGui/src/core/AppItems/plots/mvPlotLegend.cpp
@@ -86,7 +86,7 @@ namespace Marvel {
         if (dict == nullptr)
             return;
 
-        if (PyObject* item = PyDict_GetItemString(dict, "location")) { _location = ToInt(item); _dirty = true; }
+        if (PyObject* item = PyDict_GetItemString(dict, "location")) { _legendLocation = ToInt(item); _dirty = true; }
         if (PyObject* item = PyDict_GetItemString(dict, "horizontal")){ _horizontal = ToBool(item); _dirty = true;}
         if (PyObject* item = PyDict_GetItemString(dict, "outside")) {_outside = ToBool(item); _dirty = true;}
 


### PR DESCRIPTION
"location" was setting app item member "location" (location within parent) instead of the correct "_legendLocation".