### PR TITLE
Fixing Issue 1867 Nuitka Compiler Problems

### DIFF
--- a/src/mvCallbackRegistry.cpp
+++ b/src/mvCallbackRegistry.cpp
@@ -159,20 +159,19 @@ void mvRunCallback(PyObject* callable, const std::string& sender, PyObject* app_
 		if (ac) {
 			i32 count = PyLong_AsLong(ac);
 
-			if (PyMethod_Check(callable))
-				count--;
+			PyObject* m_pythonFunc = PyMethod_GET_FUNCTION(callable);
 
 			if (count > 3)
 			{
 				mvPyObject pArgs(PyTuple_New(count));
-				PyTuple_SetItem(pArgs, 0, ToPyString(sender));
-				PyTuple_SetItem(pArgs, 1, app_data); // steals data, so don't deref
-				PyTuple_SetItem(pArgs, 2, user_data); // steals data, so don't deref
+				PyTuple_SetItem(pArgs, 0, GetPyNone()); // remove self.
+				PyTuple_SetItem(pArgs, 1, ToPyString(sender));
+				PyTuple_SetItem(pArgs, 2, app_data); // steals data, so don't deref
+				PyTuple_SetItem(pArgs, 3, user_data); // steals data, so don't deref
 
-				for (int i = 3; i < count; i++)
-					PyTuple_SetItem(pArgs, i, GetPyNone());
+				mvPyObject result(PyObject_CallObject(m_pythonFunc, pArgs));
 
-				mvPyObject result(PyObject_CallObject(callable, pArgs));
+				pArgs.delRef();
 
 				// check if call succeeded
 				if (!result.isOk())
@@ -285,20 +284,19 @@ void mvRunCallback(PyObject* callable, mvUUID sender, PyObject* app_data, PyObje
 		if (ac) {
 			i32 count = PyLong_AsLong(ac);
 
-			if (PyMethod_Check(callable))
-				count--;
+			PyObject* m_pythonFunc = PyMethod_GET_FUNCTION(callable);
 
 			if (count > 3)
 			{
 				mvPyObject pArgs(PyTuple_New(count));
-				PyTuple_SetItem(pArgs, 0, ToPyUUID(sender));
-				PyTuple_SetItem(pArgs, 1, app_data); // steals data, so don't deref
-				PyTuple_SetItem(pArgs, 2, user_data); // steals data, so don't deref
+				PyTuple_SetItem(pArgs, 0, GetPyNone()); // remove self.
+				PyTuple_SetItem(pArgs, 1, ToPyUUID(sender));
+				PyTuple_SetItem(pArgs, 2, app_data); // steals data, so don't deref
+				PyTuple_SetItem(pArgs, 3, user_data); // steals data, so don't deref
 					
-				for (int i = 3; i < count; i++)
-					PyTuple_SetItem(pArgs, i, GetPyNone());
+				mvPyObject result(PyObject_CallObject(m_pythonFunc, pArgs));
 
-				mvPyObject result(PyObject_CallObject(callable, pArgs));
+				pArgs.delRef();
 
 				// check if call succeeded
 				if (!result.isOk())


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Fixing the Nuitka Compiler Issues with Classes
assignees: @hoffstadt 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->
Closes #1867 

**Description:**
<!-- A clear and concise description of what the pull request contains. -->
To ensure that the callback from a class is processed correctly, if it has more than 3 callables the first value is set to None ( self ) the other parameters remain as they are.
**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->

I testet with normal Callbacks, lambda Callbacks, class callbacks, exit Callback:

```python
import dearpygui.dearpygui as dpg

dpg.create_context()
dpg.create_viewport(height=200, width=200)
dpg.setup_dearpygui()


def say_goodbye():
    print('GOODBYE !')


# works
def cb_button1(sender, app_data, user_data):
    print(f"sender: {sender} {app_data} {user_data}")


class myClass(object):

    def __init__(self):
        pass

    # throws num arguments error
    def cb_button2(self, sender, app_data, user_data):
        print(f"sender: {sender} {app_data} {user_data}")


myclass = myClass()

with dpg.window(label="Example", height=100, width=100):
    text = dpg.add_text("Hello world")
    dpg.add_button(tag="b1", label="Button1", callback=cb_button1)
    dpg.add_checkbox(tag="b2", label="CB", user_data="Test", callback=myclass.cb_button2)
    dpg.add_button(label="Lambda Hide", callback=lambda s, a, u: dpg.configure_item(text, show=False))
    dpg.add_button(label="Lambda Show", callback=lambda s, a, u: dpg.configure_item(text, show=True))

    dpg.set_exit_callback(say_goodbye)

dpg.show_viewport()
dpg.start_dearpygui()
dpg.destroy_context()
```



