### PR TITLE
fix: Table column and row freeze inverted/swapped #1467

### DIFF
--- a/DearPyGui/src/core/AppItems/tables/mvTable.cpp
+++ b/DearPyGui/src/core/AppItems/tables/mvTable.cpp
@@ -336,7 +336,7 @@ namespace Marvel {
 				_state.lastFrameUpdate = GContext->frame;
 				_state.visible = true;
 
-				ImGui::TableSetupScrollFreeze(_freezeRows, _freezeColumns);
+				ImGui::TableSetupScrollFreeze(_freezeColumns, _freezeRows);
 
 				// columns
 				for (auto& item : _children[0])


### PR DESCRIPTION
**Description:**
just swapping input arguments for column and row freeze
