### PR TITLE
fix: error handling for DwmGetWindowAttribute

### DIFF
--- a/src/mvViewport_win32.cpp
+++ b/src/mvViewport_win32.cpp
@@ -12,8 +12,11 @@ get_horizontal_shift(const HWND window_handle)
 {
 	RECT window_rectangle, frame_rectangle;
 	GetWindowRect(window_handle, &window_rectangle);
-	DwmGetWindowAttribute(window_handle,
-		DWMWA_EXTENDED_FRAME_BOUNDS, &frame_rectangle, sizeof(RECT));
+	if (DwmGetWindowAttribute(window_handle,
+		DWMWA_EXTENDED_FRAME_BOUNDS, &frame_rectangle, sizeof(RECT)) != S_OK)
+	{
+		return 0;
+	}
 
 	return frame_rectangle.left - window_rectangle.left;
 }


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Error handling for DwmGetWindowAttribute in Win32 backend
assignees: @hoffstadt

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->
Closes #2076 

**Description:**
If DwmGetWindowAttribute fails, default to zero window offset.

**Concerning Areas:**
None