### PR TITLE
mvDrawRect: Replaced separate corner colors with a single parm (#1996)

### DIFF
--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -8026,7 +8026,7 @@ def draw_quad(p1 : Union[List[float], Tuple[float, ...]], p2 : Union[List[float]
 
 	return internal_dpg.draw_quad(p1, p2, p3, p4, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, before=before, show=show, color=color, fill=fill, thickness=thickness, **kwargs)
 
-def draw_rectangle(pmin : Union[List[float], Tuple[float, ...]], pmax : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, show: bool =True, color: Union[List[int], Tuple[int, ...]] =(255, 255, 255, 255), color_upper_left: Union[List[int], Tuple[int, ...]] =(255, 255, 255, 255), color_upper_right: Union[List[int], Tuple[int, ...]] =(255, 255, 255, 255), color_bottom_right: Union[List[int], Tuple[int, ...]] =(255, 255, 255, 255), color_bottom_left: Union[List[int], Tuple[int, ...]] =(255, 255, 255, 255), fill: Union[List[int], Tuple[int, ...]] =(0, 0, 0, -255), multicolor: bool =False, rounding: float =0.0, thickness: float =1.0, **kwargs) -> Union[int, str]:
+def draw_rectangle(pmin : Union[List[float], Tuple[float, ...]], pmax : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, show: bool =True, color: Union[List[int], Tuple[int, ...]] =(255, 255, 255, 255), corner_colors: Union[List, Tuple, None] =None, fill: Union[List[int], Tuple[int, ...]] =(0, 0, 0, -255), multicolor: bool =False, rounding: float =0.0, thickness: float =1.0, **kwargs) -> Union[int, str]:
 	"""	 Adds a rectangle.
 
 	Args:
@@ -8040,10 +8040,7 @@ def draw_rectangle(pmin : Union[List[float], Tuple[float, ...]], pmax : Union[Li
 		before (Union[int, str], optional): This item will be displayed before the specified item in the parent.
 		show (bool, optional): Attempt to render widget.
 		color (Union[List[int], Tuple[int, ...]], optional): 
-		color_upper_left (Union[List[int], Tuple[int, ...]], optional): 'multicolor' must be set to 'True'
-		color_upper_right (Union[List[int], Tuple[int, ...]], optional): 'multicolor' must be set to 'True'
-		color_bottom_right (Union[List[int], Tuple[int, ...]], optional): 'multicolor' must be set to 'True'
-		color_bottom_left (Union[List[int], Tuple[int, ...]], optional): 'multicolor' must be set to 'True'
+		corner_colors (Union[List, Tuple], optional): Corner colors in a list, starting with upper-left and going clockwise: (upper-left, upper-right, bottom-right, bottom-left). 'multicolor' must be set to 'True'.
 		fill (Union[List[int], Tuple[int, ...]], optional): 
 		multicolor (bool, optional): 
 		rounding (float, optional): Number of pixels of the radius that will round the corners of the rectangle. Note: doesn't work with multicolor
@@ -8057,7 +8054,10 @@ def draw_rectangle(pmin : Union[List[float], Tuple[float, ...]], pmax : Union[Li
 		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 		tag=kwargs['id']
 
-	return internal_dpg.draw_rectangle(pmin, pmax, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, before=before, show=show, color=color, color_upper_left=color_upper_left, color_upper_right=color_upper_right, color_bottom_right=color_bottom_right, color_bottom_left=color_bottom_left, fill=fill, multicolor=multicolor, rounding=rounding, thickness=thickness, **kwargs)
+	if any(parm in kwargs.keys() for parm in ("color_upper_left", "color_upper_right", "color_bottom_left", "color_bottom_right")):
+		warnings.warn('Use corner_colors instead of color_x_y', DeprecationWarning, 2)
+
+	return internal_dpg.draw_rectangle(pmin, pmax, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, before=before, show=show, color=color, corner_colors=corner_colors, fill=fill, multicolor=multicolor, rounding=rounding, thickness=thickness, **kwargs)
 
 def draw_text(pos : Union[List[float], Tuple[float, ...]], text : str, *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, show: bool =True, color: Union[List[int], Tuple[int, ...]] =(255, 255, 255, 255), size: float =10.0, **kwargs) -> Union[int, str]:
 	"""	 Adds text (drawlist).

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -3419,6 +3419,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         args.push_back({ mvPyDataType::Bool, "multicolor", mvArgType::KEYWORD_ARG, "False" });
         args.push_back({ mvPyDataType::Float, "rounding", mvArgType::KEYWORD_ARG, "0.0", "Number of pixels of the radius that will round the corners of the rectangle. Note: doesn't work with multicolor" });
         args.push_back({ mvPyDataType::Float, "thickness", mvArgType::KEYWORD_ARG, "1.0" });
+        args.push_back({ mvPyDataType::ListListInt, "corner_colors", mvArgType::KEYWORD_ARG, "[(255, 255, 255, 255), (255, 255, 255, 255), (255, 255, 255, 255), (255, 255, 255, 255)]", "Corner colors in a list, starting with upper-left and going clockwise: (upper-left, upper-right, bottom-right, bottom-left). 'multicolor' must be set to 'True'." });
 
         setup.about = "Adds a rectangle.";
         setup.category = { "Drawlist", "Widgets" };

--- a/src/mvDrawings.cpp
+++ b/src/mvDrawings.cpp
@@ -1451,6 +1451,41 @@ void mvDrawRect::handleSpecificKeywordArgs(PyObject* dict)
 	if (PyObject* item = PyDict_GetItemString(dict, "rounding")) _rounding = ToFloat(item);
 	if (PyObject* item = PyDict_GetItemString(dict, "thickness")) _thickness = ToFloat(item);
 	if (PyObject* item = PyDict_GetItemString(dict, "multicolor")) _multicolor = ToBool(item);
+	if (PyObject* item = PyDict_GetItemString(dict, "corner_colors"))
+	{
+        if (item != Py_None)
+		{
+            if (PyTuple_Check(item))
+			{
+				if (PyTuple_Size(item) != 4)
+					mvThrowPythonError(mvErrorCode::mvNone, "The corner_colors parm on draw_rectangle must contain 4 colors.");
+				else
+				{
+					// Note: the variables are named incorrectly, e.g. _color_bottom_right
+					// actually controls upper-left corner.  That's how old Python parms
+					// were named so we're keeping the names for a while until we drop the
+					// old parms altogether (if this ever happens).
+					// For now, we're just filling them in appropriate order.
+					_color_bottom_right = ToColor(PyTuple_GetItem(item, 0));
+					_color_bottom_left = ToColor(PyTuple_GetItem(item, 1));
+					_color_upper_left = ToColor(PyTuple_GetItem(item, 2));
+					_color_upper_right = ToColor(PyTuple_GetItem(item, 3));
+				}
+			}
+            else if (PyList_Check(item))
+			{
+				if (PyList_Size(item) != 4)
+					mvThrowPythonError(mvErrorCode::mvNone, "The corner_colors parm on draw_rectangle must contain 4 colors.");
+				else
+				{
+					_color_bottom_right = ToColor(PyList_GetItem(item, 0));
+					_color_bottom_left = ToColor(PyList_GetItem(item, 1));
+					_color_upper_left = ToColor(PyList_GetItem(item, 2));
+					_color_upper_right = ToColor(PyList_GetItem(item, 3));
+				}
+			}
+		}
+	}
 
 	if (_multicolor)
 		_rounding = 0.0f;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: mvDrawRect: Replaced separate corner colors with a single parm (#1996)
assignees: @hoffstadt 

---

Closes #1996 

**Description:**
This PR adds a single `corner_colors` argument to `draw_rectangle`, which replaces separate `color_x_y` parms (e.g. `color_upper_left`) that are used to set colors of rectangle corners.

Old `color_x_y` parms were setting colors on incorrect corners ("flipped" by 180 degrees), but if we simply change their behavior to map to correct corners, it will break existing code for those who use them. That's why we have to add new parms and deprecate old ones.

I believe that in most use cases, all 4 corners need to be setup at once, so I've added a single parm to control them all. Sometimes the user might need to control just one corner, e.g. if it's a color map and one of the colors is configured with a slider or something. In such cases, it's easy to store all 4 colors in Python and pass them all together to `configure_item`.

**Concerning Areas:**
Docs at _readthedocs.io_ will need to be updated. I haven't made any changes to the doc in this PR. Please let me know if we need doc updates in this PR too.