### PR TITLE
docs + demo: add selectable tables to docs and demo

### DIFF
--- a/dearpygui/demo.py
+++ b/dearpygui/demo.py
@@ -1724,6 +1724,46 @@ def show_demo():
                 #dpg.add_checkbox(label="sort_multi", before=table_id, user_data=table_id, callback=lambda sender, app_data, user_data:dpg.configure_item(user_data, sort_multi=app_data))
                 dpg.add_checkbox(label="sort_tristate", before="__demo_sorting_table", callback=lambda sender, app_data, user_data:dpg.configure_item("__demo_sorting_table", sort_tristate=app_data))
 
+            with dpg.tree_node(label="Selecting rows"):
+                with dpg.theme() as table_theme:
+                    with dpg.theme_component(dpg.mvTable):
+                        dpg.add_theme_color(dpg.mvThemeCol_HeaderActive, (0, 0, 0, 0), category=dpg.mvThemeCat_Core)
+                        dpg.add_theme_color(dpg.mvThemeCol_Header, (0, 0, 0, 0), category=dpg.mvThemeCat_Core)
+
+                def clb_selectable(sender, app_data, user_data):
+                    print(f"Row {user_data}")
+
+                with dpg.table(header_row=True) as table_sel_rows:
+                    dpg.add_table_column(label="First")
+                    dpg.add_table_column(label="Second")
+                    dpg.add_table_column(label="Third")
+
+                    for i in range(10):
+                        with dpg.table_row():
+                            for j in range(3):
+                                dpg.add_selectable(label=f"Row{i} Column{j}", span_columns=True, callback=clb_selectable, user_data=i)
+                dpg.bind_item_theme(table_sel_rows, table_theme)
+
+            with dpg.tree_node(label="Selecting cells"):
+                with dpg.theme() as table_theme:
+                    with dpg.theme_component(dpg.mvTable):
+                        dpg.add_theme_color(dpg.mvThemeCol_HeaderActive, (0, 0, 0, 0), category=dpg.mvThemeCat_Core)
+                        dpg.add_theme_color(dpg.mvThemeCol_Header, (0, 0, 0, 0), category=dpg.mvThemeCat_Core)
+
+                def clb_selectable(sender, app_data, user_data):
+                    print(f"Row {user_data}")
+
+                with dpg.table(header_row=True) as table_sel_cols:
+                    dpg.add_table_column(label="First")
+                    dpg.add_table_column(label="Second")
+                    dpg.add_table_column(label="Third")
+
+                    for i in range(10):
+                        with dpg.table_row():
+                            for j in range(3):
+                                dpg.add_selectable(label=f"Row{i} Column{j}", callback=clb_selectable, user_data=(i,j))
+                dpg.bind_item_theme(table_sel_cols, table_theme)
+
             with dpg.tree_node(label="Sizing Policy"):
 
                 def callback(sender, value, user_data):

--- a/docs/source/documentation/tables.rst
+++ b/docs/source/documentation/tables.rst
@@ -377,6 +377,58 @@ Scrolling
 
 Under construction
 
+Selecting
+---------
+
+You can make rows and/or cells selectable by adding a `selectable` to the table
+and assigning a callback to it. Use a theme to control the hover style. The
+`span_columns` option of the `selectable` is used to control whether
+the row or the cell is selectable.
+
+.. code-block:: python
+
+    import dearpygui.dearpygui as dpg
+
+    dpg.create_context()
+
+    with dpg.theme() as table_theme:
+        with dpg.theme_component(dpg.mvTable):
+            # dpg.add_theme_color(dpg.mvThemeCol_HeaderHovered, (255, 0, 0, 100), category=dpg.mvThemeCat_Core)
+            dpg.add_theme_color(dpg.mvThemeCol_HeaderActive, (0, 0, 0, 0), category=dpg.mvThemeCat_Core)
+            dpg.add_theme_color(dpg.mvThemeCol_Header, (0, 0, 0, 0), category=dpg.mvThemeCat_Core)
+
+    def clb_selectable(sender, app_data, user_data):
+        print(f"Row {user_data}")
+
+    with dpg.window(tag="Selectable Tables"):
+        with dpg.table(tag="SelectRows", header_row=True) as selectablerows:
+            dpg.add_table_column(label="First")
+            dpg.add_table_column(label="Second")
+            dpg.add_table_column(label="Third")
+
+            for i in range(15):
+                with dpg.table_row():
+                    for j in range(3):
+                        dpg.add_selectable(label=f"Row{i} Column{j}", span_columns=True, callback=clb_selectable, user_data=i)
+        dpg.bind_item_theme(selectablerows, table_theme)
+
+        with dpg.table(tag="SelectCells", header_row=True) as selectablecells:
+            dpg.add_table_column(label="First")
+            dpg.add_table_column(label="Second")
+            dpg.add_table_column(label="Third")
+
+            for i in range(15):
+                with dpg.table_row():
+                    for j in range(3):
+                        dpg.add_selectable(label=f"Row{i} Column{j}", callback=clb_selectable, user_data=(i,j))
+        dpg.bind_item_theme(selectablecells, table_theme)
+
+    dpg.create_viewport(width=800, height=600)
+    dpg.setup_dearpygui()
+    dpg.show_viewport()
+    dpg.start_dearpygui()
+    dpg.destroy_context()
+
 Clipping
 --------
 


### PR DESCRIPTION
---
name: Pull Request
about: improve table docs
title: docs + demo: add selectable tables to docs and demo
assignees: @hoffstadt 

---

**Description:**
I was having trouble porting my DPG 0.6.415 tables to 1.9 and I found some help from the discord about using selectables. I've added that documentation to the demo and docs.

**Concerning Areas:**
I had import issues when installing the repo locally so I technically wasn't able to run the demo. However the code I added did run fine in an external script.
