### PR TITLE
fix (mvTreeNode/mvCollapsingHeader): Keep the open state when parent …

### DIFF
--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -1211,15 +1211,22 @@ DearPyGui::draw_tree_node(ImDrawList* drawlist, mvAppItem& item, mvTreeNodeConfi
 
         ImGui::SetNextItemOpen(*config.value);
 
-        *config.value = ImGui::TreeNodeEx(item.info.internalLabel.c_str(), config.flags);
+        bool is_open = ImGui::TreeNodeEx(item.info.internalLabel.c_str(), config.flags);
+
         UpdateAppItemState(item.state);
+
+        // We're only updating the value when we know that the change was triggered
+        // by the user.  Note that `is_open` might be reset to `false` while the
+        // tree node is actually open, e.g. when the parent window gets out of sight.
+        if (item.state.toggledOpen)
+            *config.value = is_open;
 
         if (item.state.toggledOpen && !*config.value)
         {
             item.state.toggledOpen = false;
         }
 
-        if (!*config.value)
+        if (!is_open)
         {
             ImGui::EndGroup();
         }
@@ -1354,10 +1361,17 @@ DearPyGui::draw_collapsing_header(ImDrawList* drawlist, mvAppItem& item, mvColla
 
         ImGui::SetNextItemOpen(*config.value);
 
-        *config.value = ImGui::CollapsingHeader(item.info.internalLabel.c_str(), toggle, config.flags);
+        bool is_open = ImGui::CollapsingHeader(item.info.internalLabel.c_str(), toggle, config.flags);
+
         UpdateAppItemState(item.state);
 
-        if (*config.value)
+        // We're only updating the value when we know that the change was triggered
+        // by the user.  Note that `is_open` might be reset to `false` while the
+        // header is actually open, e.g. when the parent window gets out of sight.
+        if (item.state.toggledOpen)
+            *config.value = is_open;
+
+        if (is_open)
         {
             for (auto& child : item.childslots[1])
                 child->draw(drawlist, ImGui::GetCursorPosX(), ImGui::GetCursorPosY());


### PR DESCRIPTION
…window is hidden #1873

---
name: Pull Request
about: Create a pull request to help us improve
title: fix (mvTreeNode/mvCollapsingHeader): Keep the open state when parent window is hidden #1873
assignees: @hoffstadt 

---

Closes #1873 

**Description:**

This is an attempt to make the fix better than #2250.

The problem is caused by TreeNode functions returning `false` when the window is not visible, and we surely don't want that `false` to interfere with the widget's `value`. That's why we only store the `TreeNodeEx` return value when it **really** comes from user interaction (`toggledOpen` is true). If the window is hidden, `toggledOpen` can never turn into true, so it's a safe approach. Also, this way we don't have to explicitly check `window->SkipItems`, which is an internal API in Dear ImGui (I try to cut down on the use of internal-looking APIs :) ).

**Concerning Areas:**
None.