### PR TITLE
fix (mvFileDialog): callback called if cancel clicked

### DIFF
--- a/docs/source/documentation/file-directory-selector.rst
+++ b/docs/source/documentation/file-directory-selector.rst
@@ -2,14 +2,16 @@ File & Directory Selector
 =========================
 
 The file dialog item can be used to select a single file,
-multiple files, or a directory. When the user clicks the **Ok** button,
+multiple files, or a directory. When the user clicks the **Ok** or **Cancel** button,
 the dialog's callback is ran. 
 
-Information is passed through the app_data argument such as:
+If **Ok** is clicked, information is passed through the app_data argument such as:
 * file path
 * file name
 * current path
 * current filter (the file type filter)
+
+If **Cancel** is clicked, `None` is passed through the app_data argument.
 
 
 The simplest case is as a director picker. Below is the example

--- a/src/composite/mvFileDialog.cpp
+++ b/src/composite/mvFileDialog.cpp
@@ -101,18 +101,19 @@ void mvFileDialog::draw(ImDrawList* drawlist, float x, float y)
 		if (_instance.Display(info.internalLabel, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings, _min_size, _max_size))
 		{
 
-			// action if OK
-			if (_instance.IsOk())
-			{
-				mvSubmitCallback([&]()
-					{
-						if(config.alias.empty())
-							mvRunCallback(config.callback, uuid, getInfoDict(), config.user_data);
-						else	
-							mvRunCallback(config.callback, config.alias, getInfoDict(), config.user_data);
-					});
+			mvSubmitCallback([&]()
+				{
+					PyObject* appData;
+					if(_instance.IsOk())
+						appData = getInfoDict();
+					else
+						appData = Py_None;  // app data None if cancel button clicked
 
-			}
+					if(config.alias.empty())
+						mvRunCallback(config.callback, uuid, appData, config.user_data);
+					else	
+						mvRunCallback(config.callback, config.alias, appData, config.user_data);
+				});
 
 			// close
 			_instance.Close();


### PR DESCRIPTION
---
name: `mvFileDialog` cancel button
about: callback now called for both OK and Cancel buttons
title: fix (mvFileDialog): callback called if cancel clicked
assignees: @hoffstadt 

---

Fixes #1841

**Description:**
`mvFileDialog` now has its callback called if either OK or Cancel are clicked. If cancel is clicked, app_data is `None`. Previously, the callback was only called if OK was clicked, making it difficult to detect if the user clicked cancel.

**Concerning Areas:**
Very minor changes to code, but in its current state this is a breaking change - existing `mwFileDialog` callbacks expecting to receive a dict will have problems if cancel is clicked.

I'm working on an alternative solution where a cancel callback is passed as an optional keyword argument.