### PR TITLE
fix: make get_axis_limits() and set_axis_limits() support double-precision param

### DIFF
--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -1050,7 +1050,7 @@ set_axis_ticks(PyObject* self, PyObject* args, PyObject* kwargs)
 	if (!Parse((GetParsers())["set_axis_ticks"], args, kwargs, __FUNCTION__, &plotraw, &label_pairs))
 		return GetPyNone();
 
-	auto mlabel_pairs = ToVectPairStringFloat(label_pairs);
+	auto mlabel_pairs = ToVectPairStringDouble(label_pairs);
 
 	if (!GContext->manualMutexControl) std::lock_guard<std::mutex> lk(GContext->mutex);
 
@@ -1098,8 +1098,8 @@ mv_internal mv_python_function
 set_axis_limits(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	PyObject* axisraw;
-	float ymin;
-	float ymax;
+	double ymin;
+	double ymax;
 
 	if (!Parse((GetParsers())["set_axis_limits"], args, kwargs, __FUNCTION__, &axisraw, &ymin, &ymax))
 		return GetPyNone();
@@ -1125,7 +1125,7 @@ set_axis_limits(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	mvPlotAxis* graph = static_cast<mvPlotAxis*>(aplot);
 	graph->configData.setLimits = true;
-	graph->configData.limits = ImVec2(ymin, ymax);
+	graph->configData.limits = ImPlotPoint(ymin, ymax);
 	return GetPyNone();
 }
 
@@ -1228,7 +1228,7 @@ get_axis_limits(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	mvPlotAxis* graph = static_cast<mvPlotAxis*>(aplot);
 
-	const ImVec2& lim = graph->configData.limits_actual;
+	const ImPlotPoint& lim = graph->configData.limits_actual;
 	return ToPyPair(lim.x, lim.y);
 }
 

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -285,8 +285,8 @@ InsertParser_Block0(std::map<std::string, mvPythonParser>& parsers)
 		std::vector<mvPythonDataElement> args;
 		args.reserve(3);
 		args.push_back({ mvPyDataType::UUID, "axis" });
-		args.push_back({ mvPyDataType::Float, "ymin" });
-		args.push_back({ mvPyDataType::Float, "ymax" });
+		args.push_back({ mvPyDataType::Double, "ymin" });
+		args.push_back({ mvPyDataType::Double, "ymax" });
 
 		mvPythonParserSetup setup;
 		setup.about = "Sets limits on the axis for pan and zoom.";

--- a/src/mvPlotting.h
+++ b/src/mvPlotting.h
@@ -2,6 +2,7 @@
 
 #include "mvItemRegistry.h"
 #include "mvDearPyGui.h"
+#include "implot.h"
 #include <array>
 
 namespace DearPyGui
@@ -353,8 +354,8 @@ struct mvPlotAxisConfig
     ImPlotAxisFlags          flags = 0;
     int                      axis = 0;
     bool                     setLimits = false;
-    ImVec2                   limits;
-    ImVec2                   limits_actual;
+    ImPlotPoint              limits;
+    ImPlotPoint              limits_actual;
     std::vector<std::string> labels;
     std::vector<double>      labelLocations;
     std::vector<const char*> clabels; // to prevent conversion from string to char* every frame

--- a/src/mvPythonTranslator.cpp
+++ b/src/mvPythonTranslator.cpp
@@ -1289,6 +1289,41 @@ ToVectPairStringFloat(PyObject* value, const std::string& message)
 
     return items;
 }
+std::vector<std::pair<std::string, double>>
+ToVectPairStringDouble(PyObject* value, const std::string& message)
+{
+    std::vector<std::pair<std::string, double>> items;
+    if (value == nullptr)
+        return items;
+         
+
+    if (PyTuple_Check(value))
+    {
+        for (Py_ssize_t i = 0; i < PyTuple_Size(value); ++i)
+        {
+            PyObject* item = PyTuple_GetItem(value, i);
+            if (PyTuple_Size(item) == 2 && PyNumber_Check(PyTuple_GetItem(item, 1)))
+                items.emplace_back(PyUnicode_AsUTF8(PyTuple_GetItem(item, 0)), PyFloat_AsDouble(PyTuple_GetItem(item, 1)));
+
+        }
+
+    }
+    else if (PyList_Check(value))
+    {
+        for (Py_ssize_t i = 0; i < PyList_Size(value); ++i)
+        {
+            PyObject* item = PyList_GetItem(value, i);
+            if (PyList_Size(item) == 2 && PyNumber_Check(PyList_GetItem(item, 1)))
+                items.emplace_back(PyUnicode_AsUTF8(PyList_GetItem(item, 0)), PyFloat_AsDouble(PyList_GetItem(item, 1)));
+
+        }
+    }
+
+    else
+        mvThrowPythonError(mvErrorCode::mvWrongType, message);
+
+    return items;
+}
 
 std::vector<std::vector<float>>
 ToVectVectFloat(PyObject* value, const std::string& message)

--- a/src/mvPythonTranslator.h
+++ b/src/mvPythonTranslator.h
@@ -96,3 +96,4 @@ std::vector<std::vector<float>>                  ToVectVectFloat      (PyObject*
 std::vector<std::vector<int>>                    ToVectVectInt        (PyObject* value, const std::string& message = "Type must be an list/tuple of list/tuple of ints.");
 std::vector<std::vector<double>>                 ToVectVectDouble     (PyObject* value, const std::string& message = "Type must be an list/tuple of list/tuple of doubles.");
 std::vector<std::pair<std::string, float>>       ToVectPairStringFloat(PyObject* value, const std::string& message = "Type must be an list/tuple of str,float pairs.");
+std::vector<std::pair<std::string, double>>      ToVectPairStringDouble(PyObject* value, const std::string& message = "Type must be an list/tuple of str,float pairs.");


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: ''
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
mvPlotting support double-precision axis and double-precision data.
while get_axis_limits() and set_axis_limits() use float.

Tested on macos 13.0 & py3.10

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
