### PR TITLE
Added get_focused_item() to request the current nav focus

### DIFF
--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -8167,6 +8167,16 @@ def get_active_window(**kwargs) -> Union[int, str]:
 
 	return internal_dpg.get_active_window(**kwargs)
 
+def get_focused_item(**kwargs) -> Union[int, str]:
+	"""	 Returns the item currently having focus.
+
+	Args:
+	Returns:
+		Union[int, str]
+	"""
+
+	return internal_dpg.get_focused_item(**kwargs)
+
 def get_alias_id(alias : str, **kwargs) -> Union[int, str]:
 	"""	 Returns the ID associated with an alias.
 

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -641,6 +641,7 @@ PyInit__dearpygui(void)
 	MV_ADD_COMMAND(get_windows);
 	MV_ADD_COMMAND(get_all_items);
 	MV_ADD_COMMAND(get_active_window);
+	MV_ADD_COMMAND(get_focused_item);
 	MV_ADD_COMMAND(set_primary_window);
 	MV_ADD_COMMAND(push_container_stack);
 	MV_ADD_COMMAND(pop_container_stack);

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -2992,6 +2992,14 @@ get_active_window(PyObject* self, PyObject* args, PyObject* kwargs)
 }
 
 static PyObject*
+get_focused_item(PyObject* self, PyObject* args, PyObject* kwargs)
+{
+	 std::lock_guard<std::recursive_mutex> lk(GContext->mutex);
+
+	return ToPyUUID(GContext->itemRegistry->focusedItem);
+}
+
+static PyObject*
 move_item(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -2988,7 +2988,7 @@ get_active_window(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	 std::lock_guard<std::recursive_mutex> lk(GContext->mutex);
 
-	return ToPyUUID(GContext->itemRegistry->activeWindow);
+	return ToPyUUID(GContext->activeWindow);
 }
 
 static PyObject*
@@ -2996,7 +2996,7 @@ get_focused_item(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	 std::lock_guard<std::recursive_mutex> lk(GContext->mutex);
 
-	return ToPyUUID(GContext->itemRegistry->focusedItem);
+	return ToPyUUID(GContext->focusedItem);
 }
 
 static PyObject*

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -1217,6 +1217,18 @@ InsertParser_Block2(std::map<std::string, mvPythonParser>& parsers)
 
 	{
 		std::vector<mvPythonDataElement> args;
+
+		mvPythonParserSetup setup;
+		setup.about = "Returns the item currently having focus.";
+		setup.category = { "Item Registry" };
+		setup.returnType = mvPyDataType::UUID;
+
+		mvPythonParser parser = FinalizeParser(setup, args);
+		parsers.insert({ "get_focused_item", parser });
+	}
+
+	{
+		std::vector<mvPythonDataElement> args;
 		args.push_back({ mvPyDataType::UUID, "window" });
 		args.push_back({ mvPyDataType::Bool, "value" });
 

--- a/src/mvAppItemState.cpp
+++ b/src/mvAppItemState.cpp
@@ -1,7 +1,6 @@
 #include "mvAppItemState.h"
 #include <imgui.h>
 #include "mvAppItem.h"
-#include "mvItemRegistry.h"
 #include "mvContext.h"
 #include "mvPyUtils.h"
 
@@ -33,7 +32,7 @@ UpdateAppItemState(mvAppItemState& state)
     state.focused = ImGui::IsItemFocused();
     if (state.focused)
     {
-        GContext->itemRegistry->focusedItem = state.parent->uuid;
+        GContext->focusedItem = state.parent->uuid;
     }
     state.leftclicked = ImGui::IsItemClicked();
     state.rightclicked = ImGui::IsItemClicked(1);

--- a/src/mvAppItemState.cpp
+++ b/src/mvAppItemState.cpp
@@ -1,6 +1,7 @@
 #include "mvAppItemState.h"
 #include <imgui.h>
 #include "mvAppItem.h"
+#include "mvItemRegistry.h"
 #include "mvContext.h"
 #include "mvPyUtils.h"
 
@@ -30,6 +31,10 @@ UpdateAppItemState(mvAppItemState& state)
     state.hovered = ImGui::IsItemHovered();
     state.active = ImGui::IsItemActive();
     state.focused = ImGui::IsItemFocused();
+    if (state.focused)
+    {
+        GContext->itemRegistry->focusedItem = state.parent->uuid;
+    }
     state.leftclicked = ImGui::IsItemClicked();
     state.rightclicked = ImGui::IsItemClicked(1);
     state.middleclicked = ImGui::IsItemClicked(2);

--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -668,8 +668,7 @@ DearPyGui::draw_menu(ImDrawList* drawlist, mvAppItem& item, mvMenuConfig& config
                 GContext->input.mousePos.y = (int)y;
 
 
-                if (GContext->itemRegistry->activeWindow != item.uuid)
-                    GContext->itemRegistry->activeWindow = item.uuid;
+                GContext->activeWindow = item.uuid;
 
             }
 
@@ -977,8 +976,7 @@ DearPyGui::draw_child_window(ImDrawList* drawlist, mvAppItem& item, mvChildWindo
             GContext->input.mousePos.x = (int)x;
             GContext->input.mousePos.y = (int)y;
 
-            if (GContext->itemRegistry->activeWindow != item.uuid)
-                GContext->itemRegistry->activeWindow = item.uuid;
+            GContext->activeWindow = item.uuid;
 
         }
 
@@ -1656,8 +1654,7 @@ DearPyGui::draw_window(ImDrawList* drawlist, mvAppItem& item, mvWindowAppItemCon
         GContext->input.mousePos.x = (int)x;
         GContext->input.mousePos.y = (int)y;
 
-        if (GContext->itemRegistry->activeWindow != item.uuid)
-            GContext->itemRegistry->activeWindow = item.uuid;
+        GContext->activeWindow = item.uuid;
 
     }
 

--- a/src/mvContext.h
+++ b/src/mvContext.h
@@ -119,6 +119,8 @@ struct mvContext
     mvItemRegistry*     itemRegistry = nullptr;
     mvCallbackRegistry* callbackRegistry = nullptr;
     mvInput             input;
+    mvUUID              activeWindow = 0;
+    mvUUID              focusedItem = 0;
 
 };
     

--- a/src/mvItemRegistry.h
+++ b/src/mvItemRegistry.h
@@ -79,6 +79,7 @@ struct mvItemRegistry
     std::stack<mvAppItem*>                  containers;      // parent stack, top of stack becomes widget's parent
     std::unordered_map<std::string, mvUUID> aliases;
     mvUUID                                  activeWindow = 0;
+    mvUUID                                  focusedItem = 0;
     std::vector<mvAppItem*>                 delayedSearch;
     b8                                      showImGuiDebug = false;
     b8                                      showImPlotDebug = false;

--- a/src/mvItemRegistry.h
+++ b/src/mvItemRegistry.h
@@ -78,8 +78,6 @@ struct mvItemRegistry
     // misc
     std::stack<mvAppItem*>                  containers;      // parent stack, top of stack becomes widget's parent
     std::unordered_map<std::string, mvUUID> aliases;
-    mvUUID                                  activeWindow = 0;
-    mvUUID                                  focusedItem = 0;
     std::vector<mvAppItem*>                 delayedSearch;
     b8                                      showImGuiDebug = false;
     b8                                      showImPlotDebug = false;

--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -523,9 +523,7 @@ DearPyGui::draw_plot(ImDrawList* drawlist, mvAppItem& item, mvPlotConfig& config
 			GContext->input.mousePos.x = (int)x;
 			GContext->input.mousePos.y = (int)y;
 
-
-			if (GContext->itemRegistry->activeWindow != item.uuid)
-				GContext->itemRegistry->activeWindow = item.uuid;
+			GContext->activeWindow = item.uuid;
 
 		}
 

--- a/src/mvToolWindow.cpp
+++ b/src/mvToolWindow.cpp
@@ -40,8 +40,7 @@ void mvToolWindow::draw()
 
         std::lock_guard<std::recursive_mutex> lk(GContext->mutex);
 
-        if (GContext->itemRegistry->activeWindow != getUUID())
-            GContext->itemRegistry->activeWindow = getUUID();
+        GContext->activeWindow = getUUID();
 
     }
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Added get_focused_item() to request the current nav focus
assignees: @hoffstadt 

---

**Description:**

Currently there's no easy way to determine which widget is focused. Yes, there's `is_item_focused`, but it only gives a True/False test on a particular widget. You can't ask DPG, "what UUID is currently holding the focus?" - you have to either loop through all widgets checking the state of each one individually, or bind a focus handler to every widget so that you can store the focused ID somewhere.

This PR adds a function to DPG to request current focus.

Here's the test program I used:

```py
import dearpygui.dearpygui as dpg

dpg.create_context()
dpg.create_viewport(title="Test", width=750, height=700)

with dpg.window(width=300) as w:
    def update_data(s, a):
        dpg.set_value("focus-display", f"Focused UUID: {dpg.get_focused_item()}")

    with dpg.item_handler_registry() as handlers:
        dpg.add_item_visible_handler(callback=update_data)

    dpg.add_button(label="Lorem ipsum")
    dpg.add_selectable(label="dolor sit")
    dpg.add_input_text()
    dpg.add_drag_int()
    dpg.add_text(tag="focus-display")
    dpg.bind_item_handler_registry(dpg.last_item(), handlers)

dpg.show_viewport()
dpg.show_item_registry()
dpg.setup_dearpygui()
dpg.start_dearpygui()
dpg.destroy_context()
```

---

**Concerning Areas:**

These changes are implemented much like `get_active_window` is. As a result, the focused item ID is stored in `GContext->itemRegistry`, which **adds a dependency** on `mvItemRegistry` to `mvAppItemState`.

Technically, `mvAppItemState` doesn't need to know about `mvItemRegistry`. I'd say **both** `focusedItem` and `activeWindow` should reside in `GContext` rather than `itemRegistry`. Please let me know what you think on this.

I can modify the fix so that `focusedItem` (or both `focusedItem` and `activeWindow`) are in `GContext` and there are no unnecessary dependencies.