### PR TITLE
Minor demo fix: show menubar

### DIFF
--- a/dearpygui/demo.py
+++ b/dearpygui/demo.py
@@ -963,7 +963,7 @@ def show_demo():
 
             with dpg.tree_node(label="Simple Layouts"):
                 dpg.add_text("Containers can be nested for advanced layout options")
-                with dpg.child_window(width=500, height=320):
+                with dpg.child_window(width=500, height=320, menubar=True):
                     with dpg.menu_bar():
                         dpg.add_menu(label="Menu Options")
                     with dpg.child_window(autosize_x=True, height=95):


### PR DESCRIPTION
assignees: @hoffstadt

---
**Description:**

The demo application, in section `Simple Layouts`, performs the following:
 * creates a `menubar`, 
 * adds a `menu` labeled `Menu Options`

However, that `menubar` is never visible because its owner window was not created with `menubar=True`.

This PR sets the owner window to be created with `menubar=True`.
 

**Concerning Areas:**
See diff, lines 966 to 968
