### PR TITLE
Feature: activation delay on tooltips

### DIFF
--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -2641,7 +2641,7 @@ def theme_component(item_type : int =0, *, label: str =None, user_data: Any =Non
 		internal_dpg.pop_container_stack()
 
 @contextmanager
-def tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, show: bool =True, **kwargs) -> Union[int, str]:
+def tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, show: bool =True, delay: float =0.5, hide_on_activity: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds a tooltip window.
 
 	Args:
@@ -2651,6 +2651,8 @@ def tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =None,
 		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
 		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
 		show (bool, optional): Attempt to render widget.
+		delay (float, optional): Activation delay: time, in seconds, during which the mouse should stay still in order to display the tooltip.  May be zero for instant activation.
+		hide_on_activity (bool, optional): Hide the tooltip if the user has moved the mouse.  If False, the tooltip will follow mouse pointer.
 		id (Union[int, str], optional): (deprecated) 
 	Yields:
 		Union[int, str]
@@ -2660,7 +2662,7 @@ def tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =None,
 		if 'id' in kwargs.keys():
 			warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 			tag=kwargs['id']
-		widget = internal_dpg.add_tooltip(parent, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, show=show, **kwargs)
+		widget = internal_dpg.add_tooltip(parent, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, show=show, delay=delay, hide_on_activity=hide_on_activity, **kwargs)
 		internal_dpg.push_container_stack(widget)
 		yield widget
 	finally:
@@ -7229,7 +7231,7 @@ def add_time_picker(*, label: str =None, user_data: Any =None, use_internal_labe
 
 	return internal_dpg.add_time_picker(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, indent=indent, parent=parent, before=before, payload_type=payload_type, callback=callback, drag_callback=drag_callback, drop_callback=drop_callback, show=show, pos=pos, filter_key=filter_key, tracked=tracked, track_offset=track_offset, default_value=default_value, hour24=hour24, **kwargs)
 
-def add_tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, show: bool =True, **kwargs) -> Union[int, str]:
+def add_tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, show: bool =True, delay: float =0.5, hide_on_activity: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds a tooltip window.
 
 	Args:
@@ -7239,6 +7241,8 @@ def add_tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =N
 		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
 		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
 		show (bool, optional): Attempt to render widget.
+		delay (float, optional): Activation delay: time, in seconds, during which the mouse should stay still in order to display the tooltip.  May be zero for instant activation.
+		hide_on_activity (bool, optional): Hide the tooltip if the user has moved the mouse.  If False, the tooltip will follow mouse pointer.
 		id (Union[int, str], optional): (deprecated) 
 	Returns:
 		Union[int, str]
@@ -7248,7 +7252,7 @@ def add_tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =N
 		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 		tag=kwargs['id']
 
-	return internal_dpg.add_tooltip(parent, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, show=show, **kwargs)
+	return internal_dpg.add_tooltip(parent, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, show=show, delay=delay, hide_on_activity=hide_on_activity, **kwargs)
 
 def add_tree_node(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, indent: int =-1, parent: Union[int, str] =0, before: Union[int, str] =0, payload_type: str ='$$DPG_PAYLOAD', drag_callback: Callable =None, drop_callback: Callable =None, show: bool =True, pos: Union[List[int], Tuple[int, ...]] =[], filter_key: str ='', delay_search: bool =False, tracked: bool =False, track_offset: float =0.5, default_open: bool =False, open_on_double_click: bool =False, open_on_arrow: bool =False, leaf: bool =False, bullet: bool =False, selectable: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds a tree node to add items to.

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -2641,7 +2641,7 @@ def theme_component(item_type : int =0, *, label: str =None, user_data: Any =Non
 		internal_dpg.pop_container_stack()
 
 @contextmanager
-def tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, show: bool =True, delay: float =0.5, hide_on_activity: bool =False, **kwargs) -> Union[int, str]:
+def tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, show: bool =True, delay: float =0.0, hide_on_activity: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds a tooltip window.
 
 	Args:
@@ -7231,7 +7231,7 @@ def add_time_picker(*, label: str =None, user_data: Any =None, use_internal_labe
 
 	return internal_dpg.add_time_picker(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, indent=indent, parent=parent, before=before, payload_type=payload_type, callback=callback, drag_callback=drag_callback, drop_callback=drop_callback, show=show, pos=pos, filter_key=filter_key, tracked=tracked, track_offset=track_offset, default_value=default_value, hour24=hour24, **kwargs)
 
-def add_tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, show: bool =True, delay: float =0.5, hide_on_activity: bool =False, **kwargs) -> Union[int, str]:
+def add_tooltip(parent : Union[int, str], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, show: bool =True, delay: float =0.0, hide_on_activity: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds a tooltip window.
 
 	Args:

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -2529,6 +2529,8 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         );
 
         args.push_back({ mvPyDataType::UUID, "parent" });
+        args.push_back({ mvPyDataType::Float, "delay", mvArgType::KEYWORD_ARG, "0.5", "Activation delay: time, in seconds, during which the mouse should stay still in order to display the tooltip.  May be zero for instant activation." });
+        args.push_back({ mvPyDataType::Bool, "hide_on_activity", mvArgType::KEYWORD_ARG, "False", "Hide the tooltip if the user has moved the mouse.  If False, the tooltip will follow mouse pointer." });
 
         setup.about = "Adds a tooltip window.";
         setup.category = { "Containers", "Widgets" };

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -2529,7 +2529,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         );
 
         args.push_back({ mvPyDataType::UUID, "parent" });
-        args.push_back({ mvPyDataType::Float, "delay", mvArgType::KEYWORD_ARG, "0.5", "Activation delay: time, in seconds, during which the mouse should stay still in order to display the tooltip.  May be zero for instant activation." });
+        args.push_back({ mvPyDataType::Float, "delay", mvArgType::KEYWORD_ARG, "0.0", "Activation delay: time, in seconds, during which the mouse should stay still in order to display the tooltip.  May be zero for instant activation." });
         args.push_back({ mvPyDataType::Bool, "hide_on_activity", mvArgType::KEYWORD_ARG, "False", "Hide the tooltip if the user has moved the mouse.  If False, the tooltip will follow mouse pointer." });
 
         setup.about = "Adds a tooltip window.";

--- a/src/mvBasicWidgets.h
+++ b/src/mvBasicWidgets.h
@@ -74,6 +74,7 @@ namespace DearPyGui
     void fill_configuration_dict(const mvImageConfig& inConfig, PyObject* outDict);
     void fill_configuration_dict(const mvImageButtonConfig& inConfig, PyObject* outDict);
     void fill_configuration_dict(const mvKnobFloatConfig& inConfig, PyObject* outDict);
+    void fill_configuration_dict(const mvTooltipConfig& inConfig, PyObject* outDict);
 
     // specific part of `configure_item(...)`
     void set_configuration(PyObject* inDict, mvSimplePlotConfig& outConfig);
@@ -107,7 +108,7 @@ namespace DearPyGui
     void set_configuration(PyObject* inDict, mvProgressBarConfig& outConfig);
     void set_configuration(PyObject* inDict, mvImageConfig& outConfig);
     void set_configuration(PyObject* inDict, mvImageButtonConfig& outConfig);
-    void set_configuration(PyObject* inDict, mvTooltipConfig& outConfig, mvAppItemConfig& config);
+    void set_configuration(PyObject* inDict, mvTooltipConfig& outConfig);
     void set_configuration(PyObject* inDict, mvKnobFloatConfig& outConfig);
 
     // positional args TODO: combine with above
@@ -119,6 +120,7 @@ namespace DearPyGui
     void set_positional_configuration(PyObject* inDict, mvListboxConfig& outConfig);
     void set_positional_configuration(PyObject* inDict, mvRadioButtonConfig& outConfig);
     void set_positional_configuration(PyObject* inDict, mvTextConfig& outConfig);
+    void set_positional_configuration(PyObject* inDict, mvTooltipConfig& outConfig, mvAppItemConfig& config);
 
     // data source handling
     void set_data_source(mvAppItem& item, mvUUID dataSource, mvSimplePlotConfig& outConfig);
@@ -573,7 +575,8 @@ struct mvFilterSetConfig
 
 struct mvTooltipConfig
 {
-
+    float        activation_delay = 0.5;
+    bool         hide_on_move = true;
 };
 
 struct mvKnobFloatConfig
@@ -1062,7 +1065,14 @@ public:
     mvTooltipConfig configData{};
     explicit mvTooltip(mvUUID uuid) : mvAppItem(uuid) { config.show = true; } //has to be shown to check hovering
     void draw(ImDrawList* drawlist, float x, float y) override { DearPyGui::draw_tooltip(drawlist, *this); }
-    void handleSpecificRequiredArgs(PyObject* dict) override { DearPyGui::set_configuration(dict, configData, config); }
+    void handleSpecificRequiredArgs(PyObject* dict) override { DearPyGui::set_positional_configuration(dict, configData, config); }
+    void handleSpecificKeywordArgs(PyObject* dict) override { DearPyGui::set_configuration(dict, configData); }
+    void getSpecificConfiguration(PyObject* dict) override { DearPyGui::fill_configuration_dict(configData, dict); }
+
+// TODO: make these members private
+    double change_time = 0;
+    bool hovered_last_frame = false;
+    ImVec2 last_mouse_pos;
 };
 
 class mvSeparator : public mvAppItem

--- a/src/mvBasicWidgets.h
+++ b/src/mvBasicWidgets.h
@@ -575,8 +575,8 @@ struct mvFilterSetConfig
 
 struct mvTooltipConfig
 {
-    float        activation_delay = 0.5;
-    bool         hide_on_move = true;
+    float        activation_delay = 0.0f;
+    bool         hide_on_move = false;
 };
 
 struct mvKnobFloatConfig


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Activation delay on tooltips
assignees: @hoffstadt

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
This PR adds a couple parameters to tooltips that allow to:
- Only show the tooltip once the mouse stays still for a while (i.e. don't show it while the mouse is still moving).
- Hide the tooltip as soon as the mouse starts moving again.

This resembles, more or less, the usual behavior of tooltips on Windows (and maybe in other systems too). It would be nice if the tooltip also stayed still while the mouse is moving, but this would be harder to achieve so I put it aside for the moment.

**Concerning Areas:**
None.