### PR TITLE
Fix add_text_point

### DIFF
--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -562,7 +562,7 @@ def add_text(default_value : str ='', *, label: str ='', user_data: Any ='', use
 	"""Adds text. Text can have an optional label that will display to the right of the text."""
 	...
 
-def add_text_point(x : float, y : float, *, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', parent: Union[int, str] ='', before: Union[int, str] ='', source: Union[int, str] ='', show: bool ='', x_offset: int ='', y_offset: int ='', vertical: bool ='') -> Union[int, str]:
+def add_text_point(x : Union[List[float], Tuple[float, ...]], y : Union[List[float], Tuple[float, ...]], *, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', parent: Union[int, str] ='', before: Union[int, str] ='', source: Union[int, str] ='', show: bool ='', offset: Union[List[float], Tuple[float, ...]] ='', vertical: bool ='') -> Union[int, str]:
 	"""Adds a label series to a plot."""
 	...
 

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -6321,8 +6321,8 @@ def add_text_point(x, y, **kwargs):
 	"""	 Adds a label series to a plot.
 
 	Args:
-		x (float): 
-		y (float): 
+		x (Any): 
+		y (Any): 
 		label (str, optional): Overrides 'name' as label.
 		user_data (Any, optional): User data for callbacks
 		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
@@ -6331,8 +6331,7 @@ def add_text_point(x, y, **kwargs):
 		before (Union[int, str], optional): This item will be displayed before the specified item in the parent.
 		source (Union[int, str], optional): Overrides 'id' as value storage key.
 		show (bool, optional): Attempt to render widget.
-		x_offset (int, optional): 
-		y_offset (int, optional): 
+		offset (Union[List[float], Tuple[float, ...]], optional): Offset of the shown label
 		vertical (bool, optional): 
 		id (Union[int, str], optional): (deprecated)
 	Returns:

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -7061,12 +7061,12 @@ def add_text(default_value : str ='', *, label: str =None, user_data: Any =None,
 
 	return internal_dpg.add_text(default_value, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, indent=indent, parent=parent, before=before, source=source, payload_type=payload_type, drag_callback=drag_callback, drop_callback=drop_callback, show=show, pos=pos, filter_key=filter_key, tracked=tracked, track_offset=track_offset, wrap=wrap, bullet=bullet, color=color, show_label=show_label, **kwargs)
 
-def add_text_point(x : float, y : float, *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, source: Union[int, str] =0, show: bool =True, x_offset: int =..., y_offset: int =..., vertical: bool =False, **kwargs) -> Union[int, str]:
+def add_text_point(x : Union[List[float], Tuple[float, ...]], y : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, source: Union[int, str] =0, show: bool =True, offset: Union[List[float], Tuple[float, ...]] =(0.0, 0.0), vertical: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds a label series to a plot.
 
 	Args:
-		x (float): 
-		y (float): 
+		x (Any): 
+		y (Any): 
 		label (str, optional): Overrides 'name' as label.
 		user_data (Any, optional): User data for callbacks
 		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
@@ -7075,8 +7075,7 @@ def add_text_point(x : float, y : float, *, label: str =None, user_data: Any =No
 		before (Union[int, str], optional): This item will be displayed before the specified item in the parent.
 		source (Union[int, str], optional): Overrides 'id' as value storage key.
 		show (bool, optional): Attempt to render widget.
-		x_offset (int, optional): 
-		y_offset (int, optional): 
+		offset (Union[List[float], Tuple[float, ...]], optional): Offset of the shown label
 		vertical (bool, optional): 
 		id (Union[int, str], optional): (deprecated) 
 	Returns:
@@ -7087,7 +7086,7 @@ def add_text_point(x : float, y : float, *, label: str =None, user_data: Any =No
 		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 		tag=kwargs['id']
 
-	return internal_dpg.add_text_point(x, y, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, before=before, source=source, show=show, x_offset=x_offset, y_offset=y_offset, vertical=vertical, **kwargs)
+	return internal_dpg.add_text_point(x, y, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, before=before, source=source, show=show, offset=offset, vertical=vertical, **kwargs)
 
 def add_texture_registry(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, show: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds a dynamic texture.

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -4086,13 +4086,12 @@ DearPyGui::GetEntityParser(mvAppItemType type)
             MV_PARSER_ARG_SHOW)
         );
 
-        args.push_back({ mvPyDataType::Double, "x" });
-        args.push_back({ mvPyDataType::Double, "y" });
-        args.push_back({ mvPyDataType::Integer, "x_offset", mvArgType::KEYWORD_ARG });
-        args.push_back({ mvPyDataType::Integer, "y_offset", mvArgType::KEYWORD_ARG });
+        args.push_back({ mvPyDataType::DoubleList, "x" });
+        args.push_back({ mvPyDataType::DoubleList, "y" });
+        args.push_back({ mvPyDataType::FloatList, "offset", mvArgType::KEYWORD_ARG, "(0.0, 0.0)", "Offset of the shown label" });
         args.push_back({ mvPyDataType::Bool, "vertical", mvArgType::KEYWORD_ARG, "False" });
 
-        setup.about = "Adds a label series to a plot.";
+        setup.about = "Adds a label series to a plot. x and y can only have one elements each.";
         setup.category = { "Plotting", "Containers", "Widgets" };
         break;
     }

--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -1674,8 +1674,7 @@ DearPyGui::draw_label_series(ImDrawList* drawlist, mvAppItem& item, const mvLabe
 		xptr = &(*config.value.get())[0];
 		yptr = &(*config.value.get())[1];
 
-		ImPlot::PlotText(item.info.internalLabel.c_str(), (*xptr)[0], (*yptr)[0], config.vertical,
-			ImVec2((float)config.xoffset, (float)config.yoffset));
+		ImPlot::PlotText(item.config.specifiedLabel.c_str(), (*xptr)[0], (*yptr)[0], config.vertical, config.offset);
 
 		// Begin a popup for a legend entry.
 		if (ImPlot::BeginLegendPopup(item.info.internalLabel.c_str(), 1))
@@ -2233,7 +2232,7 @@ DearPyGui::set_positional_configuration(PyObject* inDict, mvPieSeriesConfig& out
 void
 DearPyGui::set_positional_configuration(PyObject* inDict, mvLabelSeriesConfig& outConfig)
 {
-	if (!VerifyRequiredArguments(GetParsers()[GetEntityCommand(mvAppItemType::mvPieSeries)], inDict))
+	if (!VerifyRequiredArguments(GetParsers()[GetEntityCommand(mvAppItemType::mvLabelSeries)], inDict))
 		return;
 
 	(*outConfig.value)[0] = ToDoubleVect(PyTuple_GetItem(inDict, 0));
@@ -2566,8 +2565,7 @@ DearPyGui::set_configuration(PyObject* inDict, mvLabelSeriesConfig& outConfig)
 		return;
 
 	if (PyObject* item = PyDict_GetItemString(inDict, "vertical")) outConfig.vertical = ToBool(item);
-	if (PyObject* item = PyDict_GetItemString(inDict, "x_offset")) outConfig.xoffset = ToInt(item);
-	if (PyObject* item = PyDict_GetItemString(inDict, "y_offset")) outConfig.yoffset = ToInt(item);
+	if (PyObject* item = PyDict_GetItemString(inDict, "offset")) outConfig.offset = ToVec2(item);
 
 	if (PyObject* item = PyDict_GetItemString(inDict, "x")) { (*outConfig.value)[0] = ToDoubleVect(item); }
 	if (PyObject* item = PyDict_GetItemString(inDict, "y")) { (*outConfig.value)[1] = ToDoubleVect(item); }
@@ -2926,8 +2924,7 @@ DearPyGui::fill_configuration_dict(const mvLabelSeriesConfig& inConfig, PyObject
 		return;
 
 	PyDict_SetItemString(outDict, "vertical", mvPyObject(ToPyBool(inConfig.vertical)));
-	PyDict_SetItemString(outDict, "x_offset", mvPyObject(ToPyInt(inConfig.xoffset)));
-	PyDict_SetItemString(outDict, "y_offset", mvPyObject(ToPyInt(inConfig.yoffset)));
+	PyDict_SetItemString(outDict, "offset", mvPyObject(ToPyPair(inConfig.offset.x, inConfig.offset.y)));
 }
 
 void

--- a/src/mvPlotting.h
+++ b/src/mvPlotting.h
@@ -256,8 +256,7 @@ struct mvPieSeriesConfig
 
 struct mvLabelSeriesConfig
 {
-    int  xoffset = 0;
-    int  yoffset = 0;
+    ImVec2  offset = ImVec2(0.0f, 0.0f);
     bool vertical = false;
     std::shared_ptr<std::vector<std::vector<double>>> value = std::make_shared<std::vector<std::vector<double>>>(
         std::vector<std::vector<double>>{ std::vector<double>{},


### PR DESCRIPTION
---
name: Fix add_text_point
about: Create a pull request to help us improve
title: Fix add_text_point

---

**Description:**
The `add_text_point()` function used to throw an exception when called because of a simple error during the parsing of the parameters. 
That has been fixed, but it also has been changed x_offset and y_offset which have been brought to the same variable `offset`. Actually these variables didn't have a default value then they used to make throw an exception if not specified.

Also the type notation of the x and y values have been changed according on how they are handled in the code.


Fixes #2108 