### PR TITLE
Adding images and additional text to first steps

### DIFF
--- a/docs/source/tutorials/first-steps.rst
+++ b/docs/source/tutorials/first-steps.rst
@@ -43,7 +43,7 @@ Confirm the pip install by running the code block below.
 
 **Result:**
 
-.. image:: https://raw.githubusercontent.com/hoffstadt/DearPyGui/assets/BasicUsageExample1.PNG
+.. image:: https://github.com/hoffstadt/DearPyGui/blob/assets/readme/first_app.gif
 
 Demo
 ----
@@ -69,6 +69,10 @@ The code for this can be found in the repo in the `demo.py`_ file
     dpg.start_dearpygui()
     dpg.destroy_context()
 
+**Result:**
+
+.. image:: https://github.com/hoffstadt/DearPyGui/blob/assets/readme/demo.gif
+
 .. note:: 
     The main script must always:
 
@@ -78,3 +82,57 @@ The code for this can be found in the repo in the `demo.py`_ file
     - Show the viewport :py:func:`show_viewport <dearpygui.dearpygui.show_viewport>`
     - Start dearpygui :py:func:`start_dearpygui <dearpygui.dearpygui.start_dearpygui>`
     - Clean up the context :py:func:`destroy_context <dearpygui.dearpygui.destroy_context>`
+
+
+
+
+Internal documentation
+----------------------
+
+The API documentation is built into the library and can be called with show_documentation(). This brings up the documentation tool for browsing and searching Dear PyGui functions. Obviously, Dear PyGui supports autocomplete for your IDE as well.
+
+**Code:**
+
+.. code-block:: python
+
+    import dearpygui.dearpygui as dpg
+
+    dpg.create_context()
+    dpg.create_viewport(title='Custom Title', width=800, height=600)
+    
+    dpg.show_documentation()
+
+    dpg.setup_dearpygui()
+    dpg.show_viewport()
+    dpg.start_dearpygui()
+    dpg.destroy_context()
+
+**Result:**
+
+.. image:: https://github.com/hoffstadt/DearPyGui/blob/assets/readthedocs/internal_documentation.png
+
+Style editor and runtime metrics
+--------------------------------
+
+The built-in style editor allows you to experiment with all style options at runtime to find the exact colors, padding, rounding and other style settings for your application. The built-in runtime metrics provide real-time information about your app performance. These tools can be activated by adding show_style_editor() and show_metrics() to your code. The following screen capture shows both tools in action at the same time, where changing the style settings immediately impact the overall application.
+
+**Code:**
+
+.. code-block:: python
+
+    import dearpygui.dearpygui as dpg
+
+    dpg.create_context()
+    dpg.create_viewport(title='Custom Title', width=800, height=600)
+    
+    dpg.show_style_editor()
+    dpg.show_metrics()
+
+    dpg.setup_dearpygui()
+    dpg.show_viewport()
+    dpg.start_dearpygui()
+    dpg.destroy_context()
+
+**Result:**
+
+.. image:: https://github.com/hoffstadt/DearPyGui/blob/assets/readthedocs/style_editor_metrics.gif


### PR DESCRIPTION
Adding screenshots/GIFs to first steps in documentation to:
1. better explain the available tools to the user.
2. be able to refer to these instructions from the GitHub readme.md
