### PR TITLE
Fix (mvViewport_win32.cpp): Add correct flag to viewport when decorated

### DIFF
--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -2863,6 +2863,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
 
         args.push_back({ mvPyDataType::Bool, "default_value", mvArgType::KEYWORD_ARG, "False" });
         args.push_back({ mvPyDataType::Bool, "span_columns", mvArgType::KEYWORD_ARG, "False", "Forces the selectable to span the width of all columns if placed in a table." });
+        args.push_back({ mvPyDataType::Bool, "disable_popup_close", mvArgType::KEYWORD_ARG, "False", "Disable closing a modal or popup window." });
 
         setup.about = "Adds a selectable. Similar to a button but can indicate its selected state.";
         break;

--- a/src/mvBasicWidgets.cpp
+++ b/src/mvBasicWidgets.cpp
@@ -575,6 +575,7 @@ DearPyGui::fill_configuration_dict(const mvSelectableConfig& inConfig, PyObject*
 
 	// window flags
 	checkbitset("span_columns", ImGuiSelectableFlags_SpanAllColumns, inConfig.flags, false);
+	checkbitset("disable_popup_close", ImGuiSelectableFlags_DontClosePopups, inConfig.flags, false);
 }
 
 void
@@ -1597,6 +1598,7 @@ DearPyGui::set_configuration(PyObject* inDict, mvSelectableConfig& outConfig, mv
 
 	// window flags
 	flagop("span_columns", ImGuiSelectableFlags_SpanAllColumns, outConfig.flags, false);
+	flagop("disable_popup_close", ImGuiSelectableFlags_DontClosePopups, outConfig.flags, false);
 
 	if (info.enabledLastFrame)
 	{

--- a/src/mvViewport_win32.cpp
+++ b/src/mvViewport_win32.cpp
@@ -24,7 +24,12 @@ mvHandleModes(mvViewport& viewport)
 	viewportData->modes = WS_OVERLAPPED;
 
 	if (viewport.resizable && viewport.decorated) viewportData->modes |= WS_THICKFRAME;
-	if (viewport.decorated) viewportData->modes |= WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+	if (viewport.decorated) {
+		viewportData->modes |= WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+	}
+	else {
+		viewportData->modes |= WS_POPUP;
+	}
 
 }
 
@@ -56,7 +61,12 @@ mvPrerender(mvViewport& viewport)
 		viewportData->modes = WS_OVERLAPPED;
 
 		if (viewport.resizable && viewport.decorated) viewportData->modes |= WS_THICKFRAME;
-		if (viewport.decorated) viewportData->modes |= WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+		if (viewport.decorated) {
+			viewportData->modes |= WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+		}
+		else {
+			viewportData->modes |= WS_POPUP;
+		}
 
 		SetWindowLongPtr(viewportData->handle, GWL_STYLE, viewportData->modes);
 		SetWindowPos(viewportData->handle, viewport.alwaysOnTop ? HWND_TOPMOST : HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: fix (mvViewport_win32): Fixing the Decorated option with the wrong offset. Issue 1716
assignees: @hoffstadt 

---

<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->
Close #1716 

**Description:**
The Option decorated was not correctly done on Windows side. On Imgui the Decorated Option is set to the WS_POPUP flag but when a user sets the decorated to false the viewport does not get the Flag WS_POPUP

#sorry4reupload