### PR TITLE
fix: exception on reopening DPG demo

### DIFF
--- a/DearPyGui/dearpygui/demo.py
+++ b/DearPyGui/dearpygui/demo.py
@@ -186,6 +186,7 @@ def _on_demo_close(sender, app_data, user_data):
     dpg.delete_item("__demo_stage1")
     dpg.delete_item("__demo_popup1")
     dpg.delete_item("__demo_popup2")
+    dpg.delete_item("__demo_popup3")
     dpg.delete_item("__demo_item_reg3")
     dpg.delete_item("__demo_item_reg6")
     dpg.delete_item("__demo_item_reg7")


### PR DESCRIPTION
An item with a hardcoded tag was not properly deleted on closing
and thus made the demo window not reopenable.

Introduced in 3e90444b8b040239643185d9996a04d304edf927
Closes #1773