### PR TITLE
Add subreddit link to reddit badge instead of discord server invite link

### DIFF
--- a/docs/source/about/repo-info.rst
+++ b/docs/source/about/repo-info.rst
@@ -16,7 +16,7 @@ Project Information
 
 .. |inline sub for reddit|
     image:: https://img.shields.io/reddit/subreddit-subscribers/dearpygui?label=r%2Fdearpygui
-        :target: https://discord.com/invite/tyE7Gu4
+        :target: https://www.reddit.com/r/DearPyGui/
 
 .. _Github Discussions: https://github.com/hoffstadt/DearPyGui/discussions
 .. _Youtube: https://www.youtube.com/channel/UCF4mg5-bD7VUFAhAiyf7v0g


### PR DESCRIPTION
Opens discord server invite link when you click Reddit Badge. It should be subreddit link.