### PR TITLE
feat: add transparency to framebuffer on linux

### DIFF
--- a/src/mvViewport_linux.cpp
+++ b/src/mvViewport_linux.cpp
@@ -142,6 +142,12 @@ mvShowViewport(mvViewport& viewport, bool minimized, bool maximized)
     glfwSetErrorCallback(glfw_error_callback);
     glfwInit();
 
+    // specifies whether the window framebuffer will be transparent
+    // if enabled and supported by the system, the window framebuffer
+    // alpha channel will be used to combine the framebuffer with
+    // the background (this does not affect window decorations).
+    glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
+
     if (!viewport.resizable)
         glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
     if (viewport.alwaysOnTop)
@@ -221,13 +227,13 @@ mvShowViewport(mvViewport& viewport, bool minimized, bool maximized)
 
     // Setup Platform/Renderer bindings
     ImGui_ImplGlfw_InitForOpenGL(viewportData->handle, true);
-        
+
 
     // Setup callbacks
     glfwSetWindowSizeCallback(viewportData->handle, window_size_callback);
     glfwSetWindowCloseCallback(viewportData->handle, window_close_callback);
 }
-    
+
  void
 mvMaximizeViewport(mvViewport& viewport)
 {


### PR DESCRIPTION
---
name: Linux Viewport Tranparent Framebuffer
about: add transparency to framebuffer on linux
title: Linux: add transparency to viewport framebuffer
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->
This feature enables adjustment of the viewport's clear color alpha channel. Assigning a value of 0 is consider fully transparent  while a value of 255 is fully opaque. This is a linux only feature. The following sample code is a demonstration of the effect.
```python
import dearpygui.dearpygui as dpg

clear_color = {
    "red"  : 0, "green" : 0,
    "blue" : 0, "alpha" : 255,
}

dpg.create_context()
dpg.create_viewport(title="Transparency Demo", width=800, height=600)
dpg.set_viewport_clear_color([*clear_color.values()])
dpg.setup_dearpygui()

def channel_cb(sender, app_data):
    key   = dpg.get_item_label(sender)
    value = dpg.get_value(sender)
    clear_color[key] = value
    dpg.set_viewport_clear_color([*clear_color.values()])

with dpg.window(label="Transparent Framebuffer", width=200, height=150):
    dpg.add_slider_int(label="red",callback=channel_cb,default_value=0,min_value=0,max_value=255)
    dpg.add_slider_int(label="green",callback=channel_cb,default_value=0,min_value=0,max_value=255)
    dpg.add_slider_int(label="blue",callback=channel_cb,default_value=0,min_value=0,max_value=255)
    dpg.add_slider_int(label="alpha",callback=channel_cb,default_value=255,min_value=0,max_value=255)

dpg.show_viewport()
dpg.start_dearpygui()
dpg.destroy_context()
```
[demo.webm](https://github.com/hoffstadt/DearPyGui/assets/20728117/408d08a5-c60e-41d1-bc90-42685298991c)

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
This code is a linux only feature. Similar effects should be achievable in the other operating system specific areas of the code base.