### PR TITLE
fix (mvFileDialog): Need an INCREF on cancel_callback #2148

### DIFF
--- a/src/mvFileDialog.cpp
+++ b/src/mvFileDialog.cpp
@@ -187,7 +187,18 @@ void mvFileDialog::handleSpecificKeywordArgs(PyObject* dict)
 		_max_size = { (float)max_size[0], (float)max_size[1] };
 	}
 
-	if (PyObject* item = PyDict_GetItemString(dict, "cancel_callback")) _cancelCallback = item;
+	if (PyObject* item = PyDict_GetItemString(dict, "cancel_callback"))
+	{
+		Py_XDECREF(_cancelCallback);
+
+		if (item == Py_None)
+			_cancelCallback = nullptr;
+		else
+		{
+			Py_XINCREF(item);
+			_cancelCallback = item;
+		}
+	}
 
 }
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: File Dialogs cancel_calback may lead to a crash
assignees: @hoffstadt 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

Closes #2148 

**Description:**
This PR adds a missing INCREF on the stored `cancel_callback` value in the file dialog. This prevents certain special effects when the callback gets out of scope in Python, like segfaults when the user clicks "Cancel".

**Concerning Areas:**
None.