### PR TITLE
mvDrawRect: Removed the default for corner_colors

### DIFF
--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -8028,7 +8028,7 @@ def draw_quad(p1 : Union[List[float], Tuple[float, ...]], p2 : Union[List[float]
 
 	return internal_dpg.draw_quad(p1, p2, p3, p4, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, before=before, show=show, color=color, fill=fill, thickness=thickness, **kwargs)
 
-def draw_rectangle(pmin : Union[List[float], Tuple[float, ...]], pmax : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, show: bool =True, color: Union[List[int], Tuple[int, ...]] =(255, 255, 255, 255), fill: Union[List[int], Tuple[int, ...]] =(0, 0, 0, -255), multicolor: bool =False, rounding: float =0.0, thickness: float =1.0, corner_colors: Union[List, Tuple, None] =[(255, 255, 255, 255), (255, 255, 255, 255), (255, 255, 255, 255), (255, 255, 255, 255)], **kwargs) -> Union[int, str]:
+def draw_rectangle(pmin : Union[List[float], Tuple[float, ...]], pmax : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, show: bool =True, color: Union[List[int], Tuple[int, ...]] =(255, 255, 255, 255), fill: Union[List[int], Tuple[int, ...]] =(0, 0, 0, -255), multicolor: bool =False, rounding: float =0.0, thickness: float =1.0, corner_colors: Union[List, Tuple, None] =None, **kwargs) -> Union[int, str]:
 	"""	 Adds a rectangle.
 
 	Args:


### PR DESCRIPTION
so that it doesn't break the old color arguments

---
name: Pull Request
about: Create a pull request to help us improve
title: mvDrawRect: Removed the default for corner_colors so that it doesn't break the old color arguments
assignees: @hoffstadt 

---

**Description:**
The commit that added `corner_colors` to draw_rectangle also set it by default to all-white colors. Unfortunately this breaks old arguments named `color_yyy_zzz`, since the default for `corner_colors` overrides whatever is specified in `color_yyy_zzz`.

**Concerning Areas:**
I'm not sure how much of a problem it is to have a default of None.

If you'd prefer to keep the default in `dearpygui.py`, there's another way to resolve this issue. We can parse `corner_colors` **before** `color_yyy_zzz`. This would involve changes in `mvDrawings.cpp` rather than `dearpygui.py`. Please let me know if that's the way to go.