### PR TITLE
Replaced submoduled imgui with packaged one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ else() # Linux
 	add_definitions(-DCUSTOM_IMGUIFILEDIALOG_CONFIG="ImGuiFileDialogConfigUnix.h")
 endif()
 
+find_package(PkgConfig)
+pkg_check_modules(IMGUI REQUIRED imgui)
+
 # various settings
 add_definitions(
     -D_CRT_SECURE_NO_WARNINGS 

--- a/DearPyGui/cmake/distribution.cmake
+++ b/DearPyGui/cmake/distribution.cmake
@@ -20,6 +20,7 @@ target_include_directories(_dearpygui
 		PRIVATE 
 			${Python_INCLUDE_DIRS}
 			${MARVEL_INCLUDE_DIR}
+			${IMGUI_INCLUDE_DIRS}
 	)
 
 target_link_directories(_dearpygui 
@@ -38,7 +39,7 @@ if(WIN32)
 
 	set_target_properties(_dearpygui PROPERTIES SUFFIX ".pyd")
 	set_target_properties(_dearpygui PROPERTIES PREFIX "")
-	target_link_libraries(_dearpygui PUBLIC d3d11 dxgi ${Python_LIBRARIES} freetype)
+	target_link_libraries(_dearpygui PUBLIC d3d11 dxgi ${Python_LIBRARIES} freetype ${IMGUI_LIBRARIES})
 
 elseif(APPLE)
 
@@ -53,6 +54,7 @@ elseif(APPLE)
 
 			glfw
 			freetype
+			${IMGUI_LIBRARIES}
 			"-undefined dynamic_lookup"
 			"-framework Metal"
 			"-framework MetalKit"
@@ -73,6 +75,7 @@ else() # Linux
 			"-fPIC -lcrypt -lpthread -ldl  -lutil -lm"
 			GL
 			glfw
+			${IMGUI_LIBRARIES}
 	)
 
 endif()

--- a/DearPyGui/cmake/dpg_sources.cmake
+++ b/DearPyGui/cmake/dpg_sources.cmake
@@ -208,20 +208,6 @@ set(MARVEL_SOURCES
 	"vendor/ImGuiFileDialog/ImGuiFileDialog.cpp"
 
 	# imgui
-	"../Dependencies/imgui/misc/cpp/imgui_stdlib.cpp"
-	"../Dependencies/imgui/imgui.cpp"
-	"../Dependencies/imgui/imgui_demo.cpp"
-	"../Dependencies/imgui/imgui_draw.cpp"
-	"../Dependencies/imgui/imgui_widgets.cpp"
-	"../Dependencies/imgui/imgui_tables.cpp"
-	"$<$<PLATFORM_ID:Windows>:../Dependencies/imgui/misc/freetype/imgui_freetype.cpp>"
-	"$<$<PLATFORM_ID:Windows>:../Dependencies/imgui/backends/imgui_impl_win32.cpp>"
-	"$<$<PLATFORM_ID:Windows>:../Dependencies/imgui/backends/imgui_impl_dx11.cpp>"
-	"$<$<PLATFORM_ID:Darwin>:../Dependencies/imgui/backends/imgui_impl_metal.mm>"
-	"$<$<PLATFORM_ID:Darwin>:../Dependencies/imgui/backends/imgui_impl_glfw.cpp>"
-	"$<$<PLATFORM_ID:Darwin>:../Dependencies/imgui/misc/freetype/imgui_freetype.cpp>"
-	"$<$<PLATFORM_ID:Linux>:../Dependencies/imgui/backends/imgui_impl_glfw.cpp>"
-	"$<$<PLATFORM_ID:Linux>:../Dependencies/imgui/backends/imgui_impl_opengl3.cpp>"
 	"$<$<PLATFORM_ID:Linux>:../Dependencies/imgui/examples/libs/gl3w/GL/gl3w.c>"
 )
 

--- a/DearPyGui/cmake/embedded.cmake
+++ b/DearPyGui/cmake/embedded.cmake
@@ -10,7 +10,7 @@ set_target_properties(coreemb
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}$<$<CONFIG:Release>:/cmake-build-release/>$<$<CONFIG:Debug>:/cmake-build-debug/>DearPyGui/"
   )
 
-target_include_directories(coreemb PRIVATE ${MARVEL_INCLUDE_DIR})
+target_include_directories(coreemb PRIVATE ${MARVEL_INCLUDE_DIR} ${IMGUI_INCLUDE_DIRS})
 
 target_compile_definitions(coreemb
 	PUBLIC
@@ -32,7 +32,7 @@ if(WIN32)
 	target_link_directories(coreemb PRIVATE "../Dependencies/cpython/PCbuild/amd64/")
 
 	# Add libraries to link to
-	target_link_libraries(coreemb PUBLIC d3d11 dxgi freetype $<$<CONFIG:Debug>:python39_d> $<$<CONFIG:Release>:python39>)
+	target_link_libraries(coreemb PUBLIC d3d11 dxgi freetype $<$<CONFIG:Debug>:python39_d> $<$<CONFIG:Release>:python39> ${IMGUI_LIBRARIES})
 	
 ###############################################################################
 # Apple Specifics
@@ -53,6 +53,7 @@ elseif(APPLE)
 
 			glfw
 			freetype
+			${IMGUI_LIBRARIES}
 			"-framework Metal"
 			"-framework MetalKit"
 			"-framework Cocoa"
@@ -77,6 +78,8 @@ else() # Linux
 	set_property(TARGET coreemb APPEND_STRING PROPERTY COMPILE_FLAGS "-fPIC -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall")
 	
 	# Add libraries to link to
-	target_link_libraries(coreemb PRIVATE "-lcrypt -lpthread -ldl -lutil -lm" GL glfw python3.9d freetype)
+==== BASE ====
+	target_link_libraries(coreemb PRIVATE "-lcrypt -lpthread -ldl -lutil -lm" GL glfw Python::Module freetype)
+==== BASE ====
 
 endif()

--- a/DearSandbox/CMakeLists.txt
+++ b/DearSandbox/CMakeLists.txt
@@ -30,8 +30,7 @@ target_include_directories(DearSandbox
 
 		"$<$<PLATFORM_ID:Linux>:${CMAKE_SOURCE_DIR}/Dependencies/cpython/build/debug/include/python3.9d/>"
 		"$<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/Dependencies/cpython/PC/>"
-		"../Dependencies/imgui/"
-		"../Dependencies/imgui/backends/"
+		${IMGUI_INCLUDE_DIRS}
 		"../DearPyGui/vendor/implot/"
 		"../DearPyGui/src/"
 		"../DearPyGui/src/ui/"
@@ -90,5 +89,6 @@ else() # Linux
 			"-lcrypt -lpthread -ldl -lutil -lm"
 			coreemb
 			python3.9d
+			${IMGUI_LIBRARIES}
 	)
 endif()

--- a/ImguiTesting/CMakeLists.txt
+++ b/ImguiTesting/CMakeLists.txt
@@ -22,19 +22,6 @@ target_sources(PureImgui
 		"../DearPyGui/vendor/implot/implot_demo.cpp"
 
 		# imgui
-		"../Dependencies/imgui/imgui.cpp"
-		"../Dependencies/imgui/imgui_demo.cpp"
-		"../Dependencies/imgui/imgui_draw.cpp"
-		"../Dependencies/imgui/imgui_widgets.cpp"
-		"../Dependencies/imgui/imgui_tables.cpp"
-		"$<$<PLATFORM_ID:Windows>:../Dependencies/imgui/misc/freetype/imgui_freetype.cpp>"
-		"$<$<PLATFORM_ID:Windows>:../Dependencies/imgui/backends/imgui_impl_win32.cpp>"
-		"$<$<PLATFORM_ID:Windows>:../Dependencies/imgui/backends/imgui_impl_dx11.cpp>"
-		"$<$<PLATFORM_ID:Darwin>:../Dependencies/imgui/backends/imgui_impl_metal.mm>"
-		"$<$<PLATFORM_ID:Darwin>:../Dependencies/imgui/backends/imgui_impl_glfw.cpp>"
-		"$<$<PLATFORM_ID:Darwin>:../Dependencies/imgui/misc/freetype/imgui_freetype.cpp>"
-		"$<$<PLATFORM_ID:Linux>:../Dependencies/imgui/backends/imgui_impl_glfw.cpp>"
-		"$<$<PLATFORM_ID:Linux>:../Dependencies/imgui/backends/imgui_impl_opengl3.cpp>"
 		"$<$<PLATFORM_ID:Linux>:../Dependencies/imgui/examples/libs/gl3w/GL/gl3w.c>"
 )
 
@@ -68,10 +55,6 @@ target_include_directories(PureImgui
 		"../Dependencies/glfw/include/"
 		"../Dependencies/glfw/deps/"
 		"../Dependencies/gl3w/"
-		"../Dependencies/imgui/"
-		"../Dependencies/imgui/misc/freetype/"
-		"../Dependencies/imgui/backends/"
-		"../Dependencies/imgui/examples/libs/gl3w"
 		"../DearPyGui/vendor/implot/"
 		"../DearPyGui/vendor/stb/"
 		"../DearPyGui/vendor/imnodes/"
@@ -80,7 +63,7 @@ target_include_directories(PureImgui
 target_link_libraries(PureImgui
 
 	PRIVATE
-		
+		${IMGUI_LIBRARIES}		
 		freetype
 		$<$<PLATFORM_ID:Linux>:GL>
 		$<$<PLATFORM_ID:Linux>:glfw>


### PR DESCRIPTION
**Description:**
Imgui should be used from packages, not from the submodule.

**Concerning Areas:**
On Windows sane packaging mechanism is provided by MSYS2 and (to less extent, since `conda` is terribly slow) Anaconda.
