### PR TITLE
fix: a horizontal group glues to previous line (#1999)

### DIFF
--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -1138,7 +1138,7 @@ DearPyGui::draw_group(ImDrawList* drawlist, mvAppItem& item, mvGroupConfig& conf
 
             child->draw(drawlist, ImGui::GetCursorPosX(), ImGui::GetCursorPosY());
 
-            if (config.horizontal)
+            if (config.horizontal && child->config.show)
                 ImGui::SameLine((1 + child->info.location) * config.xoffset, config.hspacing);
 
             if (child->config.tracked)


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: A horizontal group sticks to the previous line if the first child is hidden
assignees: @hoffstadt 

---

Closes #1999 

**Description:**
A group with horizontal=True now doesn't call ImGui::SameLine() after hidden children - those with config.show==false.

It doesn't make much sense to call ImGui::SameLine() twice in a row (if a child somewhere in the middle was hidden), and calling it after the first child (if it's hidden) can actually break things.

**Concerning Areas:**
None.