### PR TITLE
fix: axis limits location wrong

### DIFF
--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -371,7 +371,7 @@ DearPyGui::draw_plot(ImDrawList* drawlist, mvAppItem& item, mvPlotConfig& config
 			auto axis = static_cast<mvPlotAxis*>(child.get());
 			if (axis->configData.setLimits || axis->configData._dirty)
 			{
-				switch (item.info.location)
+				switch (axis->info.location)
 				{
 				case(0): ImPlot::SetNextPlotLimitsX(axis->configData.limits.x, axis->configData.limits.y, ImGuiCond_Always); break;
 				case(1): ImPlot::SetNextPlotLimitsY(axis->configData.limits.x, axis->configData.limits.y, ImGuiCond_Always); break;
@@ -385,7 +385,7 @@ DearPyGui::draw_plot(ImDrawList* drawlist, mvAppItem& item, mvPlotConfig& config
 			if (!axis->configData.labels.empty())
 			{
 				// TODO: Checks
-				if (item.info.location == 0)
+				if (axis->info.location == 0)
 					ImPlot::SetNextPlotTicksX(axis->configData.labelLocations.data(), (int)axis->configData.labels.size(), axis->configData.clabels.data());
 				else
 					ImPlot::SetNextPlotTicksY(axis->configData.labelLocations.data(), (int)axis->configData.labels.size(), axis->configData.clabels.data());


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: ''
assignees: ''

---

**Description:**
when set plot axis ticks or limits on axisX, it will affect on axisY instead. 

Tested on MacOS 12.4 & py3.9

Influence Interface:
dpg.set_axis_ticks
dpg.set_axis_limits




