### PR TITLE
Font pixel snap

### DIFF
--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -1850,12 +1850,13 @@ def filter_set(*, label: str =None, user_data: Any =None, use_internal_label: bo
 		internal_dpg.pop_container_stack()
 
 @contextmanager
-def font(file : str, size : int, *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =internal_dpg.mvReservedUUID_0, **kwargs) -> Union[int, str]:
+def font(file : str, size : int, *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =internal_dpg.mvReservedUUID_0, pixel_snapH: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds font to a font registry.
 
 	Args:
 		file (str): 
 		size (int): 
+		pixel_snapH (bool, optional): Align every glyph to pixel boundary. Useful e.g. if you are merging a non-pixel aligned font with the default font, or rendering text piece-by-piece (e.g. for coloring).
 		label (str, optional): Overrides 'name' as label.
 		user_data (Any, optional): User data for callbacks
 		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
@@ -1875,7 +1876,7 @@ def font(file : str, size : int, *, label: str =None, user_data: Any =None, use_
 		if 'default_font' in kwargs.keys():
 			warnings.warn('default_font keyword removed', DeprecationWarning, 2)
 			kwargs.pop('default_font', None)
-		widget = internal_dpg.add_font(file, size, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, **kwargs)
+		widget = internal_dpg.add_font(file, size, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, pixel_snapH=pixel_snapH, **kwargs)
 		internal_dpg.push_container_stack(widget)
 		yield widget
 	finally:
@@ -4308,12 +4309,13 @@ def add_float_vect_value(*, label: str =None, user_data: Any =None, use_internal
 
 	return internal_dpg.add_float_vect_value(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, source=source, default_value=default_value, parent=parent, **kwargs)
 
-def add_font(file : str, size : int, *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =internal_dpg.mvReservedUUID_0, **kwargs) -> Union[int, str]:
+def add_font(file : str, size : int, *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =internal_dpg.mvReservedUUID_0, pixel_snapH: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds font to a font registry.
 
 	Args:
 		file (str): 
 		size (int): 
+		pixel_snapH (bool, optional): Align every glyph to pixel boundary. Useful e.g. if you are merging a non-pixel aligned font with the default font, or rendering text piece-by-piece (e.g. for coloring).
 		label (str, optional): Overrides 'name' as label.
 		user_data (Any, optional): User data for callbacks
 		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
@@ -4335,7 +4337,7 @@ def add_font(file : str, size : int, *, label: str =None, user_data: Any =None, 
 
 		kwargs.pop('default_font', None)
 
-	return internal_dpg.add_font(file, size, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, **kwargs)
+	return internal_dpg.add_font(file, size, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, pixel_snapH=pixel_snapH, **kwargs)
 
 def add_font_chars(chars : Union[List[int], Tuple[int, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, **kwargs) -> Union[int, str]:
 	"""	 Adds specific font characters to a font.

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -4831,6 +4831,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
 
         args.push_back({ mvPyDataType::String, "file" });
         args.push_back({ mvPyDataType::Integer, "size" });
+        args.push_back({ mvPyDataType::Bool, "pixel_snapH", mvArgType::KEYWORD_ARG, "False", "Align every glyph to pixel boundary. Useful e.g. if you are merging a non-pixel aligned font with the default font, or rendering text piece-by-piece (e.g. for coloring)." });
         args.push_back({ mvPyDataType::UUID, "parent", mvArgType::KEYWORD_ARG, "internal_dpg.mvReservedUUID_0", "Parent to add this item to. (runtime adding)" });
         args.push_back({ mvPyDataType::Bool, "default_font", mvArgType::DEPRECATED_REMOVE_KEYWORD_ARG });
 

--- a/src/mvFontItems.cpp
+++ b/src/mvFontItems.cpp
@@ -50,8 +50,10 @@ void mvFont::customAction(void* data)
 
 	ImGuiIO& io = ImGui::GetIO();
 
+	ImFontConfig cfg;
+	cfg.PixelSnapH = _pixel_snap_h;
 	_fontPtr = io.Fonts->AddFontFromFileTTF(_file.c_str(), _size,
-		nullptr, _ranges.Data);
+		&cfg, _ranges.Data);
 
 	if (_fontPtr == nullptr)
 	{
@@ -178,6 +180,14 @@ void mvFont::handleSpecificRequiredArgs(PyObject* dict)
 
 }
 
+void mvFont::handleSpecificKeywordArgs(PyObject* dict)
+{
+	if (dict == nullptr)
+		return;
+
+    if (PyObject* item = PyDict_GetItemString(dict, "pixel_snapH")) _pixel_snap_h = ToBool(item);
+}
+
 void mvFont::getSpecificConfiguration(PyObject* dict)
 {
 	if (dict == nullptr)
@@ -185,6 +195,7 @@ void mvFont::getSpecificConfiguration(PyObject* dict)
 
 	PyDict_SetItemString(dict, "file", ToPyString(_file));
 	PyDict_SetItemString(dict, "size", ToPyFloat(_size));
+	PyDict_SetItemString(dict, "pixel_snapH", ToPyFloat(_pixel_snap_h));
 }
 
 void mvFontChars::handleSpecificRequiredArgs(PyObject* dict)

--- a/src/mvFontItems.cpp
+++ b/src/mvFontItems.cpp
@@ -195,7 +195,7 @@ void mvFont::getSpecificConfiguration(PyObject* dict)
 
 	PyDict_SetItemString(dict, "file", ToPyString(_file));
 	PyDict_SetItemString(dict, "size", ToPyFloat(_size));
-	PyDict_SetItemString(dict, "pixel_snapH", ToPyFloat(_pixel_snap_h));
+	PyDict_SetItemString(dict, "pixel_snapH", ToPyBool(_pixel_snap_h));
 }
 
 void mvFontChars::handleSpecificRequiredArgs(PyObject* dict)

--- a/src/mvFontItems.h
+++ b/src/mvFontItems.h
@@ -51,6 +51,7 @@ public:
     void draw(ImDrawList* drawlist, float x, float y) override;
     void customAction(void* data = nullptr) override;
     void handleSpecificRequiredArgs(PyObject* dict) override;
+    void handleSpecificKeywordArgs(PyObject* dict) override;
     void getSpecificConfiguration(PyObject* dict) override;
     ImFont* getFontPtr() { return _fontPtr; }
 
@@ -60,6 +61,7 @@ public:
     std::string _file;
     float       _size = 13.0f;
     bool        _default = false;
+    bool        _pixel_snap_h = false;
 
     // finalized
     ImFont* _fontPtr = nullptr;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Ability to enable pixel snap on fonts
assignees: @hoffstadt 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
ImGui provides a way for font characters to be snapped to whole-pixel boundaries - this is useful when you compute text sizes with monospace fonts by just multiplying character width by the text length. Text width returned by `get_text_size` is automatically rounded so you often can't rely on it with non-snapped fonts; with `pixel_snapH=true`, though, `get_text_size` doesn't lose any fractional values (because they are always integer).

With this fix, the pixel snap parameter gets exposed in DPG API so one can turn it on.

**Concerning Areas:**
None.
