### PR TITLE
feat: exposed callback queue

### DIFF
--- a/DearPyGui/dearpygui/_dearpygui.pyi
+++ b/DearPyGui/dearpygui/_dearpygui.pyi
@@ -630,7 +630,7 @@ def clear_selected_nodes(node_editor : Union[int, str]) -> None:
 	"""Clears a node editor's selected nodes."""
 	...
 
-def configure_app(*, docking: bool ='', docking_space: bool ='', load_init_file: str ='', init_file: str ='', auto_save_init_file: bool ='', device: int ='', auto_device: bool ='', allow_alias_overwrites: bool ='', manual_alias_management: bool ='', skip_required_args: bool ='', skip_positional_args: bool ='', skip_keyword_args: bool ='', wait_for_input: bool ='', **kwargs) -> None:
+def configure_app(*, docking: bool ='', docking_space: bool ='', load_init_file: str ='', init_file: str ='', auto_save_init_file: bool ='', device: int ='', auto_device: bool ='', allow_alias_overwrites: bool ='', manual_alias_management: bool ='', skip_required_args: bool ='', skip_positional_args: bool ='', skip_keyword_args: bool ='', wait_for_input: bool ='', manual_callback_management: bool ='', **kwargs) -> None:
 	"""Configures app."""
 	...
 
@@ -788,6 +788,10 @@ def get_app_configuration() -> dict:
 
 def get_axis_limits(axis : Union[int, str]) -> Union[List[float], Tuple[float, ...]]:
 	"""Get the specified axis limits."""
+	...
+
+def get_callback_queue() -> Any:
+	"""New in 1.2. Returns and clears callback queue."""
 	...
 
 def get_colormap_color(colormap : Union[int, str], index : int) -> Union[List[int], Tuple[int, ...]]:

--- a/DearPyGui/dearpygui/_dearpygui_RTD.py
+++ b/DearPyGui/dearpygui/_dearpygui_RTD.py
@@ -47,6 +47,22 @@ from dearpygui._dearpygui import mvMat4
 # Helper Commands
 ########################################################################################################################
 
+def run_callbacks(jobs):
+    """ New in 1.2. Runs callbacks from the callback queue and checks arguments. """
+
+    if jobs is None:
+        pass
+    else:
+        for job in jobs:
+            if job[0] is None:
+                pass
+            else:
+                sig = inspect.signature(job[0])
+                args = []
+                for arg in range(len(sig.parameters)):
+                    args.append(job[arg+1])
+                job[0](*args)
+
 def get_major_version():
     """ return Dear PyGui Major Version """
     return internal_dpg.get_app_configuration()["major_version"]
@@ -70,7 +86,6 @@ def configure_app(**kwargs) -> None:
 def configure_viewport(item : Union[int, str], **kwargs) -> None:
 	"""Configures a viewport after creation."""
 	internal_dpg.configure_viewport(item, **kwargs)
-
 
 def start_dearpygui():
     """Prepares viewport (if not done already). sets up, cleans up, and runs main event loop.
@@ -6994,6 +7009,16 @@ def get_axis_limits(axis):
 	"""
 
 	return internal_dpg.get_axis_limits(axis)
+
+def get_callback_queue():
+	"""	 New in 1.2. Returns and clears callback queue.
+
+	Args:
+	Returns:
+		Any
+	"""
+
+	return internal_dpg.get_callback_queue()
 
 def get_colormap_color(colormap, index):
 	"""	 Returns a color from a colormap given an index >= 0. (ex. 0 will be the first color in the color list of the color map) Modulo will be performed against the number of items in the color list.

--- a/DearPyGui/dearpygui/_header.py
+++ b/DearPyGui/dearpygui/_header.py
@@ -31,6 +31,22 @@ from dearpygui._dearpygui import mvMat4
 # Helper Commands
 ########################################################################################################################
 
+def run_callbacks(jobs):
+    """ New in 1.2. Runs callbacks from the callback queue and checks arguments. """
+
+    if jobs is None:
+        pass
+    else:
+        for job in jobs:
+            if job[0] is None:
+                pass
+            else:
+                sig = inspect.signature(job[0])
+                args = []
+                for arg in range(len(sig.parameters)):
+                    args.append(job[arg+1])
+                job[0](*args)
+
 def get_major_version():
     """ return Dear PyGui Major Version """
     return internal_dpg.get_app_configuration()["major_version"]
@@ -54,7 +70,6 @@ def configure_app(**kwargs) -> None:
 def configure_viewport(item : Union[int, str], **kwargs) -> None:
 	"""Configures a viewport after creation."""
 	internal_dpg.configure_viewport(item, **kwargs)
-
 
 def start_dearpygui():
     """Prepares viewport (if not done already). sets up, cleans up, and runs main event loop.

--- a/DearPyGui/dearpygui/dearpygui.py
+++ b/DearPyGui/dearpygui/dearpygui.py
@@ -47,6 +47,22 @@ from dearpygui._dearpygui import mvMat4
 # Helper Commands
 ########################################################################################################################
 
+def run_callbacks(jobs):
+    """ New in 1.2. Runs callbacks from the callback queue and checks arguments. """
+
+    if jobs is None:
+        pass
+    else:
+        for job in jobs:
+            if job[0] is None:
+                pass
+            else:
+                sig = inspect.signature(job[0])
+                args = []
+                for arg in range(len(sig.parameters)):
+                    args.append(job[arg+1])
+                job[0](*args)
+
 def get_major_version():
     """ return Dear PyGui Major Version """
     return internal_dpg.get_app_configuration()["major_version"]
@@ -70,7 +86,6 @@ def configure_app(**kwargs) -> None:
 def configure_viewport(item : Union[int, str], **kwargs) -> None:
 	"""Configures a viewport after creation."""
 	internal_dpg.configure_viewport(item, **kwargs)
-
 
 def start_dearpygui():
     """Prepares viewport (if not done already). sets up, cleans up, and runs main event loop.
@@ -7820,6 +7835,16 @@ def get_axis_limits(axis : Union[int, str], **kwargs) -> Union[List[float], Tupl
 	"""
 
 	return internal_dpg.get_axis_limits(axis, **kwargs)
+
+def get_callback_queue(**kwargs) -> Any:
+	"""	 New in 1.2. Returns and clears callback queue.
+
+	Args:
+	Returns:
+		Any
+	"""
+
+	return internal_dpg.get_callback_queue(**kwargs)
 
 def get_colormap_color(colormap : Union[int, str], index : int, **kwargs) -> Union[List[int], Tuple[int, ...]]:
 	"""	 Returns a color from a colormap given an index >= 0. (ex. 0 will be the first color in the color list of the color map) Modulo will be performed against the number of items in the color list.

--- a/DearPyGui/src/core/mvContext.h
+++ b/DearPyGui/src/core/mvContext.h
@@ -99,6 +99,9 @@ namespace Marvel {
         b8 skipRequiredArgs = false;
         b8 skipPositionalArgs = false;
         b8 skipKeywordArgs = false;
+
+        // callback registry
+        b8 manualCallbacks = false;
     };
 
     struct mvContext

--- a/DearPyGui/src/modules/dearpygui.cpp
+++ b/DearPyGui/src/modules/dearpygui.cpp
@@ -606,6 +606,7 @@ namespace Marvel {
 		MV_ADD_COMMAND(is_key_pressed);
 		MV_ADD_COMMAND(is_key_released);
 		MV_ADD_COMMAND(is_key_down);
+		MV_ADD_COMMAND(get_callback_queue);
 
 		// item registry
 		MV_ADD_COMMAND(focus_item);

--- a/DearPyGui/src/modules/dearpygui_parsers.h
+++ b/DearPyGui/src/modules/dearpygui_parsers.h
@@ -496,6 +496,7 @@ namespace Marvel {
 			args.push_back({ mvPyDataType::Bool, "skip_positional_args", mvArgType::KEYWORD_ARG, "False" });
 			args.push_back({ mvPyDataType::Bool, "skip_keyword_args", mvArgType::KEYWORD_ARG, "False" });
 			args.push_back({ mvPyDataType::Bool, "wait_for_input", mvArgType::KEYWORD_ARG, "False", "New in 1.1. Only update when user input occurs" });
+			args.push_back({ mvPyDataType::Bool, "manual_callback_management", mvArgType::KEYWORD_ARG, "False", "New in 1.2"});
 
 			mvPythonParserSetup setup;
 			setup.about = "Configures app.";
@@ -1822,6 +1823,18 @@ namespace Marvel {
 			mvPythonParser parser = FinalizeParser(setup, args);
 
 			parsers.insert({ "show_tool", parser });
+		}
+
+		{
+			std::vector<mvPythonDataElement> args;
+
+			mvPythonParserSetup setup;
+			setup.about = "New in 1.2. Returns and clears callback queue.";
+			setup.category = { "General" };
+			setup.returnType = mvPyDataType::Object;
+
+			mvPythonParser parser = FinalizeParser(setup, args);
+			parsers.insert({ "get_callback_queue", parser });
 		}
 	}
 }

--- a/DearPyGui/src/ui/mvCallbackRegistry.cpp
+++ b/DearPyGui/src/ui/mvCallbackRegistry.cpp
@@ -66,6 +66,18 @@ namespace Marvel {
 			return;
 		}
 
+		if (GContext->IO.manualCallbacks)
+		{
+			if (callable != nullptr)
+				Py_XINCREF(callable);
+			if (app_data != nullptr)
+				Py_XINCREF(app_data);
+			if (user_data != nullptr)
+				Py_XINCREF(user_data);
+			GContext->callbackRegistry->jobs.push_back({ sender, callable, app_data, user_data });
+			return;
+		}
+
 		mvSubmitCallback([=]() {
 			mvRunCallback(callable, sender, app_data, user_data);
 			});
@@ -76,11 +88,24 @@ namespace Marvel {
 
 		if (GContext->callbackRegistry->callCount > GContext->callbackRegistry->maxNumberOfCalls)
 		{
+
 			if (app_data != nullptr)
 				Py_XDECREF(app_data);
 			if (user_data != nullptr)
 				Py_XDECREF(user_data);
 			assert(false);
+			return;
+		}
+
+		if (GContext->IO.manualCallbacks)
+		{
+			if (callable != nullptr)
+				Py_XINCREF(callable);
+			if (app_data != nullptr)
+				Py_XINCREF(app_data);
+			if (user_data != nullptr)
+				Py_XINCREF(user_data);
+			GContext->callbackRegistry->jobs.push_back({ 0, callable, app_data, user_data, sender });
 			return;
 		}
 

--- a/DearPyGui/src/ui/mvCallbackRegistry.h
+++ b/DearPyGui/src/ui/mvCallbackRegistry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mutex>
+#include <vector>
 #include "mvThreadPool.h"
 #include "mvContext.h"
 
@@ -14,10 +15,20 @@ namespace Marvel {
 		return callback;
 	}
 
+	struct mvCallbackJob
+	{
+		mvUUID      sender    = 0;
+		PyObject*   callback  = nullptr;
+		PyObject*   app_data  = nullptr;
+		PyObject*   user_data = nullptr;
+		std::string sender_str;
+	};
+
 	struct mvCallbackRegistry
 	{
 		const i32 maxNumberOfCalls = 50;
 
+		std::vector<mvCallbackJob> jobs;
 		mvQueue<mvFunctionWrapper> tasks;
 		mvQueue<mvFunctionWrapper> calls;
 		std::atomic<b8>            running = false;
@@ -38,7 +49,6 @@ namespace Marvel {
 	void mvAddCallback(PyObject* callback, mvUUID sender, PyObject* app_data, PyObject* user_data);
 	void mvAddCallback(PyObject* callback, const std::string& sender, PyObject* app_data, PyObject* user_data);
 	bool mvRunCallbacks();
-
 
 	template<typename F, typename ...Args>
 	std::future<typename std::invoke_result<F, Args...>::type> mvSubmitTask(F f)

--- a/DearSandbox/sandbox.py
+++ b/DearSandbox/sandbox.py
@@ -3,6 +3,7 @@ import dearpygui.demo as demo
 from dearpygui_ext.logger import mvLogger
 
 dpg.create_context()
+#dpg.configure_app(manual_callback_management=True)
 dpg.create_viewport()
 dpg.setup_dearpygui()
 
@@ -24,6 +25,7 @@ demo.show_demo()
 # main loop
 dpg.show_viewport()
 while dpg.is_dearpygui_running():
+    #dpg.run_callbacks(dpg.get_callback_queue())
     dpg.render_dearpygui_frame()  
 
 dpg.destroy_context()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 import shutil
 import subprocess
 
-wip_version = "1.1.3"
+wip_version = "1.2a1"
 
 def version_number():
     """This function reads the version number which is populated by github actions"""


### PR DESCRIPTION
## Exposed Callback Queue
Allows users to manually run callbacks. This is mostly for debugging and should allow users to use their IDE to step through callbacks.

This adds 2 commands:

1. `dpg.get_callback_queue()` - returns a list of callback jobs. Each "job" is [callback, sender, app data, user data]
2. `dpg.run_callbacks(...)` - helper function that takes in the callback queue and runs the callbacks while performing checks.

## Basic example
```python
import dearpygui.dearpygui as dpg

dpg.create_context()
dpg.configure_app(manual_callback_management=True)
dpg.create_viewport()
dpg.setup_dearpygui()

with dpg.window(label="Testing"):
    dpg.add_button(label="Press me", callback=lambda s, a, u: print("Hello", s, a, u))

# main loop
dpg.show_viewport()
while dpg.is_dearpygui_running():
    dpg.run_callbacks(dpg.get_callback_queue())
    dpg.render_dearpygui_frame()  

dpg.destroy_context()
```