### PR TITLE
Update BuildPythonForLinux.sh

### DIFF
--- a/scripts/BuildPythonForLinux.sh
+++ b/scripts/BuildPythonForLinux.sh
@@ -37,7 +37,7 @@ cd "build/$target"
 
 # Reconfiguring is time-consuming. Skip if it's already been done
 if [ ! -f Makefile ]; then
-    ../../configure $configure_args
+    /bin/bash ../../configure $configure_args
 fi
 
 make $jobs


### PR DESCRIPTION
without "/bin/bash" added before ../../configure $configure_args
It doesn't run.  With it, it runs.
Linux/Ubuntu 20.04

---
name: Pull Request
about: Create a pull request to help us improve
title: ''
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
