### PR TITLE
fix: mvKnobFloat enable property

### DIFF
--- a/DearPyGui/dearpygui/_dearpygui.pyi
+++ b/DearPyGui/dearpygui/_dearpygui.pyi
@@ -322,7 +322,7 @@ def add_key_release_handler(key : int ='', *, label: str ='', user_data: Any =''
 	"""Adds a key release handler."""
 	...
 
-def add_knob_float(*, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', width: int ='', height: int ='', indent: int ='', parent: Union[int, str] ='', before: Union[int, str] ='', source: Union[int, str] ='', payload_type: str ='', callback: Callable ='', drag_callback: Callable ='', drop_callback: Callable ='', show: bool ='', pos: Union[List[int], Tuple[int, ...]] ='', filter_key: str ='', tracked: bool ='', track_offset: float ='', default_value: float ='', min_value: float ='', max_value: float ='') -> Union[int, str]:
+def add_knob_float(*, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', width: int ='', height: int ='', indent: int ='', parent: Union[int, str] ='', before: Union[int, str] ='', source: Union[int, str] ='', payload_type: str ='', callback: Callable ='', drag_callback: Callable ='', drop_callback: Callable ='', show: bool ='', enabled: bool ='', pos: Union[List[int], Tuple[int, ...]] ='', filter_key: str ='', tracked: bool ='', track_offset: float ='', default_value: float ='', min_value: float ='', max_value: float ='') -> Union[int, str]:
 	"""Adds a knob that rotates based on change in x mouse position."""
 	...
 

--- a/DearPyGui/dearpygui/_dearpygui_RTD.py
+++ b/DearPyGui/dearpygui/_dearpygui_RTD.py
@@ -4609,6 +4609,7 @@ def add_knob_float(**kwargs):
 		drag_callback (Callable, optional): Registers a drag callback for drag and drop.
 		drop_callback (Callable, optional): Registers a drop callback for drag and drop.
 		show (bool, optional): Attempt to render widget.
+		enabled (bool, optional): Turns off functionality of widget and applies the disabled theme.
 		pos (Union[List[int], Tuple[int, ...]], optional): Places the item relative to window coordinates, [0,0] is top left.
 		filter_key (str, optional): Used by filter widget.
 		tracked (bool, optional): Scroll tracking

--- a/DearPyGui/dearpygui/dearpygui.py
+++ b/DearPyGui/dearpygui/dearpygui.py
@@ -5084,7 +5084,7 @@ def add_key_release_handler(key : int =-1, *, label: str =None, user_data: Any =
 
 	return internal_dpg.add_key_release_handler(key, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, callback=callback, show=show, parent=parent, **kwargs)
 
-def add_knob_float(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, width: int =0, height: int =0, indent: int =-1, parent: Union[int, str] =0, before: Union[int, str] =0, source: Union[int, str] =0, payload_type: str ='$$DPG_PAYLOAD', callback: Callable =None, drag_callback: Callable =None, drop_callback: Callable =None, show: bool =True, pos: Union[List[int], Tuple[int, ...]] =[], filter_key: str ='', tracked: bool =False, track_offset: float =0.5, default_value: float =0.0, min_value: float =0.0, max_value: float =100.0, **kwargs) -> Union[int, str]:
+def add_knob_float(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, width: int =0, height: int =0, indent: int =-1, parent: Union[int, str] =0, before: Union[int, str] =0, source: Union[int, str] =0, payload_type: str ='$$DPG_PAYLOAD', callback: Callable =None, drag_callback: Callable =None, drop_callback: Callable =None, show: bool =True, enabled: bool =True, pos: Union[List[int], Tuple[int, ...]] =[], filter_key: str ='', tracked: bool =False, track_offset: float =0.5, default_value: float =0.0, min_value: float =0.0, max_value: float =100.0, **kwargs) -> Union[int, str]:
 	"""	 Adds a knob that rotates based on change in x mouse position.
 
 	Args:
@@ -5103,6 +5103,7 @@ def add_knob_float(*, label: str =None, user_data: Any =None, use_internal_label
 		drag_callback (Callable, optional): Registers a drag callback for drag and drop.
 		drop_callback (Callable, optional): Registers a drop callback for drag and drop.
 		show (bool, optional): Attempt to render widget.
+		enabled (bool, optional): Turns off functionality of widget and applies the disabled theme.
 		pos (Union[List[int], Tuple[int, ...]], optional): Places the item relative to window coordinates, [0,0] is top left.
 		filter_key (str, optional): Used by filter widget.
 		tracked (bool, optional): Scroll tracking
@@ -5119,7 +5120,7 @@ def add_knob_float(*, label: str =None, user_data: Any =None, use_internal_label
 		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 		tag=kwargs['id']
 
-	return internal_dpg.add_knob_float(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, width=width, height=height, indent=indent, parent=parent, before=before, source=source, payload_type=payload_type, callback=callback, drag_callback=drag_callback, drop_callback=drop_callback, show=show, pos=pos, filter_key=filter_key, tracked=tracked, track_offset=track_offset, default_value=default_value, min_value=min_value, max_value=max_value, **kwargs)
+	return internal_dpg.add_knob_float(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, width=width, height=height, indent=indent, parent=parent, before=before, source=source, payload_type=payload_type, callback=callback, drag_callback=drag_callback, drop_callback=drop_callback, show=show, enabled=enabled, pos=pos, filter_key=filter_key, tracked=tracked, track_offset=track_offset, default_value=default_value, min_value=min_value, max_value=max_value, **kwargs)
 
 def add_line_series(x : Union[List[float], Tuple[float, ...]], y : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, source: Union[int, str] =0, show: bool =True, **kwargs) -> Union[int, str]:
 	"""	 Adds a line series to a plot.

--- a/DearPyGui/src/ui/AppItems/custom/mvKnob.cpp
+++ b/DearPyGui/src/ui/AppItems/custom/mvKnob.cpp
@@ -76,9 +76,12 @@ namespace Marvel {
 
         ScopedID id(uuid);
 
-        if (KnobFloat(config.specifiedLabel.c_str(), _value.get(), _min, _max, _step))
+        if (!config.enabled) _disabled_value = *_value;
+
+        if (KnobFloat(config.specifiedLabel.c_str(), config.enabled ? _value.get() : &_disabled_value, _min, _max, _step))
         {
             auto value = *_value;
+
             mvSubmitCallback([=]() {
                 if(config.alias.empty())
                     mvAddCallback(getCallback(false), uuid, ToPyFloat(value), config.user_data);

--- a/DearPyGui/src/ui/AppItems/mvAppItem.cpp
+++ b/DearPyGui/src/ui/AppItems/mvAppItem.cpp
@@ -4032,6 +4032,7 @@ namespace Marvel {
                 MV_PARSER_ARG_SOURCE |
                 MV_PARSER_ARG_CALLBACK |
                 MV_PARSER_ARG_SHOW |
+                MV_PARSER_ARG_ENABLED |
                 MV_PARSER_ARG_FILTER |
                 MV_PARSER_ARG_DROP_CALLBACK |
                 MV_PARSER_ARG_DRAG_CALLBACK |


### PR DESCRIPTION

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
hook up enable value and add enable keyword
checked configuration return value
disabeled style system is handled by style system
tested disable value

to test diable is working properly run 

```Python
with dpg.window():
    dpg.add_knob_float(tag="knobby", callback=lambda sender: print("knob callback ran", dpg.get_value(sender)))
    dpg.add_checkbox(label="here boii", default_value=True, callback=lambda sender: dpg.configure_item("knobby", enabled=dpg.get_value(sender)))
    dpg.add_button(label="here", callback=lambda: print(dpg.get_item_configuration("knobby")))
```

**Concerning Areas:**
without submitting the dpg item to the custom knob we cannot change how it is drawn so it will draw similar to others where the value is visually overwritten
