### PR TITLE
Bugfix/1997 drawing thickness

### DIFF
--- a/src/mvDrawings.cpp
+++ b/src/mvDrawings.cpp
@@ -104,16 +104,16 @@ void mvDrawArrow::draw(ImDrawList* drawlist, float x, float y)
 
 	if (ImPlot::GetCurrentContext()->CurrentPlot)
 	{
-		drawlist->AddLine(ImPlot::PlotToPixels(tp1), ImPlot::PlotToPixels(tp1), _color, (float)ImPlot::GetCurrentContext()->Mx * _thickness);
-		drawlist->AddTriangle(ImPlot::PlotToPixels(tpp1), ImPlot::PlotToPixels(tpp2), ImPlot::PlotToPixels(tpp3), _color, (float)ImPlot::GetCurrentContext()->Mx * _thickness);
 		drawlist->AddTriangleFilled(ImPlot::PlotToPixels(tpp1), ImPlot::PlotToPixels(tpp2), ImPlot::PlotToPixels(tpp3), _color);
+		drawlist->AddLine(ImPlot::PlotToPixels(tp1), ImPlot::PlotToPixels(tp2), _color, (float)ImPlot::GetCurrentContext()->Mx * _thickness);
+		drawlist->AddTriangle(ImPlot::PlotToPixels(tpp1), ImPlot::PlotToPixels(tpp2), ImPlot::PlotToPixels(tpp3), _color, (float)ImPlot::GetCurrentContext()->Mx * _thickness);
 	}
 	else
 	{
 		mvVec2 start = { x, y };
+		drawlist->AddTriangleFilled(tpp1 + start, tpp2 + start, tpp3 + start, _color);
 		drawlist->AddLine(tp1 + start, tp2 + start, _color, _thickness);
 		drawlist->AddTriangle(tpp1 + start, tpp2 + start, tpp3 + start, _color, _thickness);
-		drawlist->AddTriangleFilled(tpp1 + start, tpp2 + start, tpp3 + start, _color);
 	}
 }
 
@@ -519,15 +519,14 @@ void mvDrawEllipse::draw(ImDrawList* drawlist, float x, float y)
 		}
 	}
 
+	if (_fill.r >= 0.0f)
+		drawlist->AddConvexPolyFilled(finalpoints.data(), (int)finalpoints.size(), _fill);
 	if (ImPlot::GetCurrentContext()->CurrentPlot)
 		drawlist->AddPolyline(finalpoints.data(), (int)finalpoints.size(),
 			_color, false, ImPlot::GetCurrentContext()->Mx * _thickness);
 	else
 		drawlist->AddPolyline(finalpoints.data(), (int)finalpoints.size(),
 			_color, false, _thickness);
-	if (_fill.r < 0.0f)
-		return;
-	drawlist->AddConvexPolyFilled(finalpoints.data(), (int)finalpoints.size(), _fill);
 }
 
 void mvDrawEllipse::handleSpecificRequiredArgs(PyObject* dict)
@@ -1185,11 +1184,8 @@ void mvDrawPolygon::draw(ImDrawList* drawlist, float x, float y)
 			finalpoints.push_back(ImVec2{ point.x, point.y });
 		}
 	}
-	// TODO: Find a way to store lines and only calc new fill lines when dirty similar to ellipse
-	drawlist->AddPolyline(finalpoints.data(), (int)finalpoints.size(), _color, false, _thickness);
-	if (_fill.r < 0.0f)
-		return;
 
+	if (_fill.r >= 0.0f)
 	{
 		size_t i;
 		int y;
@@ -1267,6 +1263,8 @@ void mvDrawPolygon::draw(ImDrawList* drawlist, float x, float y)
 		}
 		delete[] polyints;
 	}
+	// TODO: Find a way to store lines and only calc new fill lines when dirty similar to ellipse
+	drawlist->AddPolyline(finalpoints.data(), (int)finalpoints.size(), _color, false, _thickness);
 }
 
 void mvDrawPolygon::handleSpecificRequiredArgs(PyObject* dict)
@@ -1453,20 +1451,18 @@ void mvDrawQuad::draw(ImDrawList* drawlist, float x, float y)
 
 	if (ImPlot::GetCurrentContext()->CurrentPlot)
 	{
+		if (_fill.r >= 0.0f)
+			drawlist->AddQuadFilled(ImPlot::PlotToPixels(tp1), ImPlot::PlotToPixels(tp2), ImPlot::PlotToPixels(tp3),
+				ImPlot::PlotToPixels(tp4), _fill);
 		drawlist->AddQuad(ImPlot::PlotToPixels(tp1), ImPlot::PlotToPixels(tp2), ImPlot::PlotToPixels(tp3),
 			ImPlot::PlotToPixels(tp4), _color, ImPlot::GetCurrentContext()->Mx * _thickness);
-		if (_fill.r < 0.0f)
-			return;
-		drawlist->AddQuadFilled(ImPlot::PlotToPixels(tp1), ImPlot::PlotToPixels(tp2), ImPlot::PlotToPixels(tp3),
-			ImPlot::PlotToPixels(tp4), _fill);
 	}
 	else
 	{
 		mvVec2 start = { x, y };
+		if (_fill.r >= 0.0f)
+			drawlist->AddQuadFilled(tp1 + start, tp2 + start, tp3 + start, tp4 + start, _fill);
 		drawlist->AddQuad(tp1 + start, tp2 + start, tp3 + start, tp4 + start, _color, _thickness);
-		if (_fill.r < 0.0f)
-			return;
-		drawlist->AddQuadFilled(tp1 + start, tp2 + start, tp3 + start, tp4 + start, _fill);
 	}
 }
 
@@ -1561,29 +1557,21 @@ void mvDrawRect::draw(ImDrawList* drawlist, float x, float y)
 
 	if (ImPlot::GetCurrentContext()->CurrentPlot)
 	{
+		if (_multicolor)
+			drawlist->AddRectFilledMultiColor(ImPlot::PlotToPixels(tpmin), ImPlot::PlotToPixels(tpmax), _color_bottom_right, _color_bottom_left, _color_upper_left, _color_upper_right);
+		else if (_fill.r >= 0.0f)
+			drawlist->AddRectFilled(ImPlot::PlotToPixels(tpmin), ImPlot::PlotToPixels(tpmax), _fill, ImPlot::GetCurrentContext()->Mx * _rounding, ImDrawCornerFlags_All);
 		drawlist->AddRect(ImPlot::PlotToPixels(tpmin), ImPlot::PlotToPixels(tpmax), _color,
 			ImPlot::GetCurrentContext()->Mx * _rounding, ImDrawCornerFlags_All, ImPlot::GetCurrentContext()->Mx * _thickness);
-		if (_multicolor)
-		{
-			drawlist->AddRectFilledMultiColor(ImPlot::PlotToPixels(tpmin), ImPlot::PlotToPixels(tpmax), _color_bottom_right, _color_bottom_left, _color_upper_left, _color_upper_right);
-			return;
-		}
-		if (_fill.r < 0.0f)
-			return;
-		drawlist->AddRectFilled(ImPlot::PlotToPixels(tpmin), ImPlot::PlotToPixels(tpmax), _fill, ImPlot::GetCurrentContext()->Mx * _rounding, ImDrawCornerFlags_All);
 	}
 	else
 	{
 		mvVec2 start = { x, y };
-		drawlist->AddRect(tpmin + start, tpmax + start, _color, _rounding, ImDrawCornerFlags_All, _thickness);
 		if (_multicolor)
-		{
 			drawlist->AddRectFilledMultiColor(tpmin + start, tpmax + start, _color_bottom_right, _color_bottom_left, _color_upper_left, _color_upper_right);
-			return;
-		}
-		if (_fill.r < 0.0f)
-			return;
-		drawlist->AddRectFilled(tpmin + start, tpmax + start, _fill, _rounding, ImDrawCornerFlags_All);
+		else if (_fill.r >= 0.0f)
+			drawlist->AddRectFilled(tpmin + start, tpmax + start, _fill, _rounding, ImDrawCornerFlags_All);
+		drawlist->AddRect(tpmin + start, tpmax + start, _color, _rounding, ImDrawCornerFlags_All, _thickness);
 	}
 }
 
@@ -1762,20 +1750,20 @@ void mvDrawTriangle::draw(ImDrawList* drawlist, float x, float y)
 
 	if (ImPlot::GetCurrentContext()->CurrentPlot)
 	{
+		if (_fill.r >= 0.0f)
+		{
+			drawlist->AddTriangleFilled(ImPlot::PlotToPixels(tp1), ImPlot::PlotToPixels(tp2), ImPlot::PlotToPixels(tp3),
+				_fill);
+		}
 		drawlist->AddTriangle(ImPlot::PlotToPixels(tp1), ImPlot::PlotToPixels(tp2), ImPlot::PlotToPixels(tp3),
 			_color, ImPlot::GetCurrentContext()->Mx * _thickness);
-		if (_fill.r < 0.0f)
-			return;
-		drawlist->AddTriangleFilled(ImPlot::PlotToPixels(tp1), ImPlot::PlotToPixels(tp2), ImPlot::PlotToPixels(tp3),
-			_fill);
 	}
 	else
 	{
 		mvVec2 start = { x, y };
+		if (_fill.r >= 0.0f)
+			drawlist->AddTriangleFilled(tp1 + start, tp2 + start, tp3 + start, _fill);
 		drawlist->AddTriangle(tp1 + start, tp2 + start, tp3 + start, _color, _thickness);
-		if (_fill.r < 0.0f)
-			return;
-		drawlist->AddTriangleFilled(tp1 + start, tp2 + start, tp3 + start, _fill);
 	}
 }
 

--- a/src/mvDrawings.cpp
+++ b/src/mvDrawings.cpp
@@ -385,19 +385,17 @@ void mvDrawCircle::draw(ImDrawList* drawlist, float x, float y)
 
 	if (ImPlot::GetCurrentContext()->CurrentPlot)
 	{
+		if (_fill.r >= 0.0f)
+			drawlist->AddCircleFilled(ImPlot::PlotToPixels(tcenter), ImPlot::GetCurrentContext()->Mx * _radius, _fill, _segments);
 		drawlist->AddCircle(ImPlot::PlotToPixels(tcenter), ImPlot::GetCurrentContext()->Mx * _radius, _color,
 			ImPlot::GetCurrentContext()->Mx * _segments, _thickness);
-		if (_fill.r < 0.0f)
-			return;
-		drawlist->AddCircleFilled(ImPlot::PlotToPixels(tcenter), ImPlot::GetCurrentContext()->Mx * _radius, _fill, _segments);
 	}
 	else
 	{
 		mvVec2 start = { x, y };
+		if (_fill.r >= 0.0f)
+			drawlist->AddCircleFilled(tcenter + start, _radius, _fill, _segments);
 		drawlist->AddCircle(tcenter + start, _radius, _color, _segments, _thickness);
-		if (_fill.r < 0.0f)
-			return;
-		drawlist->AddCircleFilled(tcenter + start, _radius, _fill, _segments);
 	}
 }
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Drawing API: outline thickness on screen is half of the specified 'thickness' value
assignees: @hoffstadt

---

Closes #1997 

**Description:**
This fix reverts the rendering order in Drawing API so that for each primitive, background is filled first and only then the outline is drawn. This prevents background from partially covering the outline and thus reducing its width.

**Concerning Areas:**
Some users might have used larger thickness (e.g. 2 pixels) to make outline visible - they'll need to change their code to use the actual pixel width of the outline, e.g. thickness=1 if they need a 1-pixel outline.
