### PR TITLE
Sub-menus in a menu bar do not pull down on hover #2131

### DIFF
--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -629,8 +629,6 @@ DearPyGui::draw_menu(ImDrawList* drawlist, mvAppItem& item, mvMenuConfig& config
     // draw
     //-----------------------------------------------------------------------------
     {
-        ScopedID id(item.uuid);
-
         // create menu and see if its selected
         if (ImGui::BeginMenu(item.info.internalLabel.c_str(), item.config.enabled))
         {


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Sub-menus in a menu bar do not pull down on hover
assignees: @hoffstadt 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

Closes #2131

**Description:**
In a menu bar, when one of sub-menus is opened, others do not open automatically when hovered. In Dear ImGui, they do open automatically, i.e. the user does not need to click them to open.

The issue is caused by ScopedID in `DearPyGui::draw_menu`, which breaks hover logic inside of ImGui::BeginMenu. More details in the ticket: #2131.

**Concerning Areas:**
None.