### PR TITLE
feat: double-click handlers for items

### DIFF
--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -5079,6 +5079,29 @@ def add_item_clicked_handler(button : int =-1, *, label: str =None, user_data: A
 
 	return internal_dpg.add_item_clicked_handler(button, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, callback=callback, show=show, **kwargs)
 
+def add_item_double_clicked_handler(button : int =-1, *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, callback: Callable =None, show: bool =True, **kwargs) -> Union[int, str]:
+	"""	 Adds a double-click handler.
+
+	Args:
+		button (int, optional): Submits callback for all mouse buttons
+		label (str, optional): Overrides 'name' as label.
+		user_data (Any, optional): User data for callbacks
+		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
+		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
+		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
+		callback (Callable, optional): Registers a callback.
+		show (bool, optional): Attempt to render widget.
+		id (Union[int, str], optional): (deprecated) 
+	Returns:
+		Union[int, str]
+	"""
+
+	if 'id' in kwargs.keys():
+		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
+		tag=kwargs['id']
+
+	return internal_dpg.add_item_double_clicked_handler(button, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, callback=callback, show=show, **kwargs)
+
 def add_item_deactivated_after_edit_handler(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, callback: Callable =None, show: bool =True, **kwargs) -> Union[int, str]:
 	"""	 Adds a deactivated after edit handler.
 

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -1038,6 +1038,7 @@ DearPyGui::GetEntityDesciptionFlags(mvAppItemType type)
     case mvAppItemType::mvActivatedHandler:
     case mvAppItemType::mvActiveHandler:
     case mvAppItemType::mvClickedHandler:
+    case mvAppItemType::mvDoubleClickedHandler:
     case mvAppItemType::mvDeactivatedAfterEditHandler:
     case mvAppItemType::mvDeactivatedHandler:
     case mvAppItemType::mvEditedHandler:
@@ -1248,6 +1249,7 @@ DearPyGui::GetAllowableParents(mvAppItemType type)
     case mvAppItemType::mvActivatedHandler:
     case mvAppItemType::mvActiveHandler:
     case mvAppItemType::mvClickedHandler:
+    case mvAppItemType::mvDoubleClickedHandler:
     case mvAppItemType::mvDeactivatedAfterEditHandler:
     case mvAppItemType::mvDeactivatedHandler:
     case mvAppItemType::mvEditedHandler:
@@ -1562,6 +1564,7 @@ DearPyGui::GetAllowableChildren(mvAppItemType type)
         MV_ADD_CHILD(mvAppItemType::mvActivatedHandler),
         MV_ADD_CHILD(mvAppItemType::mvActiveHandler),
         MV_ADD_CHILD(mvAppItemType::mvClickedHandler),
+        MV_ADD_CHILD(mvAppItemType::mvDoubleClickedHandler),
         MV_ADD_CHILD(mvAppItemType::mvDeactivatedAfterEditHandler),
         MV_ADD_CHILD(mvAppItemType::mvDeactivatedHandler),
         MV_ADD_CHILD(mvAppItemType::mvEditedHandler),
@@ -1642,6 +1645,7 @@ DearPyGui::GetAllowableChildren(mvAppItemType type)
         MV_ADD_CHILD(mvAppItemType::mvActivatedHandler),
         MV_ADD_CHILD(mvAppItemType::mvActiveHandler),
         MV_ADD_CHILD(mvAppItemType::mvClickedHandler),
+        MV_ADD_CHILD(mvAppItemType::mvDoubleClickedHandler),
         MV_ADD_CHILD(mvAppItemType::mvDeactivatedAfterEditHandler),
         MV_ADD_CHILD(mvAppItemType::mvDeactivatedHandler),
         MV_ADD_CHILD(mvAppItemType::mvEditedHandler),
@@ -1662,6 +1666,7 @@ DearPyGui::GetAllowableChildren(mvAppItemType type)
         MV_ADD_CHILD(mvAppItemType::mvActivatedHandler),
         MV_ADD_CHILD(mvAppItemType::mvActiveHandler),
         MV_ADD_CHILD(mvAppItemType::mvClickedHandler),
+        MV_ADD_CHILD(mvAppItemType::mvDoubleClickedHandler),
         MV_ADD_CHILD(mvAppItemType::mvDeactivatedAfterEditHandler),
         MV_ADD_CHILD(mvAppItemType::mvDeactivatedHandler),
         MV_ADD_CHILD(mvAppItemType::mvEditedHandler),
@@ -1677,6 +1682,7 @@ DearPyGui::GetAllowableChildren(mvAppItemType type)
         MV_ADD_CHILD(mvAppItemType::mvNodeAttribute),
         MV_ADD_CHILD(mvAppItemType::mvActiveHandler),
         MV_ADD_CHILD(mvAppItemType::mvClickedHandler),
+        MV_ADD_CHILD(mvAppItemType::mvDoubleClickedHandler),
         MV_ADD_CHILD(mvAppItemType::mvHoverHandler),
         MV_ADD_CHILD(mvAppItemType::mvVisibleHandler),
         MV_ADD_CHILD(mvAppItemType::mvDragPayload),
@@ -1758,6 +1764,7 @@ DearPyGui::GetAllowableChildren(mvAppItemType type)
         MV_ADD_CHILD(mvAppItemType::mvActivatedHandler),
         MV_ADD_CHILD(mvAppItemType::mvActiveHandler),
         MV_ADD_CHILD(mvAppItemType::mvClickedHandler),
+        MV_ADD_CHILD(mvAppItemType::mvDoubleClickedHandler),
         MV_ADD_CHILD(mvAppItemType::mvDeactivatedAfterEditHandler),
         MV_ADD_CHILD(mvAppItemType::mvDeactivatedHandler),
         MV_ADD_CHILD(mvAppItemType::mvEditedHandler),
@@ -4835,6 +4842,21 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         args.push_back({ mvPyDataType::Integer, "button", mvArgType::POSITIONAL_ARG, "-1", "Submits callback for all mouse buttons" });
 
         setup.about = "Adds a clicked handler.";
+        setup.category = { "Widgets", "Events" };
+        break;
+    }
+    case mvAppItemType::mvDoubleClickedHandler:              
+    {
+        AddCommonArgs(args, (CommonParserArgs)(
+            MV_PARSER_ARG_ID |
+            MV_PARSER_ARG_SHOW |
+            MV_PARSER_ARG_PARENT |
+            MV_PARSER_ARG_CALLBACK)
+        );
+
+        args.push_back({ mvPyDataType::Integer, "button", mvArgType::POSITIONAL_ARG, "-1", "Submits callback for all mouse buttons" });
+
+        setup.about = "Adds a double click handler.";
         setup.category = { "Widgets", "Events" };
         break;
     }

--- a/src/mvAppItem.h
+++ b/src/mvAppItem.h
@@ -371,6 +371,7 @@ GetEntityCommand(mvAppItemType type)
     case mvAppItemType::mvDeactivatedAfterEditHandler: return "add_item_deactivated_after_edit_handler";
     case mvAppItemType::mvToggledOpenHandler:          return "add_item_toggled_open_handler";
     case mvAppItemType::mvClickedHandler:              return "add_item_clicked_handler";
+    case mvAppItemType::mvDoubleClickedHandler:        return "add_item_double_clicked_handler";
     case mvAppItemType::mvDragPayload:                 return "add_drag_payload";
     case mvAppItemType::mvResizeHandler:               return "add_item_resize_handler";
     case mvAppItemType::mvFont:                        return "add_font";

--- a/src/mvAppItemState.cpp
+++ b/src/mvAppItemState.cpp
@@ -13,6 +13,7 @@ ResetAppItemState(mvAppItemState& state)
     state.leftclicked = false;
     state.rightclicked = false;
     state.middleclicked = false;
+    state.doubleclicked.fill(false);
     state.visible = false;
     state.edited = false;
     state.activated = false;
@@ -32,6 +33,10 @@ UpdateAppItemState(mvAppItemState& state)
     state.leftclicked = ImGui::IsItemClicked();
     state.rightclicked = ImGui::IsItemClicked(1);
     state.middleclicked = ImGui::IsItemClicked(2);
+    for (int i = 0; i < state.doubleclicked.size(); i++)
+    {
+        state.doubleclicked[i] = IsItemDoubleClicked(i);
+    }
     state.visible = ImGui::IsItemVisible();
     state.edited = ImGui::IsItemEdited();
     state.activated = ImGui::IsItemActivated();

--- a/src/mvAppItemState.h
+++ b/src/mvAppItemState.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mvCore.h"
+#include <array>
 
 #ifndef PyObject_HEAD
 struct _object;
@@ -57,6 +58,11 @@ b8 IsItemDeactivatedAfterEdit(mvAppItemState& state, i32 frameDelay = 0);
 b8 IsItemToogledOpen         (mvAppItemState& state, i32 frameDelay = 0);
 b8 IsItemRectSizeResized     (mvAppItemState& state, i32 frameDelay = 0);
 
+inline b8 IsItemDoubleClicked(ImGuiMouseButton mouse_button)
+{
+    return ImGui::IsMouseDoubleClicked(mouse_button) && ImGui::IsItemHovered(ImGuiHoveredFlags_None);
+}
+
 struct mvAppItemState
 {
     b8         hovered              = false;
@@ -65,6 +71,7 @@ struct mvAppItemState
     b8         leftclicked          = false;
     b8         rightclicked         = false;
     b8         middleclicked        = false;
+    std::array<b8, 5> doubleclicked = {};
     b8         visible              = false;
     b8         edited               = false;
     b8         activated            = false;

--- a/src/mvAppItemTypes.inc
+++ b/src/mvAppItemTypes.inc
@@ -126,6 +126,7 @@
     X( mvDeactivatedAfterEditHandler ) \
     X( mvToggledOpenHandler ) \
     X( mvClickedHandler ) \
+    X( mvDoubleClickedHandler ) \
     X( mvDragPayload ) \
     X( mvResizeHandler ) \
     X( mvFont ) \

--- a/src/mvBasicWidgets.cpp
+++ b/src/mvBasicWidgets.cpp
@@ -3034,6 +3034,10 @@ DearPyGui::draw_simple_plot(ImDrawList* drawlist, mvAppItem& item, const mvSimpl
 	item.state.leftclicked = ImGui::IsItemClicked();
 	item.state.rightclicked = ImGui::IsItemClicked(1);
 	item.state.middleclicked = ImGui::IsItemClicked(2);
+    for (int i = 0; i < item.state.doubleclicked.size(); i++)
+    {
+        item.state.doubleclicked[i] = IsItemDoubleClicked(i);
+    }
 	item.state.visible = ImGui::IsItemVisible();
 	item.state.rectMin = { ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y };
 	item.state.rectMax = { ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y };
@@ -4885,6 +4889,10 @@ DearPyGui::draw_radio_button(ImDrawList* drawlist, mvAppItem& item, mvRadioButto
 	item.state.leftclicked = ImGui::IsItemClicked();
 	item.state.rightclicked = ImGui::IsItemClicked(1);
 	item.state.middleclicked = ImGui::IsItemClicked(2);
+    for (int i = 0; i < item.state.doubleclicked.size(); i++)
+    {
+        item.state.doubleclicked[i] = IsItemDoubleClicked(i);
+    }
 	item.state.visible = ImGui::IsItemVisible();
 	item.state.activated = ImGui::IsItemActivated();
 	item.state.deactivated = ImGui::IsItemDeactivated();
@@ -6020,6 +6028,10 @@ DearPyGui::draw_text(ImDrawList* drawlist, mvAppItem& item, mvTextConfig& config
 			item.state.leftclicked |= ImGui::IsItemClicked();
 			item.state.rightclicked |= ImGui::IsItemClicked(1);
 			item.state.middleclicked |= ImGui::IsItemClicked(2);
+			for (int i = 0; i < item.state.doubleclicked.size(); i++)
+			{
+				item.state.doubleclicked[i] = IsItemDoubleClicked(i);
+			}
 			item.state.visible |= ImGui::IsItemVisible();
 			item.state.edited |= ImGui::IsItemEdited();
 			item.state.activated |= ImGui::IsItemActivated();

--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -853,6 +853,10 @@ DearPyGui::draw_tab(ImDrawList* drawlist, mvAppItem& item, mvTabConfig& config)
             item.state.leftclicked = ImGui::IsItemClicked();
             item.state.rightclicked = ImGui::IsItemClicked(1);
             item.state.middleclicked = ImGui::IsItemClicked(2);
+            for (int i = 0; i < item.state.doubleclicked.size(); i++)
+            {
+                item.state.doubleclicked[i] = IsItemDoubleClicked(i);
+            }
             item.state.visible = ImGui::IsItemVisible();
             item.state.activated = ImGui::IsItemActivated();
             item.state.deactivated = ImGui::IsItemDeactivated();
@@ -897,6 +901,10 @@ DearPyGui::draw_tab(ImDrawList* drawlist, mvAppItem& item, mvTabConfig& config)
             item.state.leftclicked = ImGui::IsItemClicked();
             item.state.rightclicked = ImGui::IsItemClicked(1);
             item.state.middleclicked = ImGui::IsItemClicked(2);
+            for (int i = 0; i < item.state.doubleclicked.size(); i++)
+            {
+                item.state.doubleclicked[i] = IsItemDoubleClicked(i);
+            }
             item.state.visible = ImGui::IsItemVisible();
             item.state.activated = ImGui::IsItemActivated();
             item.state.deactivated = ImGui::IsItemDeactivated();

--- a/src/mvItemHandlers.h
+++ b/src/mvItemHandlers.h
@@ -45,6 +45,19 @@ public:
     void applySpecificTemplate(mvAppItem* item) override;
 };
 
+class mvDoubleClickedHandler : public mvAppItem
+{
+public:
+    int _button = -1;
+    explicit mvDoubleClickedHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    void draw(ImDrawList* drawlist, float x, float y) override {}
+    void customAction(void* data = nullptr) override;
+    void handleSpecificRequiredArgs(PyObject* dict) override;
+    void handleSpecificKeywordArgs(PyObject* dict) override;
+    void getSpecificConfiguration(PyObject* dict) override;
+    void applySpecificTemplate(mvAppItem* item) override;
+};
+
 class mvDeactivatedAfterEditHandler : public mvAppItem
 {
 public:

--- a/src/mvNodes.cpp
+++ b/src/mvNodes.cpp
@@ -449,6 +449,10 @@ void mvNode::draw(ImDrawList* drawlist, float x, float y)
         state.leftclicked = ImGui::IsItemClicked();
         state.rightclicked = ImGui::IsItemClicked(1);
         state.middleclicked = ImGui::IsItemClicked(2);
+        for (int i = 0; i < state.doubleclicked.size(); i++)
+        {
+            state.doubleclicked[i] = IsItemDoubleClicked(i);
+        }
         state.visible = ImGui::IsItemVisible();
 
         for (auto& item : childslots[1])


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Allow double_click_handler to be bound to items
assignees: @hoffstadt 

---

Closes #1534 

**Description:**
Added a double-click handler for items, modeled after the regular click handler, but with appropriate click flags being pulled from ImGui.

**Concerning Areas:**
None.