### PR TITLE
mvNodeEditor: Nodes created with show=False lead to segfault #2151

### DIFF
--- a/src/mvNodes.cpp
+++ b/src/mvNodes.cpp
@@ -264,8 +264,14 @@ void mvNodeEditor::draw(ImDrawList* drawlist, float x, float y)
         child->state.lastFrameUpdate = GContext->frame;
         child->state.hovered = false;
 
-        ImVec2 size = ImNodes::GetNodeDimensions(static_cast<mvNode*>(child.get())->getId());
-        child->state.rectSize = { size.x, size.y };
+        if (child->config.show)
+        {
+            // We can only refer to visible nodes here
+            ImVec2 size = ImNodes::GetNodeDimensions(static_cast<mvNode*>(child.get())->getId());
+            child->state.rectSize = { size.x, size.y };
+        }
+        else
+            child->state.rectSize = { 0.0f, 0.0f };
 
         if (anyNodeHovered && nodeHovered == static_cast<mvNode*>(child.get())->getId())
             child->state.hovered = true;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: mvNodeEditor: Nodes created with show=False lead to segfault #2151
assignees: @hoffstadt 

---

Closes #2151 

**Description:**
When a node is created with show=False, it doesn't render anything and therefore does not exist in ImNodes. Later in `mvNodeEditor::draw()`, when the node state is being updated, `mvNodeEditor` attempts to get the node rectangle using `ImNodes::GetNodeDimensions()`, which segfaults because no such node exists. An assert in `GetNodeDimensions` hints that it must only be used on existing nodes.

This PR adds a check and only calls `GetNodeDimensions` for visible nodes; for hidden nodes it sets the rect size to (0, 0). **Note:** this is **not** how most other DPG widgets behave - they typically retain their `rectSize` after `dpg.hide()`; however, it's consistent with how **nodes** work without this fix - whenever a node is hidden, its rect size gets reset to zero.

**Concerning Areas:**
None.