### PR TITLE
fix (plots): set_axis_ticks can be used on secondary Y axes

### DIFF
--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -393,7 +393,15 @@ DearPyGui::draw_plot(ImDrawList* drawlist, mvAppItem& item, mvPlotConfig& config
 				if (axis->info.location == 0)
 					ImPlot::SetNextPlotTicksX(axis->configData.labelLocations.data(), (int)axis->configData.labels.size(), axis->configData.clabels.data());
 				else
-					ImPlot::SetNextPlotTicksY(axis->configData.labelLocations.data(), (int)axis->configData.labels.size(), axis->configData.clabels.data());
+				{
+					ImPlotYAxis axis_id = ImPlotYAxis_1;
+					switch (axis->info.location)
+					{
+					case(2): axis_id = ImPlotYAxis_2; break;
+					case(3): axis_id = ImPlotYAxis_3; break;
+					}
+					ImPlot::SetNextPlotTicksY(axis->configData.labelLocations.data(), (int)axis->configData.labels.size(), axis->configData.clabels.data(), false, axis_id);
+				}
 			}
 		}
 		else


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: fix (plots): set_axis_ticks can be used on secondary Y axes #2253
assignees: @hoffstadt

---

Closes #2253

**Description:**
Added axis ID on `SetNextPlotTicksY` so that `set_axis_ticks` works on multiple Y axes the same way as `set_axis_limits` does.

**Concerning Areas:**
None.