### PR TITLE
Fix not showing "picker_mode" in demo

### DIFF
--- a/dearpygui/demo.py
+++ b/dearpygui/demo.py
@@ -438,9 +438,8 @@ def show_demo():
                                            )
 
                 dpg.add_text("Color Picker")
-                _before_id = dpg.add_group()
-
-                with dpg.group(horizontal=True):
+                
+                with dpg.group(horizontal=True) as _before_id:
                     dpg.add_text("picker_mode:")
                     dpg.add_radio_button(("mvColorPicker_bar", "mvColorPicker_wheel"), callback=_color_picker_configs, 
                                          user_data=_color_picker_id, horizontal=True)

--- a/dearpygui/demo.py
+++ b/dearpygui/demo.py
@@ -438,9 +438,10 @@ def show_demo():
                                            )
 
                 dpg.add_text("Color Picker")
+                _before_id = dpg.add_group()
 
                 with dpg.group(horizontal=True):
-                    _before_id = dpg.add_text("picker_mode:")
+                    dpg.add_text("picker_mode:")
                     dpg.add_radio_button(("mvColorPicker_bar", "mvColorPicker_wheel"), callback=_color_picker_configs, 
                                          user_data=_color_picker_id, horizontal=True)
                 


### PR DESCRIPTION
---
name: Fix not showing "picker_mode" in demo
about: Fixing demo
title: Fix not showing "picker_mode" in demo

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
In the "Color Picker & Edit" section of the demo the option "picker_mode" wasn't shown, now it's visible. This has been done creating a dummy group just to create an ID where the `_add_config_options` down in the code can "attach" to.

Actually this opens the question on why this happens. The parameter `before` should work differently.
Should I open an issue about that?

**Concerning Areas:**
None
