### PR TITLE
fix: initial position for dpg.window with popup=True (#1975)

### DIFF
--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -373,8 +373,11 @@ DearPyGui::set_configuration(PyObject* inDict, mvAppItem& itemc, mvWindowAppItem
 
     if (PyObject* item = PyDict_GetItemString(inDict, "label"))
     {
-        itemc.info.dirtyPos = true;
-        itemc.info.dirty_size = true;
+        if (item != Py_None)
+        {
+            itemc.info.dirtyPos = true;
+            itemc.info.dirty_size = true;
+        }
     }
 
     if (PyObject* item = PyDict_GetItemString(inDict, "no_open_over_existing_popup")) outConfig.no_open_over_existing_popup = ToBool(item);


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: A window with popup=True is positioned incorrectly
assignees: @hoffstadt 

---

Closes #1975 

**Description:**
A window can be positioned at the mouse cursor automatically - this auto-positioning is used unless the window got a label at creation. However, the way all calls to DPG API are routed to `internal_dpg`, the C++ implementation gets all possible parameters no matter whether the user specified them on the initial call. That is, even for `dpg.window()` without `label=something`, C++ will see `label=None` passed in.

This fix corrects auto-positioning by additionally checking that the label is not None.

**Concerning Areas:**
None.