### PR TITLE
feat (mvFileDialog): cancel button callback

### DIFF
--- a/docs/source/documentation/file-directory-selector.rst
+++ b/docs/source/documentation/file-directory-selector.rst
@@ -3,9 +3,12 @@ File & Directory Selector
 
 The file dialog item can be used to select a single file,
 multiple files, or a directory. When the user clicks the **Ok** button,
-the dialog's callback is ran. 
+the dialog's callback is run. An optional second callback, to be run 
+when the cancel button is clicked, can be provided as a keyword
+argument.
 
-Information is passed through the app_data argument such as:
+When OK is clicked, information is passed through the app_data argument
+such as:
 * file path
 * file name
 * current path
@@ -26,7 +29,12 @@ The simplest case is as a director picker. Below is the example
         print("Sender: ", sender)
         print("App Data: ", app_data)
 
-    dpg.add_file_dialog(directory_selector=True, show=False, callback=callback, tag="file_dialog_id")
+	def cancel_callback(sender, app_data):
+		print('Cancel was clicked.')
+
+    dpg.add_file_dialog(
+		directory_selector=True, show=False, callback=callback, tag="file_dialog_id",
+		cancel_callback=cancel_callback)
 
     with dpg.window(label="Tutorial", width=800, height=300):
         dpg.add_button(label="Directory Selector", callback=lambda: dpg.show_item("file_dialog_id"))

--- a/docs/source/documentation/file-directory-selector.rst
+++ b/docs/source/documentation/file-directory-selector.rst
@@ -26,15 +26,18 @@ The simplest case is as a director picker. Below is the example
     dpg.create_context()
 
     def callback(sender, app_data):
+        print('OK was clicked.')
         print("Sender: ", sender)
         print("App Data: ", app_data)
 
-	def cancel_callback(sender, app_data):
-		print('Cancel was clicked.')
+    def cancel_callback(sender, app_data):
+        print('Cancel was clicked.')
+        print("Sender: ", sender)
+        print("App Data: ", app_data)
 
     dpg.add_file_dialog(
-		directory_selector=True, show=False, callback=callback, tag="file_dialog_id",
-		cancel_callback=cancel_callback)
+        directory_selector=True, show=False, callback=callback, tag="file_dialog_id",
+        cancel_callback=cancel_callback)
 
     with dpg.window(label="Tutorial", width=800, height=300):
         dpg.add_button(label="Directory Selector", callback=lambda: dpg.show_item("file_dialog_id"))

--- a/src/composite/mvFileDialog.cpp
+++ b/src/composite/mvFileDialog.cpp
@@ -102,7 +102,7 @@ void mvFileDialog::draw(ImDrawList* drawlist, float x, float y)
 		{
 
 			// action if OK clicked or if cancel clicked and cancel callback provided
-			if (_instance.IsOk() or (!_instance.IsOk() and _cancelCallback))
+			if (_instance.IsOk() || (!_instance.IsOk() && _cancelCallback))
 			{
 				mvSubmitCallback([&]()
 					{
@@ -115,7 +115,7 @@ void mvFileDialog::draw(ImDrawList* drawlist, float x, float y)
 							appData = getInfoDict();
 						} else {
 							callback = _cancelCallback;
-							appData = Py_None;
+							appData = getInfoDict();
 						}
 
 						if(config.alias.empty())

--- a/src/composite/mvFileDialog.h
+++ b/src/composite/mvFileDialog.h
@@ -46,4 +46,5 @@ public:
     bool            _directory = false;
     mvVec2          _min_size = { 100.0f, 100.0f };
     mvVec2          _max_size = { 30000.0f, 30000.0f };
+	PyObject*	    _cancelCallback = nullptr;
 };

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -3062,6 +3062,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         args.push_back({ mvPyDataType::Bool, "directory_selector", mvArgType::KEYWORD_ARG, "False", "Shows only directory/paths as options. Allows selection of directory/paths only." });
         args.push_back({ mvPyDataType::IntList, "min_size", mvArgType::KEYWORD_ARG, "[100, 100]", "Minimum window size." });
         args.push_back({ mvPyDataType::IntList, "max_size", mvArgType::KEYWORD_ARG, "[30000, 30000]", "Maximum window size." });
+		args.push_back({ mvPyDataType::Callable, "cancel_callback", mvArgType::KEYWORD_ARG, "None", "Callback called when cancel button is clicked." });
 
         setup.about = "Displays a file or directory selector depending on keywords. Displays a file dialog by default. Callback will be ran when the file or directory picker is closed. The app_data arguemnt will be populated with information related to the file and directory as a dictionary.";
         setup.category = { "Containers", "Widgets", "File Dialog" };


### PR DESCRIPTION
---
name: feat (mvFileDialog): cancel button callback
about: A cancel button callback can be provided to `file_dialog()` as an optional keyword argument
title: Cancel button callback
assignees: @hoffstadt 

---

Fixes #1841.
Replaces #1842. 

**Description:**
A new optional keyword argument providing a callback function can be passed to `file_dialog`. The new keyword argument is `cancel_callback`. The callback will be run if the user clicks the file dialog's cancel button. Documentation has been updated. Previously, a callback was only called if OK was clicked, making it difficult to detect if the user clicked cancel.

**Concerning Areas:**
My first dpg and C++ contribution so it's likely I've done something wrong.
