### PR TITLE
fix: item config/info oddities

### DIFF
--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -2471,7 +2471,7 @@ destroy_context(PyObject* self, PyObject* args, PyObject* kwargs)
 	{
 		// hacky fix, started was set to false
 		// to exit the event loop, but needs to be
-		// true in order to run DPG commands for the 
+		// true in order to run DPG commands for the
 		// exit callback.
 		GContext->started = true;
 		mvSubmitCallback([=]() {
@@ -3504,6 +3504,11 @@ get_item_info(PyObject* self, PyObject* args, PyObject* kwargs)
 		else
 			PyDict_SetItemString(pdict, "theme", mvPyObject(GetPyNone()));
 
+		if (appitem->handlerRegistry)
+			PyDict_SetItemString(pdict, "handlers", mvPyObject(ToPyUUID(appitem->handlerRegistry->uuid)));
+		else
+			PyDict_SetItemString(pdict, "handlers", mvPyObject(GetPyNone()));
+
 		if (appitem->font)
 			PyDict_SetItemString(pdict, "font", mvPyObject(ToPyUUID(appitem->font->uuid)));
 		else
@@ -3526,7 +3531,7 @@ get_item_info(PyObject* self, PyObject* args, PyObject* kwargs)
 		PyDict_SetItemString(pdict, "deactivatedae_handler_applicable", mvPyObject(ToPyBool(applicableState & MV_STATE_DEACTIVATEDAE)));
 		PyDict_SetItemString(pdict, "toggled_open_handler_applicable", mvPyObject(ToPyBool(applicableState & MV_STATE_TOGGLED_OPEN)));
 		PyDict_SetItemString(pdict, "resized_handler_applicable", mvPyObject(ToPyBool(applicableState & MV_STATE_RECT_SIZE)));
-
+		
 	}
 
 	else
@@ -4051,7 +4056,7 @@ capture_next_item(PyObject* self, PyObject* args, PyObject* kwargs)
 		GContext->itemRegistry->captureCallback = nullptr;
 	else
 		GContext->itemRegistry->captureCallback = callable;
-			
+
 	GContext->itemRegistry->captureCallbackUserData = user_data;
 
 	return GetPyNone();

--- a/src/mvBasicWidgets.cpp
+++ b/src/mvBasicWidgets.cpp
@@ -404,7 +404,7 @@ DearPyGui::fill_configuration_dict(const mvInputTextConfig& inConfig, PyObject* 
 		return;
 
 	PyDict_SetItemString(outDict, "hint", mvPyObject(ToPyString(inConfig.hint)));
-	PyDict_SetItemString(outDict, "multline", mvPyObject(ToPyBool(inConfig.multiline)));
+	PyDict_SetItemString(outDict, "multiline", mvPyObject(ToPyBool(inConfig.multiline)));
 
 	// helper to check and set bit
 	auto checkbitset = [outDict](const char* keyword, int flag, const int& flags)
@@ -3431,8 +3431,8 @@ DearPyGui::draw_drag_float(ImDrawList* drawlist, mvAppItem& item, mvDragFloatCon
 
 		if (!item.config.enabled) config.disabled_value = *config.value;
 
-		if (ImGui::DragFloat(item.info.internalLabel.c_str(), 
-			item.config.enabled ? config.value.get() : &config.disabled_value, 
+		if (ImGui::DragFloat(item.info.internalLabel.c_str(),
+			item.config.enabled ? config.value.get() : &config.disabled_value,
 			config.speed, config.minv, config.maxv, config.format.c_str(), config.flags))
 		{
 			auto value = *config.value;
@@ -3627,7 +3627,7 @@ DearPyGui::draw_drag_int(ImDrawList* drawlist, mvAppItem& item, mvDragIntConfig&
 
 		if (!item.config.enabled) config.disabled_value = *config.value;
 
-		if (ImGui::DragInt(item.info.internalLabel.c_str(), 
+		if (ImGui::DragInt(item.info.internalLabel.c_str(),
 			item.config.enabled ? config.value.get() : &config.disabled_value, config.speed,
 			config.minv, config.maxv, config.format.c_str(), config.flags))
 		{
@@ -3959,7 +3959,7 @@ DearPyGui::draw_drag_doublex(ImDrawList* drawlist, mvAppItem& item, mvDragDouble
 		bool activated = false;
 
 		if (!item.config.enabled) std::copy(config.value->data(), config.value->data() + 2, config.disabled_value);
-		
+
 		if(config.size > 1 && config.size < 5)
 			activated = ImGui::DragScalarN(item.info.internalLabel.c_str(), ImGuiDataType_Double, item.config.enabled ? config.value->data() : &config.disabled_value[0], config.size, config.speed, &config.minv, &config.maxv, config.format.c_str(), config.flags);
 
@@ -5105,7 +5105,7 @@ DearPyGui::draw_input_int(ImDrawList* drawlist, mvAppItem& item, mvInputIntConfi
 
 			// If the widget is edited through ctrl+click mode the active value will be entered every frame.
 			// If the value is out of bounds the value will be overwritten with max or min so each frame the value will be switching between the
-			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every 
+			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every
 			// frame we check if the value was already submitted.
 			if (config.last_value != *config.value)
 			{
@@ -5254,7 +5254,7 @@ DearPyGui::draw_input_floatx(ImDrawList* drawlist, mvAppItem& item, mvInputFloat
 
 			// If the widget is edited through ctrl+click mode the active value will be entered every frame.
 			// If the value is out of bounds the value will be overwritten with max or min so each frame the value will be switching between the
-			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every 
+			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every
 			// frame we check if the value was already submitted.
 			if (config.last_value != *config.value)
 			{
@@ -5377,7 +5377,7 @@ DearPyGui::draw_input_float(ImDrawList* drawlist, mvAppItem& item, mvInputFloatC
 
 			// If the widget is edited through ctrl+click mode the active value will be entered every frame.
 			// If the value is out of bounds the value will be overwritten with max or min so each frame the value will be switching between the
-			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every 
+			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every
 			// frame we check if the value was already submitted.
 			if (config.last_value != *config.value)
 			{
@@ -5595,7 +5595,7 @@ DearPyGui::draw_input_double(ImDrawList* drawlist, mvAppItem& item, mvInputDoubl
 
 			// If the widget is edited through ctrl+click mode the active value will be entered every frame.
 			// If the value is out of bounds the value will be overwritten with max or min so each frame the value will be switching between the
-			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every 
+			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every
 			// frame we check if the value was already submitted.
 			if (config.last_value != *config.value)
 			{
@@ -5731,7 +5731,7 @@ DearPyGui::draw_input_doublex(ImDrawList* drawlist, mvAppItem& item, mvInputDoub
 
 			// If the widget is edited through ctrl+click mode the active value will be entered every frame.
 			// If the value is out of bounds the value will be overwritten with max or min so each frame the value will be switching between the
-			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every 
+			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every
 			// frame we check if the value was already submitted.
 			if (config.last_value != *config.value)
 			{
@@ -5880,7 +5880,7 @@ DearPyGui::draw_input_intx(ImDrawList* drawlist, mvAppItem& item, mvInputIntMult
 
 			// If the widget is edited through ctrl+click mode the active value will be entered every frame.
 			// If the value is out of bounds the value will be overwritten with max or min so each frame the value will be switching between the
-			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every 
+			// ctrl+click value and the bounds value until the widget is not in ctrl+click mode. To prevent the callback from running every
 			// frame we check if the value was already submitted.
 			if (config.last_value != *config.value)
 			{
@@ -6011,7 +6011,7 @@ DearPyGui::draw_text(ImDrawList* drawlist, mvAppItem& item, mvTextConfig& config
 			ImGui::TextUnformatted(item.config.specifiedLabel.c_str());
 
 			//-----------------------------------------------------------------------------
-			// update state - locally updating the item state when label is used. We do not 
+			// update state - locally updating the item state when label is used. We do not
 			// need to update RectMin parameter since its based on the text corner.
 			//-----------------------------------------------------------------------------
 			item.state.hovered |= ImGui::IsItemHovered();
@@ -6244,7 +6244,7 @@ DearPyGui::draw_tab_button(ImDrawList* drawlist, mvAppItem& item, mvTabButtonCon
 	apply_drag_drop(&item);
 }
 
-void 
+void
 DearPyGui::draw_menu_item(ImDrawList* drawlist, mvAppItem& item, mvMenuItemConfig& config)
 {
 	//-----------------------------------------------------------------------------
@@ -6298,8 +6298,8 @@ DearPyGui::draw_menu_item(ImDrawList* drawlist, mvAppItem& item, mvMenuItemConfi
 		ScopedID id(item.uuid);
 
 		// This is ugly and goes against our style system but its the only widget that ImGui chooses to push the disable color for us
-		// so we have to map our text disable color to the system text disable color, or we can create a new constant which goes agains our 
-		// constants. 
+		// so we have to map our text disable color to the system text disable color, or we can create a new constant which goes agains our
+		// constants.
 		ImGui::PushStyleColor(ImGuiCol_TextDisabled, ImGui::GetStyleColorVec4(ImGuiCol_Text));
 
 		// create menu item and see if its selected
@@ -6704,17 +6704,17 @@ DearPyGui::draw_filter_set(ImDrawList* drawlist, mvAppItem& item, mvFilterSetCon
 
 void
 DearPyGui::draw_separator(ImDrawList* drawlist, mvAppItem& item)
-{ 
-	ImGui::Separator(); 
+{
+	ImGui::Separator();
 }
 
 void
 DearPyGui::draw_spacer(ImDrawList* drawlist, mvAppItem& item)
-{ 
-	if (item.config.width == 0 && item.config.height == 0) 
-		ImGui::Spacing(); 
-	else 
-		ImGui::Dummy({ (float)item.config.width, (float)item.config.height }); 
+{
+	if (item.config.width == 0 && item.config.height == 0)
+		ImGui::Spacing();
+	else
+		ImGui::Dummy({ (float)item.config.width, (float)item.config.height });
 }
 
 void
@@ -6733,7 +6733,7 @@ DearPyGui::draw_menubar(ImDrawList* drawlist, mvAppItem& item)
 	}
 }
 
-void 
+void
 DearPyGui::draw_viewport_menubar(ImDrawList* drawlist, mvAppItem& item)
 {
 	if (ImGui::BeginMainMenuBar())
@@ -6787,7 +6787,7 @@ DearPyGui::draw_tooltip(ImDrawList* drawlist, mvAppItem& item)
 	}
 }
 
-void 
+void
 mvDragIntMulti::setPyValue(PyObject* value)
 {
 	std::vector<int> temp = ToIntVect(value);
@@ -6802,7 +6802,7 @@ mvDragIntMulti::setPyValue(PyObject* value)
 		configData.value = std::make_shared<std::array<int, 4>>(temp_array);
 }
 
-void 
+void
 mvDragFloatMulti::setPyValue(PyObject* value)
 {
 	std::vector<float> temp = ToFloatVect(value);
@@ -6862,7 +6862,7 @@ mvSliderDoubleMulti::setPyValue(PyObject* value)
 		configData.value = std::make_shared<std::array<double, 4>>(temp_array);
 }
 
-void 
+void
 mvSliderIntMulti::setPyValue(PyObject* value)
 {
 	std::vector<int> temp = ToIntVect(value);
@@ -6920,7 +6920,7 @@ mvRadioButton::setPyValue(PyObject* value)
 	}
 }
 
-void 
+void
 mvInputIntMulti::setPyValue(PyObject* value)
 {
 	std::vector<int> temp = ToIntVect(value);
@@ -6935,7 +6935,7 @@ mvInputIntMulti::setPyValue(PyObject* value)
 		configData.value = std::make_shared<std::array<int, 4>>(temp_array);
 }
 
-void 
+void
 mvInputFloatMulti::setPyValue(PyObject* value)
 {
 	std::vector<float> temp = ToFloatVect(value);
@@ -6965,7 +6965,7 @@ mvInputDoubleMulti::setPyValue(PyObject* value)
 		configData.value = std::make_shared<std::array<double, 4>>(temp_array);
 }
 
-void 
+void
 mvFilterSet::setPyValue(PyObject* value)
 {
 	auto str_value = ToString(value);
@@ -6984,7 +6984,7 @@ mvFilterSet::setPyValue(PyObject* value)
 	configData.imguiFilter.Build();
 }
 
-void 
+void
 mvSimplePlot::setPyValue(PyObject* value)
 {
 	*configData.value = ToFloatVect(value);

--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -159,6 +159,13 @@ DearPyGui::fill_configuration_dict(const mvWindowAppItemConfig& inConfig, PyObje
     PyDict_SetItemString(outDict, "collapsed", mvPyObject(ToPyBool(inConfig.collapsed)));
     PyDict_SetItemString(outDict, "min_size", mvPyObject(ToPyPairII(inConfig.min_size.x, inConfig.min_size.y)));
     PyDict_SetItemString(outDict, "max_size", mvPyObject(ToPyPairII(inConfig.max_size.x, inConfig.max_size.y)));
+    if (inConfig.on_close)
+    {
+        Py_XINCREF(inConfig.on_close);
+        PyDict_SetItemString(outDict, "on_close", inConfig.on_close);
+    }
+    else
+        PyDict_SetItemString(outDict, "on_close", GetPyNone());
 
     // helper to check and set bit
     auto checkbitset = [outDict](const char* keyword, int flag, const int& flags)
@@ -166,7 +173,7 @@ DearPyGui::fill_configuration_dict(const mvWindowAppItemConfig& inConfig, PyObje
         PyDict_SetItemString(outDict, keyword, mvPyObject(ToPyBool(flags & flag)));
     };
 
-    // window flags
+        // window flags
     checkbitset("autosize", ImGuiWindowFlags_AlwaysAutoResize, inConfig.windowflags);
     checkbitset("no_resize", ImGuiWindowFlags_NoResize, inConfig.windowflags);
     checkbitset("no_title_bar", ImGuiWindowFlags_NoTitleBar, inConfig.windowflags);

--- a/src/mvNodes.cpp
+++ b/src/mvNodes.cpp
@@ -84,7 +84,8 @@ void mvNodeEditor::getSpecificConfiguration(PyObject* dict)
         Py_XINCREF(_delinkCallback);
         PyDict_SetItemString(dict, "delink_callback", _delinkCallback);
     }
-
+    else
+        PyDict_SetItemString(dict, "delink_callback", GetPyNone());
 
     // helper to check and set bit
     auto checkbitset = [dict](const char* keyword, int flag, const int& flags)

--- a/testing/simple_tests.py
+++ b/testing/simple_tests.py
@@ -186,7 +186,6 @@ class TestItemDetails(unittest.TestCase):
     def setUp(self):
         dpg.create_context()
         self.wndw = dpg.add_window()
-        dpg.push_container_stack(self.wndw)
         dpg.setup_dearpygui()
 
     def test_cfg_on_close_in_mvWindowAppItem(self):
@@ -204,6 +203,22 @@ class TestItemDetails(unittest.TestCase):
         cfg3 = dpg.get_item_configuration(self.wndw)
         self.assertTrue("on_close" in cfg3)
         self.assertTrue(cfg3.get("on_close", 0) is None)
+
+    def test_info_mvItemHandlerRegistry_in_mvAll(self):
+        info1 = dpg.get_item_info(self.wndw)
+        self.assertTrue("handlers" in info1)
+        self.assertTrue(info1.get("handlers", 0) is None)
+
+        ihreg_id = dpg.add_item_handler_registry()
+        dpg.bind_item_handler_registry(self.wndw, ihreg_id)
+        info2 = dpg.get_item_info(self.wndw)
+        self.assertTrue("handlers" in info2)
+        self.assertTrue(info2.get("handlers", 0) == ihreg_id)
+
+        dpg.bind_item_handler_registry(self.wndw, 0)
+        info3 = dpg.get_item_info(self.wndw)
+        self.assertTrue("handlers" in info3)
+        self.assertTrue(info3.get("handlers", 0) is None)
 
     def tearDown(self):
         dpg.stop_dearpygui()

--- a/testing/simple_tests.py
+++ b/testing/simple_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import dearpygui.dearpygui as dpg
 
+
 class TestSimple(unittest.TestCase):
 
     def setUp(self):
@@ -48,7 +49,7 @@ class TestSimple(unittest.TestCase):
 
 
     def test_zelete_items(self):
-        
+
         children = dpg.get_item_children(self.window_id, 1)
 
 class TestDragDrop(unittest.TestCase):
@@ -153,8 +154,8 @@ class TestDragDrop(unittest.TestCase):
                         dpg.add_line_series([0,1,2,3,4,5], [0,1,2,3,4,5], label="data")
 
 
-            self.test_bind_items = dpg.get_item_children(basic, slot=1) 
-            self.test_bind_items += dpg.get_item_children(color, slot=1) 
+            self.test_bind_items = dpg.get_item_children(basic, slot=1)
+            self.test_bind_items += dpg.get_item_children(color, slot=1)
             self.test_bind_items += dpg.get_item_children(containers, slot=1)
             self.test_bind_items += dpg.get_item_children(custom, slot=1)
             self.test_bind_items += dpg.get_item_children(misc, slot=1)
@@ -179,6 +180,37 @@ class TestDragDrop(unittest.TestCase):
                 dpg.add_text(dpg.get_item_type(item))
                 dpg.add_text(f"Item ID: {item}")
             #print(f'[TestDragDrop] Completed bind {dpg.get_item_type(item)}')
+
+
+class TestItemDetails(unittest.TestCase):
+    def setUp(self):
+        dpg.create_context()
+        self.wndw = dpg.add_window()
+        dpg.push_container_stack(self.wndw)
+        dpg.setup_dearpygui()
+
+    def test_cfg_on_close_in_mvWindowAppItem(self):
+        cfg1 = dpg.get_item_configuration(self.wndw)
+        self.assertTrue("on_close" in cfg1)
+        self.assertTrue(cfg1.get("on_close", 0) is None)
+
+        cb_on_close = lambda sender, adata, udata: ...
+        dpg.configure_item(self.wndw, on_close=cb_on_close)
+        cfg2 = dpg.get_item_configuration(self.wndw)
+        self.assertTrue("on_close" in cfg2)
+        self.assertTrue(cfg2.get("on_close", 0) is cb_on_close)
+
+        dpg.configure_item(self.wndw, on_close=None)
+        cfg3 = dpg.get_item_configuration(self.wndw)
+        self.assertTrue("on_close" in cfg3)
+        self.assertTrue(cfg3.get("on_close", 0) is None)
+
+    def tearDown(self):
+        dpg.stop_dearpygui()
+        dpg.destroy_context()
+
+
+
 
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], verbosity=2, exit=should_exit)

--- a/testing/simple_tests.py
+++ b/testing/simple_tests.py
@@ -226,11 +226,21 @@ class TestItemDetails(unittest.TestCase):
         self.assertTrue("multline" not in cfg)
         self.assertTrue("multiline" in cfg)
 
+    def test_cfg_delink_callback_in_mvNodeEditor(self):
+        node_editor = dpg.add_node_editor(parent=self.wndw)
+        cfg1 = dpg.get_item_configuration(node_editor)
+        self.assertTrue("delink_callback" in cfg1)
+        self.assertTrue(cfg1.get("delink_callback", 0) is None)
+
+        dl_cb = lambda *args: ...
+        dpg.configure_item(node_editor, delink_callback=dl_cb)
+        cfg2 = dpg.get_item_configuration(node_editor)
+        self.assertTrue("delink_callback" in cfg2)
+        self.assertTrue(cfg2.get("delink_callback", 0) is dl_cb)
+
     def tearDown(self):
         dpg.stop_dearpygui()
         dpg.destroy_context()
-
-
 
 
 if __name__ == '__main__':

--- a/testing/simple_tests.py
+++ b/testing/simple_tests.py
@@ -220,6 +220,12 @@ class TestItemDetails(unittest.TestCase):
         self.assertTrue("handlers" in info3)
         self.assertTrue(info3.get("handlers", 0) is None)
 
+    def test_cfg_multiline_in_mvInputText(self):
+        input_txt = dpg.add_input_text(parent=self.wndw)
+        cfg = dpg.get_item_configuration(input_txt)
+        self.assertTrue("multline" not in cfg)
+        self.assertTrue("multiline" in cfg)
+
     def tearDown(self):
         dpg.stop_dearpygui()
         dpg.destroy_context()


### PR DESCRIPTION
**Description:**
* `mvWindowAppItem::getSpecificConfiguration` now includes `on_close`
* `mvNodeEditor::getSpecificConfiguration` now includes `delink_callback` even when null/None (was previously only included when not null/None)
* `mvInputText::getSpecificConfiguration` outDict key "multline" corrected to "mult**i**line"
* Included an item's bound item handler registry in the `get_item_info` output dict as "handers"

**Concerning Areas:**
The change to `mvInputText::getSpecificConfiguration` is technically a breaking change. However, I do not think it is an option commonly accessed (unlike something like "width"). This change is likely to go unnoticed by a vast majority of users.

(my editor trimmed a lot of trailing whitespace, sorry 😓)
