### PR TITLE
Update textures.rst with deleting textures instructions

### DIFF
--- a/docs/source/documentation/textures.rst
+++ b/docs/source/documentation/textures.rst
@@ -56,7 +56,7 @@ and any type that supports python's buffer protocol with contiguous data. Below 
     dpg.start_dearpygui()
     dpg.destroy_context()
 
-The texture can be deleted by simply with `dpg.delete_item("texture_tag")`. However, for the tag/alias to be released items that use `"texture_tag"` (such as a plot series) must also be deleted. 
+The texture can be deleted with `dpg.delete_item("texture_tag")`. However, for the tag/alias to be released items that use `"texture_tag"` (such as a plot series) must also be deleted. 
 
 Dynamic Textures
 ----------------

--- a/docs/source/documentation/textures.rst
+++ b/docs/source/documentation/textures.rst
@@ -56,6 +56,8 @@ and any type that supports python's buffer protocol with contiguous data. Below 
     dpg.start_dearpygui()
     dpg.destroy_context()
 
+The texture can be deleted by simply with `dpg.delete_item("texture_tag")`. However, for the tag/alias to be released items that use `"texture_tag"` (such as a plot series) must also be deleted. 
+
 Dynamic Textures
 ----------------
 


### PR DESCRIPTION
alias will remain unless the items/series using the texture are deleted as well

---
name: Pull Request
about: Textures documentation
title: 'Update textures.rst with deleting textures instructions'
assignees: ''

---

**Description:**
I was having issues deleting a static texture (the value would be deleted but the alias remained, preventing me from using it again to update the texture) but deleting the image_series that was using it solved the issue. I've added those details to the documentation