### PR TITLE
mvNodeLink: Passing state to handlers instead of nullptr #2197

### DIFF
--- a/src/mvNodes.cpp
+++ b/src/mvNodes.cpp
@@ -690,7 +690,7 @@ void mvNodeLink::handleSpecificRequiredArgs(PyObject* dict)
 void mvNodeLink::customAction(void* data)
 {
     if (handlerRegistry)
-        handlerRegistry->checkEvents(data);
+        handlerRegistry->checkEvents(&state);
 }
 
 void mvNodeLink::draw(ImDrawList* drawlist, float x, float y)


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: mvNodeLink: Passing state to handlers instead of nullptr
assignees: @hoffstadt 

---

Closes #2197 

**Description:**
`data` in `mvNodeLink::customAction` is always null. Item handlers are supposed to get the item state instead, so this PR corrects that and passes the state to checkEvents, just like other `checkEvents` calls in `mvNodes.cpp` do.

**Concerning Areas:**
PR #2223 needs to be merged first - without that PR, the issue #2197 doesn't occur (it's masked by #2196), and therefore can't be tested for.