### PR TITLE
mvContainers: Tree nodes and collapsing headers maintain open state after minimising window #1873

### DIFF
--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -1197,7 +1197,7 @@ DearPyGui::draw_tree_node(ImDrawList* drawlist, mvAppItem& item, mvTreeNodeConfi
         else
             config.flags &= ~ImGuiTreeNodeFlags_Selected;
 
-        ImGui::SetNextItemOpen(*config.value);
+        ImGui::SetNextItemOpen(*config.value, ImGuiCond_Appearing);
 
         *config.value = ImGui::TreeNodeEx(item.info.internalLabel.c_str(), config.flags);
         UpdateAppItemState(item.state);
@@ -1340,7 +1340,7 @@ DearPyGui::draw_collapsing_header(ImDrawList* drawlist, mvAppItem& item, mvColla
         if (config.closable)
             toggle = &item.config.show;
 
-        ImGui::SetNextItemOpen(*config.value);
+        ImGui::SetNextItemOpen(*config.value, ImGuiCond_Appearing);
 
         *config.value = ImGui::CollapsingHeader(item.info.internalLabel.c_str(), toggle, config.flags);
         UpdateAppItemState(item.state);


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: mvContainers: Tree nodes and collapsing headers maintain open/close state after minimising window #1873
assignees: @hoffstadt 

---

Closes #1873 

**Description:**
When an open tree node or collapsing header was inside a child window, if you minimised the viewport, upon re-opening the viewport the tree node/collapsing header would be closed.

This PR adds the `ImGuiCond_Appearing` argument to `ImGui::SetNextItemOpen`. 

`ImGui::SetNextItemOpen` sets the tree node/collapsing header open state. And `ImGuiCond_Appearing` condition enum has the description: "Set the variable if the object/window is appearing after being hidden/inactive (or the first time)".

This fix was proposed by user sedenka - see https://github.com/hoffstadt/DearPyGui/issues/1873#issuecomment-1232173894

**Concerning Areas:**
I'm not 100% sure if this is the correct fix. But my testing hasn't revealed any issues and it does completely fix the bug.
