### PR TITLE
Adding Viewport Option disable_close ( only on Windows ) && Fix Issue with Decorated

### DIFF
--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -702,7 +702,7 @@ def create_translation_matrix(translation : Union[List[float], Tuple[float, ...]
 	"""New in 1.1. Creates a translation matrix."""
 	...
 
-def create_viewport(*, title: str ='', small_icon: str ='', large_icon: str ='', width: int ='', height: int ='', x_pos: int ='', y_pos: int ='', min_width: int ='', max_width: int ='', min_height: int ='', max_height: int ='', resizable: bool ='', vsync: bool ='', always_on_top: bool ='', decorated: bool ='', clear_color: Union[List[float], Tuple[float, ...]] ='') -> None:
+def create_viewport(*, title: str ='', small_icon: str ='', large_icon: str ='', width: int ='', height: int ='', x_pos: int ='', y_pos: int ='', min_width: int ='', max_width: int ='', min_height: int ='', max_height: int ='', resizable: bool ='', vsync: bool ='', always_on_top: bool ='', decorated: bool ='', clear_color: Union[List[float], Tuple[float, ...]] ='', disable_close: bool ='') -> None:
 	"""Creates a viewport. Viewports are required."""
 	...
 

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -4905,7 +4905,7 @@ def add_listbox(items=(), **kwargs):
 		filter_key (str, optional): Used by filter widget.
 		tracked (bool, optional): Scroll tracking
 		track_offset (float, optional): 0.0f:top, 0.5f:center, 1.0f:bottom
-		default_value (str, optional): String value fo the item that will be selected by default.
+		default_value (str, optional): String value of the item that will be selected by default.
 		num_items (int, optional): Expands the height of the listbox to show specified number of items.
 		id (Union[int, str], optional): (deprecated)
 	Returns:
@@ -6835,6 +6835,7 @@ def create_viewport(**kwargs):
 		always_on_top (bool, optional): Forces the viewport to always be drawn ontop of all other viewports.
 		decorated (bool, optional): Enabled and disabled the decorator bar at the top of the viewport.
 		clear_color (Union[List[float], Tuple[float, ...]], optional): Sets the color of the back of the viewport.
+		disable_close (bool, optional): Disable/Enable the close button from the viewport. Can be used with set_exit_callback
 	Returns:
 		None
 	"""

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -5431,7 +5431,7 @@ def add_listbox(items : Union[List[str], Tuple[str, ...]] =(), *, label: str =No
 		filter_key (str, optional): Used by filter widget.
 		tracked (bool, optional): Scroll tracking
 		track_offset (float, optional): 0.0f:top, 0.5f:center, 1.0f:bottom
-		default_value (str, optional): String value fo the item that will be selected by default.
+		default_value (str, optional): String value of the item that will be selected by default.
 		num_items (int, optional): Expands the height of the listbox to show specified number of items.
 		id (Union[int, str], optional): (deprecated) 
 	Returns:
@@ -7617,7 +7617,7 @@ def create_translation_matrix(translation : Union[List[float], Tuple[float, ...]
 
 	return internal_dpg.create_translation_matrix(translation, **kwargs)
 
-def create_viewport(*, title: str ='Dear PyGui', small_icon: str ='', large_icon: str ='', width: int =1280, height: int =800, x_pos: int =100, y_pos: int =100, min_width: int =250, max_width: int =10000, min_height: int =250, max_height: int =10000, resizable: bool =True, vsync: bool =True, always_on_top: bool =False, decorated: bool =True, clear_color: Union[List[float], Tuple[float, ...]] =(0, 0, 0, 255), **kwargs) -> None:
+def create_viewport(*, title: str ='Dear PyGui', small_icon: str ='', large_icon: str ='', width: int =1280, height: int =800, x_pos: int =100, y_pos: int =100, min_width: int =250, max_width: int =10000, min_height: int =250, max_height: int =10000, resizable: bool =True, vsync: bool =True, always_on_top: bool =False, decorated: bool =True, clear_color: Union[List[float], Tuple[float, ...]] =(0, 0, 0, 255), disable_close: bool =False, **kwargs) -> None:
 	"""	 Creates a viewport. Viewports are required.
 
 	Args:
@@ -7637,11 +7637,12 @@ def create_viewport(*, title: str ='Dear PyGui', small_icon: str ='', large_icon
 		always_on_top (bool, optional): Forces the viewport to always be drawn ontop of all other viewports.
 		decorated (bool, optional): Enabled and disabled the decorator bar at the top of the viewport.
 		clear_color (Union[List[float], Tuple[float, ...]], optional): Sets the color of the back of the viewport.
+		disable_close (bool, optional): Disable/Enable the close button from the viewport. Can be used with set_exit_callback
 	Returns:
 		None
 	"""
 
-	return internal_dpg.create_viewport(title=title, small_icon=small_icon, large_icon=large_icon, width=width, height=height, x_pos=x_pos, y_pos=y_pos, min_width=min_width, max_width=max_width, min_height=min_height, max_height=max_height, resizable=resizable, vsync=vsync, always_on_top=always_on_top, decorated=decorated, clear_color=clear_color, **kwargs)
+	return internal_dpg.create_viewport(title=title, small_icon=small_icon, large_icon=large_icon, width=width, height=height, x_pos=x_pos, y_pos=y_pos, min_width=min_width, max_width=max_width, min_height=min_height, max_height=max_height, resizable=resizable, vsync=vsync, always_on_top=always_on_top, decorated=decorated, clear_color=clear_color, disable_close=disable_close, **kwargs)
 
 def delete_item(item : Union[int, str], *, children_only: bool =False, slot: int =-1, **kwargs) -> None:
 	"""	 Deletes an item..

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -1828,7 +1828,7 @@ set_frame_callback(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	i32 frame = 0;
 	PyObject* callback;
-	PyObject* user_data=nullptr;
+	PyObject* user_data = nullptr;
 
 	if (!Parse((GetParsers())["set_frame_callback"], args, kwargs, __FUNCTION__,
 		&frame, &callback, &user_data))
@@ -1840,7 +1840,7 @@ set_frame_callback(PyObject* self, PyObject* args, PyObject* kwargs)
 	// TODO: check previous entry and deprecate if existing
 	Py_XINCREF(callback);
 
-	if(user_data)
+	if (user_data)
 		Py_XINCREF(user_data);
 	mvSubmitCallback([=]()
 		{
@@ -1862,7 +1862,7 @@ set_exit_callback(PyObject* self, PyObject* args, PyObject* kwargs)
 		return GetPyNone();
 
 	Py_XINCREF(callback);
-	if(user_data)
+	if (user_data)
 		Py_XINCREF(user_data);
 	mvSubmitCallback([=]()
 		{
@@ -1926,6 +1926,7 @@ get_viewport_configuration(PyObject* self, PyObject* args, PyObject* kwargs)
 		PyDict_SetItemString(pdict, "always_on_top", mvPyObject(ToPyBool(viewport->alwaysOnTop)));
 		PyDict_SetItemString(pdict, "decorated", mvPyObject(ToPyBool(viewport->decorated)));
 		PyDict_SetItemString(pdict, "title", mvPyObject(ToPyString(viewport->title)));
+		PyDict_SetItemString(pdict, "disable_close", mvPyObject(ToPyBool(viewport->disableClose)));
 	}
 	else
 		mvThrowPythonError(mvErrorCode::mvNone, "No viewport created");
@@ -1968,6 +1969,7 @@ create_viewport(PyObject* self, PyObject* args, PyObject* kwargs)
 	b32 vsync = true;
 	b32 always_on_top = false;
 	b32 decorated = true;
+	b32 disable_close = false;
 
 	PyObject* color = PyList_New(4);
 	PyList_SetItem(color, 0, PyFloat_FromDouble(0.0));
@@ -1978,7 +1980,7 @@ create_viewport(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	if (!Parse((GetParsers())["create_viewport"], args, kwargs, __FUNCTION__,
 		&title, &small_icon, &large_icon, &width, &height, &x_pos, &y_pos, &min_width, &max_width, &min_height, &max_height,
-		&resizable, &vsync, &always_on_top, &decorated, &color
+		&resizable, &vsync, &always_on_top, &decorated, &color, &disable_close
 	))
 		return GetPyNone();
 
@@ -1999,6 +2001,7 @@ create_viewport(PyObject* self, PyObject* args, PyObject* kwargs)
 	if (PyObject* item = PyDict_GetItemString(kwargs, "always_on_top")) { viewport->modesDirty = true; viewport->alwaysOnTop = ToBool(item); }
 	if (PyObject* item = PyDict_GetItemString(kwargs, "decorated")) { viewport->modesDirty = true; viewport->decorated = ToBool(item); }
 	if (PyObject* item = PyDict_GetItemString(kwargs, "title")) { viewport->titleDirty = true; viewport->title = ToString(item); }
+	if (PyObject* item = PyDict_GetItemString(kwargs, "disable_close")) viewport->disableClose = ToBool(item);
 
 	GContext->viewport = viewport;
 
@@ -2051,7 +2054,7 @@ configure_viewport(PyObject* self, PyObject* args, PyObject* kwargs)
 		if (PyObject* item = PyDict_GetItemString(kwargs, "always_on_top")) { viewport->modesDirty = true; viewport->alwaysOnTop = ToBool(item); }
 		if (PyObject* item = PyDict_GetItemString(kwargs, "decorated")) { viewport->modesDirty = true; viewport->decorated = ToBool(item); }
 		if (PyObject* item = PyDict_GetItemString(kwargs, "title")) { viewport->titleDirty = true; viewport->title = ToString(item); }
-
+		if (PyObject* item = PyDict_GetItemString(kwargs, "disable_close")) viewport->disableClose = ToBool(item);
 	}
 	else
 		mvThrowPythonError(mvErrorCode::mvNone, "No viewport created");
@@ -2287,37 +2290,37 @@ save_image(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	switch (imageType)
 	{
-        case MV_IMAGE_TYPE_PNG_:
-        {
-            std::vector<unsigned char> convertedData = ToUCharVect(data);
-            int result = stbi_write_png(file, width, height, components, convertedData.data(), sizeof(unsigned char)*components*width);
-            break;
-        }
-        case MV_IMAGE_TYPE_BMP_:
-        {
-            std::vector<unsigned char> convertedData = ToUCharVect(data);
-            int result = stbi_write_bmp(file, width, height, components, convertedData.data());
-            break;
-        }
-        case MV_IMAGE_TYPE_TGA_:
-        {
-            std::vector<unsigned char> convertedData = ToUCharVect(data);
-            int result = stbi_write_tga(file, width, height, components, convertedData.data());
-            break;
-        }
-        case MV_IMAGE_TYPE_HDR_:
-        {
-            std::vector<float> convertedData = ToFloatVect(data);
-            int result = stbi_write_hdr(file, width, height, components, convertedData.data());
-            break;
-        }
-        case MV_IMAGE_TYPE_JPG_:
-        {
-            std::vector<unsigned char> convertedData = ToUCharVect(data);
-            int result = stbi_write_jpg(file, width, height, components, convertedData.data(), quality);
-            break;
-        }
-        default: break;
+	case MV_IMAGE_TYPE_PNG_:
+	{
+		std::vector<unsigned char> convertedData = ToUCharVect(data);
+		int result = stbi_write_png(file, width, height, components, convertedData.data(), sizeof(unsigned char) * components * width);
+		break;
+	}
+	case MV_IMAGE_TYPE_BMP_:
+	{
+		std::vector<unsigned char> convertedData = ToUCharVect(data);
+		int result = stbi_write_bmp(file, width, height, components, convertedData.data());
+		break;
+	}
+	case MV_IMAGE_TYPE_TGA_:
+	{
+		std::vector<unsigned char> convertedData = ToUCharVect(data);
+		int result = stbi_write_tga(file, width, height, components, convertedData.data());
+		break;
+	}
+	case MV_IMAGE_TYPE_HDR_:
+	{
+		std::vector<float> convertedData = ToFloatVect(data);
+		int result = stbi_write_hdr(file, width, height, components, convertedData.data());
+		break;
+	}
+	case MV_IMAGE_TYPE_JPG_:
+	{
+		std::vector<unsigned char> convertedData = ToUCharVect(data);
+		int result = stbi_write_jpg(file, width, height, components, convertedData.data(), quality);
+		break;
+	}
+	default: break;
 	}
 
 	return GetPyNone();
@@ -2363,10 +2366,10 @@ output_frame_buffer(PyObject* self, PyObject* args, PyObject* kwargs)
 	// TODO: support other formats
 	if (file[filepathLength - 3] == 'p' && file[filepathLength - 2] == 'n' && file[filepathLength - 1] == 'g')
 	{
-        std::string fileStored = file;
-        mvSubmitTask([fileStored](){
-            OutputFrameBuffer(fileStored.c_str());
-        });
+		std::string fileStored = file;
+		mvSubmitTask([fileStored]() {
+			OutputFrameBuffer(fileStored.c_str());
+			});
 
 	}
 	else
@@ -2412,7 +2415,7 @@ render_dearpygui_frame(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	MV_PROFILE_SCOPE("Frame")
 
-	Py_BEGIN_ALLOW_THREADS;
+		Py_BEGIN_ALLOW_THREADS;
 	auto window = GContext->viewport;
 	mvRenderFrame();
 	Py_END_ALLOW_THREADS;
@@ -2489,11 +2492,11 @@ destroy_context(PyObject* self, PyObject* args, PyObject* kwargs)
 
 
 		//#define X(el) el::s_class_theme_component = nullptr; el::s_class_theme_disabled_component = nullptr;
-		#define X(el) DearPyGui::GetClassThemeComponent(mvAppItemType::el) = nullptr; DearPyGui::GetDisabledClassThemeComponent(mvAppItemType::el) = nullptr;
+#define X(el) DearPyGui::GetClassThemeComponent(mvAppItemType::el) = nullptr; DearPyGui::GetDisabledClassThemeComponent(mvAppItemType::el) = nullptr;
 		MV_ITEM_TYPES
-		#undef X
+#undef X
 
-		mvSubmitCallback([=]() {
+			mvSubmitCallback([=]() {
 			GContext->callbackRegistry->running = false;
 				});
 		if (GContext->future.valid())
@@ -2989,8 +2992,8 @@ delete_item(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	mvUUID item = GetIDFromPyObject(itemraw);
 
-    if(item != 0)
-	    DeleteItem((*GContext->itemRegistry), item, childrenOnly, slot);
+	if (item != 0)
+		DeleteItem((*GContext->itemRegistry), item, childrenOnly, slot);
 
 	return GetPyNone();
 
@@ -3884,11 +3887,11 @@ get_item_types(PyObject* self, PyObject* args, PyObject* kwargs)
 	if (!GContext->manualMutexControl) std::lock_guard<std::mutex> lk(GContext->mutex);
 
 	PyObject* pdict = PyDict_New();
-	#define X(el) PyDict_SetItemString(pdict, #el, PyLong_FromLong((int)mvAppItemType::el));
+#define X(el) PyDict_SetItemString(pdict, #el, PyLong_FromLong((int)mvAppItemType::el));
 	MV_ITEM_TYPES
-	#undef X
+#undef X
 
-	return pdict;
+		return pdict;
 }
 
 static PyObject*
@@ -4045,13 +4048,13 @@ capture_next_item(PyObject* self, PyObject* args, PyObject* kwargs)
 		Py_XDECREF(GContext->itemRegistry->captureCallbackUserData);
 
 	Py_XINCREF(callable);
-	if(user_data)
+	if (user_data)
 		Py_XINCREF(user_data);
 	if (callable == Py_None)
 		GContext->itemRegistry->captureCallback = nullptr;
 	else
 		GContext->itemRegistry->captureCallback = callable;
-			
+
 	GContext->itemRegistry->captureCallbackUserData = user_data;
 
 	return GetPyNone();
@@ -4072,7 +4075,7 @@ get_callback_queue(PyObject* self, PyObject* args, PyObject* kwargs)
 		else
 			PyTuple_SetItem(job, 0, GetPyNone());
 
-		if(GContext->callbackRegistry->jobs[i].sender == 0)
+		if (GContext->callbackRegistry->jobs[i].sender == 0)
 			PyTuple_SetItem(job, 1, ToPyString(GContext->callbackRegistry->jobs[i].sender_str));
 		else
 			PyTuple_SetItem(job, 1, ToPyUUID(GContext->callbackRegistry->jobs[i].sender));

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -20,7 +20,7 @@ InsertParser_Block0(std::map<std::string, mvPythonParser>& parsers)
 		std::vector<mvPythonDataElement> args;
 		args.push_back({ mvPyDataType::Integer, "frame" });
 		args.push_back({ mvPyDataType::Callable, "callback" });
-		args.push_back({ mvPyDataType::Object, "user_data", mvArgType::KEYWORD_ARG, "None", "New in 1.3. Optional user data to send to the callback"});
+		args.push_back({ mvPyDataType::Object, "user_data", mvArgType::KEYWORD_ARG, "None", "New in 1.3. Optional user data to send to the callback" });
 
 		mvPythonParserSetup setup;
 		setup.about = "Sets a callback to run on first frame.";
@@ -347,7 +347,7 @@ InsertParser_Block0(std::map<std::string, mvPythonParser>& parsers)
 	//-----------------------------------------------------------------------------
 	{
 		std::vector<mvPythonDataElement> args;
-		args.reserve(16);
+		args.reserve(17);
 		args.push_back({ mvPyDataType::String, "title", mvArgType::KEYWORD_ARG, "'Dear PyGui'", "Sets the title of the viewport." });
 		args.push_back({ mvPyDataType::String, "small_icon", mvArgType::KEYWORD_ARG, "''", "Sets the small icon that is found in the viewport's decorator bar. Must be ***.ico on windows and either ***.ico or ***.png on mac." });
 		args.push_back({ mvPyDataType::String, "large_icon", mvArgType::KEYWORD_ARG, "''", "Sets the large icon that is found in the task bar while the app is running. Must be ***.ico on windows and either ***.ico or ***.png on mac." });
@@ -364,6 +364,7 @@ InsertParser_Block0(std::map<std::string, mvPythonParser>& parsers)
 		args.push_back({ mvPyDataType::Bool, "always_on_top", mvArgType::KEYWORD_ARG, "False", "Forces the viewport to always be drawn ontop of all other viewports." });
 		args.push_back({ mvPyDataType::Bool, "decorated", mvArgType::KEYWORD_ARG, "True", "Enabled and disabled the decorator bar at the top of the viewport." });
 		args.push_back({ mvPyDataType::FloatList, "clear_color", mvArgType::KEYWORD_ARG, "(0, 0, 0, 255)", "Sets the color of the back of the viewport." });
+		args.push_back({ mvPyDataType::Bool, "disable_close", mvArgType::KEYWORD_ARG, "False", "Disable/Enable the close button from the viewport. Can be used with set_exit_callback" });
 
 		mvPythonParserSetup setup;
 		setup.about = "Creates a viewport. Viewports are required.";
@@ -494,7 +495,7 @@ InsertParser_Block1(std::map<std::string, mvPythonParser>& parsers)
 		args.push_back({ mvPyDataType::Bool, "skip_positional_args", mvArgType::KEYWORD_ARG, "False" });
 		args.push_back({ mvPyDataType::Bool, "skip_keyword_args", mvArgType::KEYWORD_ARG, "False" });
 		args.push_back({ mvPyDataType::Bool, "wait_for_input", mvArgType::KEYWORD_ARG, "False", "New in 1.1. Only update when user input occurs" });
-		args.push_back({ mvPyDataType::Bool, "manual_callback_management", mvArgType::KEYWORD_ARG, "False", "New in 1.2"});
+		args.push_back({ mvPyDataType::Bool, "manual_callback_management", mvArgType::KEYWORD_ARG, "False", "New in 1.2" });
 
 		mvPythonParserSetup setup;
 		setup.about = "Configures app.";
@@ -565,7 +566,7 @@ InsertParser_Block1(std::map<std::string, mvPythonParser>& parsers)
 		args.push_back({ mvPyDataType::Integer, "width" });
 		args.push_back({ mvPyDataType::Integer, "height" });
 		args.push_back({ mvPyDataType::Object, "data" });
-		args.push_back({ mvPyDataType::Integer, "components", mvArgType::KEYWORD_ARG, "4", "Number of components (1-4). Default of 4."});
+		args.push_back({ mvPyDataType::Integer, "components", mvArgType::KEYWORD_ARG, "4", "Number of components (1-4). Default of 4." });
 		//args.push_back({ mvPyDataType::Integer, "stride_in_bytes", mvArgType::KEYWORD_ARG, "1.0", "Stride in bytes (only used for png)." });
 		args.push_back({ mvPyDataType::Integer, "quality", mvArgType::KEYWORD_ARG, "50", "Stride in bytes (only used for jpg)." });
 
@@ -580,8 +581,8 @@ InsertParser_Block1(std::map<std::string, mvPythonParser>& parsers)
 	{
 		std::vector<mvPythonDataElement> args;
 		args.reserve(1);
-		args.push_back({ mvPyDataType::String, "file", mvArgType::POSITIONAL_ARG, "''"});
-		args.push_back({ mvPyDataType::Callable, "callback", mvArgType::KEYWORD_ARG, "None", "Callback will return framebuffer as an array through the second arg."});
+		args.push_back({ mvPyDataType::String, "file", mvArgType::POSITIONAL_ARG, "''" });
+		args.push_back({ mvPyDataType::Callable, "callback", mvArgType::KEYWORD_ARG, "None", "Callback will return framebuffer as an array through the second arg." });
 
 		mvPythonParserSetup setup;
 		setup.about = "Outputs frame buffer as a png if file is specified or through the second argument of a callback if specified. Render loop must have been started.";

--- a/src/mvViewport.h
+++ b/src/mvViewport.h
@@ -34,6 +34,8 @@ struct mvViewport
 	b8 alwaysOnTop = false;
 	b8 decorated   = true;
     b8 fullScreen  = false;
+	b8 disableClose = false;
+
 
 	// position/size
 	b8  sizeDirty    = false;


### PR DESCRIPTION
---
name: Pull Request
about: Adding Viewportsupport for disabling the Close Button on Windows Systems
title: ''
assignees: @hoffstadt 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->
Where do we start... adding a new option to the viewport:
- disable_close
  True = Viewport can not be closed anymore
  False = Viewport can still be closed

Functionality is just added on Windows because i do not have a Linux or Mac System.
Also the Getter and Setter functions could not be added.

Also in that commit;
Fixed the Issue with the Window ( primary window) + decorated Viewport on windows with the padding.


**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
