### PR TITLE
Replaced hardcoded python interpreter version with dynamically discoverable one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ else() # Linux
 	add_definitions(-DCUSTOM_IMGUIFILEDIALOG_CONFIG="ImGuiFileDialogConfigUnix.h")
 endif()
 
+find_package(Python COMPONENTS Interpreter Development)
+
 # various settings
 add_definitions(
     -D_CRT_SECURE_NO_WARNINGS 

--- a/DearPyGui/cmake/embedded.cmake
+++ b/DearPyGui/cmake/embedded.cmake
@@ -32,7 +32,7 @@ if(WIN32)
 	target_link_directories(coreemb PRIVATE "../Dependencies/cpython/PCbuild/amd64/")
 
 	# Add libraries to link to
-	target_link_libraries(coreemb PUBLIC d3d11 dxgi freetype $<$<CONFIG:Debug>:python39_d> $<$<CONFIG:Release>:python39>)
+	target_link_libraries(coreemb PUBLIC d3d11 dxgi freetype Python::Module)
 	
 ###############################################################################
 # Apple Specifics
@@ -77,6 +77,6 @@ else() # Linux
 	set_property(TARGET coreemb APPEND_STRING PROPERTY COMPILE_FLAGS "-fPIC -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall")
 	
 	# Add libraries to link to
-	target_link_libraries(coreemb PRIVATE "-lcrypt -lpthread -ldl -lutil -lm" GL glfw python3.9d freetype)
+	target_link_libraries(coreemb PRIVATE "-lcrypt -lpthread -ldl -lutil -lm" GL glfw Python::Module freetype)
 
 endif()

--- a/DearSandbox/CMakeLists.txt
+++ b/DearSandbox/CMakeLists.txt
@@ -57,7 +57,7 @@ target_compile_definitions(DearSandbox
 if (WIN32)
 
 	target_link_directories(DearSandbox PRIVATE "../Dependencies/cpython/PCbuild/amd64/")
-	target_link_libraries(DearSandbox PUBLIC coreemb $<$<CONFIG:Debug>:python39_d> $<$<CONFIG:Release>:python39>)
+	target_link_libraries(DearSandbox PUBLIC coreemb Python::Module)
 
 	add_custom_command(TARGET DearSandbox PRE_BUILD
 						COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -74,7 +74,7 @@ elseif(APPLE)
 
     target_link_directories(DearSandbox PRIVATE ../Dependencies/cpython/build/debug/lib)
 
-	target_link_libraries(DearSandbox PUBLIC coreemb -ldl "-framework CoreFoundation" "python3.9d")
+	target_link_libraries(DearSandbox PUBLIC coreemb -ldl "-framework CoreFoundation" Python::Module)
 
 	file(GLOB PYTHON_LIBS_PATH "../Dependencies/cpython/build/debug/lib/python*")
 
@@ -89,6 +89,6 @@ else() # Linux
 		PUBLIC
 			"-lcrypt -lpthread -ldl -lutil -lm"
 			coreemb
-			python3.9d
+			Python::Module
 	)
 endif()


### PR DESCRIPTION
**Description:**
Currently python libraries and versions are hardcoded. But different distros have different versions.

**Concerning Areas:**
Windows and other self-sufficient (flatpack/snap) builds. For Windows it is recommended to just build against Anaconda and/or WinPython.
