### PR TITLE
Fixing Issue 1130 decorated=false being wrong with primary_window

### DIFF
--- a/src/mvViewport_win32.cpp
+++ b/src/mvViewport_win32.cpp
@@ -157,8 +157,8 @@ mvHandleMsg(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) noexcept
 			}
 			else
 			{
-				GContext->viewport->clientHeight = cheight + 39;
-				GContext->viewport->clientWidth = cwidth + 16;
+				GContext->viewport->clientHeight = cheight;
+				GContext->viewport->clientWidth = cwidth;
 			}
 
 			//GContext->viewport->resized = true;
@@ -232,8 +232,8 @@ mvHandleMsg(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) noexcept
 			}
 			else
 			{
-				GContext->viewport->clientHeight = cheight + 39;
-				GContext->viewport->clientWidth = cwidth + 16;
+				GContext->viewport->clientHeight = cheight;
+				GContext->viewport->clientWidth = cwidth;
 			}
 				
 			GContext->viewport->resized = true;


### PR DESCRIPTION
---
name: Pull Request
about: Fixing the Issue #1130 
title: Fixing the Issue #1130 
assignees: @hoffstadt 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->
Closes #1130 

**Description:**
<!-- A clear and concise description of what the pull request contains. -->
This pullrequest contains the fix for the incorrectly displayed window in the viewport when the window is declared as primary window and decorated=True.

In an older fix, a fix was made for the decorated=True option that set the correct flag in the OS (Windows). By setting the correct flag, the two additional values are no longer needed.

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
not one