### PR TITLE
Fix (mvViewport_win32.cpp): Add correct flag to viewport when decorated

### DIFF
--- a/src/mvViewport_win32.cpp
+++ b/src/mvViewport_win32.cpp
@@ -24,7 +24,12 @@ mvHandleModes(mvViewport& viewport)
 	viewportData->modes = WS_OVERLAPPED;
 
 	if (viewport.resizable && viewport.decorated) viewportData->modes |= WS_THICKFRAME;
-	if (viewport.decorated) viewportData->modes |= WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+	if (viewport.decorated) {
+		viewportData->modes |= WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+	}
+	else {
+		viewportData->modes |= WS_POPUP;
+	}
 
 }
 
@@ -56,7 +61,12 @@ mvPrerender(mvViewport& viewport)
 		viewportData->modes = WS_OVERLAPPED;
 
 		if (viewport.resizable && viewport.decorated) viewportData->modes |= WS_THICKFRAME;
-		if (viewport.decorated) viewportData->modes |= WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+		if (viewport.decorated) {
+			viewportData->modes |= WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+		}
+		else {
+			viewportData->modes |= WS_POPUP;
+		}
 
 		SetWindowLongPtr(viewportData->handle, GWL_STYLE, viewportData->modes);
 		SetWindowPos(viewportData->handle, viewport.alwaysOnTop ? HWND_TOPMOST : HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);


### PR DESCRIPTION
fix (mvViewport_win32):  Fixing the Decorated option with the wrong offset. Issue 1716

---
name: Pull Request
about: Create a pull request to help us improve
title: mv
assignees: @hoffstadt 

---

Close #1716 

**Description:**
The Option decorated was not correctly done on Windows side. On Imgui the Decorated Option is set to the WS_POPUP flag but when a user sets the decorated to false the viewport does not get the Flag WS_POPUP