### PR TITLE
Feature: get_item_configuration() for fonts

### DIFF
--- a/src/mvFontItems.cpp
+++ b/src/mvFontItems.cpp
@@ -178,6 +178,15 @@ void mvFont::handleSpecificRequiredArgs(PyObject* dict)
 
 }
 
+void mvFont::getSpecificConfiguration(PyObject* dict)
+{
+	if (dict == nullptr)
+		return;
+
+	PyDict_SetItemString(dict, "file", ToPyString(_file));
+	PyDict_SetItemString(dict, "size", ToPyFloat(_size));
+}
+
 void mvFontChars::handleSpecificRequiredArgs(PyObject* dict)
 {
 	if (!VerifyRequiredArguments(GetParsers()[GetEntityCommand(type)], dict))

--- a/src/mvFontItems.h
+++ b/src/mvFontItems.h
@@ -51,6 +51,7 @@ public:
     void draw(ImDrawList* drawlist, float x, float y) override;
     void customAction(void* data = nullptr) override;
     void handleSpecificRequiredArgs(PyObject* dict) override;
+    void getSpecificConfiguration(PyObject* dict) override;
     ImFont* getFontPtr() { return _fontPtr; }
 
 public:


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: get_item_configuration() for fonts
assignees: @hoffstadt 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->

**Description:**
It might be useful to be able to get some font properties back from the font object (e.g. to build another font based off this one). This fix adds ability to request font file name and size.

**Concerning Areas:**
None.