### PR TITLE
Update ImGuiFileDialog.cpp

### DIFF
--- a/thirdparty/ImGuiFileDialog/ImGuiFileDialog.cpp
+++ b/thirdparty/ImGuiFileDialog/ImGuiFileDialog.cpp
@@ -1738,7 +1738,18 @@ namespace IGFD
 					newPath = prCurrentPath + std::string(1u, PATH_SEP) + vInfos->fileName;
 			}
 
-			if (IGFD::Utils::IsDirectoryExist(newPath))
+			bool is_directory_accessible = false;
+
+			try {
+				const std::filesystem::path fspath(newPath);
+				const auto dir_iter = std::filesystem::directory_iterator(fspath);
+				is_directory_accessible = true;
+			}
+			catch (...) {
+				is_directory_accessible = false;
+			}
+
+			if (IGFD::Utils::IsDirectoryExist(newPath) && is_directory_accessible)
 			{
 				if (puShowDrives)
 				{


### PR DESCRIPTION
**Description:**
The bug manifests as a freeze or crash of DPG when attempting to access a directory that the current user does not have permission to access using file_dialog. This commit fixes the issue by adding a code snippet that checks the permission to access the target directory before attempting to do so. If the user does not have permission, the program will not access the target directory and stay in the current path.

**Reproduce the bug:**
Use file_dialog to access any directory for which you don't have permission.