### PR TITLE
fix: draw_ellipse/draw_polyline broken #1425

### DIFF
--- a/DearPyGui/src/core/AppItems/drawing/mvDrawPolyline.cpp
+++ b/DearPyGui/src/core/AppItems/drawing/mvDrawPolyline.cpp
@@ -52,6 +52,8 @@ namespace Marvel {
 		mvVec4 start = { x, y };
 
 		std::vector<mvVec4> points = _points;
+		std::vector<ImVec2> finalpoints;
+		finalpoints.reserve(_points.size());
 
 		for (auto& point : points)
 			point = _transform * point;
@@ -80,17 +82,21 @@ namespace Marvel {
 				ImVec2 impoint = ImPlot::PlotToPixels(point);
 				point.x = impoint.x;
 				point.y = impoint.y;
+				finalpoints.push_back(impoint);
 			}
 
-			drawlist->AddPolyline((const ImVec2*)const_cast<const mvVec4*>(points.data()), (int)_points.size(), _color,
+			drawlist->AddPolyline(finalpoints.data(), (int)finalpoints.size(), _color,
 				_closed, ImPlot::GetCurrentContext()->Mx * _thickness);
 		}
 		else
 		{
 			for (auto& point : points)
+			{
 				point = point + start;
+				finalpoints.push_back(ImVec2{ point.x, point.y });
+			}
 
-			drawlist->AddPolyline((const ImVec2*)const_cast<const mvVec4*>(points.data()), (int)_points.size(), _color,
+			drawlist->AddPolyline(finalpoints.data(), (int)finalpoints.size(), _color,
 				_closed, _thickness);
 		}
 


### PR DESCRIPTION
* Fixed issue with draw_ellipse
* Fixed same issue with draw_polyline.

There was also a mistake in the ellipse calculation.

This example:
```python
import dearpygui.dearpygui as dpg

dpg.create_context()
dpg.create_viewport(title='Ellipse', width=400, height=400)
dpg.setup_dearpygui()

with dpg.viewport_drawlist(front=True, tag='vpf'):
    dpg.draw_rectangle((100,100), (400,200))
    dpg.draw_ellipse((100,100), (400,200))

dpg.show_viewport()
dpg.start_dearpygui()
dpg.destroy_context()
```

Should look like this:
![image](https://user-images.githubusercontent.com/39973752/142333951-037be7dc-a031-40a6-a97e-f98e81ea30b0.png)

But looked like this instead:
![image](https://user-images.githubusercontent.com/39973752/142334102-757319a5-60e6-47b2-b43e-c23f20f423fb.png)

We just needed to divide the widths and heights in the equation.

