### PR TITLE
fix: text widget state update #1933

### DIFF
--- a/src/mvBasicWidgets.cpp
+++ b/src/mvBasicWidgets.cpp
@@ -5993,14 +5993,6 @@ DearPyGui::draw_text(ImDrawList* drawlist, mvAppItem& item, mvTextConfig& config
 		//ImGui::Text("%s", _value.c_str());
 		ImGui::TextUnformatted(config.value->c_str()); // this doesn't have a buffer size limit
 
-		item.state.lastFrameUpdate = GContext->frame;
-		item.state.visible = ImGui::IsItemVisible();
-		item.state.hovered = ImGui::IsItemHovered();
-		item.state.leftclicked = ImGui::IsItemClicked(0);
-		item.state.rightclicked = ImGui::IsItemClicked(1);
-		item.state.middleclicked = ImGui::IsItemClicked(2);
-		item.state.contextRegionAvail = { ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y };
-
 		if (config.wrap >= 0)
 			ImGui::PopTextWrapPos();
 
@@ -6012,14 +6004,13 @@ DearPyGui::draw_text(ImDrawList* drawlist, mvAppItem& item, mvTextConfig& config
 			ImGui::SameLine();
 			ImGui::SetCursorPos({ valueEndX + style.ItemInnerSpacing.x, textVertCenter });
 			ImGui::TextUnformatted(item.config.specifiedLabel.c_str());
-
-			item.state.visible = ImGui::IsItemVisible();
-			item.state.hovered = ImGui::IsItemHovered();
-			item.state.leftclicked = ImGui::IsItemClicked(0);
-			item.state.rightclicked = ImGui::IsItemClicked(1);
-			item.state.middleclicked = ImGui::IsItemClicked(2);
 		}
 	}
+
+	//-----------------------------------------------------------------------------
+	// update state
+	//-----------------------------------------------------------------------------
+	UpdateAppItemState(item.state);
 
 	//-----------------------------------------------------------------------------
 	// postdraw


### PR DESCRIPTION
**Description:**
Item state update was left inside of the drawing of the widget, this was most likely done due to left label causing two spots were state was updated. when refactoring the code this was missed. This was tested by inspecting the item state of the demo text color and word wrapping section and viewing the item registry to ensure states were updated correctly when the item was interacted with by the mouse and the item width was changed with the word wrapping slider.

The old item state update was removed and the new item state update function was used.
