### PR TITLE
Update year of copyright in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Dear PyGui, LLC
+Copyright (c) 2024 Dear PyGui, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the year of copyright from 2023 to 2024. 

Some projects mention copyright year as 2021 - 2024. That would also be a possibility. The license year as part of distribution info needs to be updated as well.

