### PR TITLE
Ability to hide separators

### DIFF
--- a/src/mvBasicWidgets.cpp
+++ b/src/mvBasicWidgets.cpp
@@ -6302,6 +6302,8 @@ DearPyGui::draw_filter_set(ImDrawList* drawlist, mvAppItem& item, mvFilterSetCon
 void
 DearPyGui::draw_separator(ImDrawList* drawlist, mvAppItem& item)
 {
+	if (!item.config.show)
+		return;
 	ImGui::Separator();
 }
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Ability to hide separators
assignees: @hoffstadt 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
This PR makes separators (`dpg.add_separator`) hideable via `show_item`/`hide_item`. Initially separators did not use the visibility flag - probably for the sake of performance (though the performance gain would be doubtful). However, in some cases one might want to hide them - e.g. when building a context menu where some sections can be hidden depending on context.

A workaround would be to put the separator into a group and hide the group, but that looks rather clumsy; I'd better give separators the same ability that all other widgets already have.

**Concerning Areas:**
None.