### PR TITLE
chore: add `__name__` block to `demo.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,13 @@ dpg.destroy_context()
 <p align="center"><a href="https://dearpygui.readthedocs.io/en/latest/tutorials/first-steps.html#first-run"><img src="https://raw.githubusercontent.com/hoffstadt/DearPyGui/assets/readme/first_app.gif" alt="Dear PyGui example window"></a></p>
                                                                                            
 ## Demo
-The built-in demo shows all of Dear PyGui's functionality. Use [this code](https://dearpygui.readthedocs.io/en/latest/tutorials/first-steps.html#demo) to run the demo. The following impression shows a few, but not nearly all, of the available widgets and features. Since the Python code of the demo can be <a href="https://github.com/hoffstadt/DearPyGui/blob/master/dearpygui/demo.py" alt="demo code repository">inspected</a>, you can leverage the demo code to build your own apps.
+The built-in demo shows all of Dear PyGui's functionality. To run the demo, you can run:
+
+```bash
+python -m dearpygui.demo
+```
+
+Or you can use [this code](https://dearpygui.readthedocs.io/en/latest/tutorials/first-steps.html#demo) to run the demo. The following impression shows a few, but not nearly all, of the available widgets and features. Since the Python code of the demo can be <a href="https://github.com/hoffstadt/DearPyGui/blob/master/dearpygui/demo.py" alt="demo code repository">inspected</a>, you can leverage the demo code to build your own apps.
 <br/><br/>
 <p align="center"><a href="https://dearpygui.readthedocs.io/en/latest/tutorials/first-steps.html#demo"><img src="https://raw.githubusercontent.com/hoffstadt/DearPyGui/assets/readme/demo.gif" alt="Dear PyGui demo"></a></p>
   

--- a/dearpygui/demo.py
+++ b/dearpygui/demo.py
@@ -2848,3 +2848,17 @@ def show_demo():
                         dpg.add_dynamic_texture(app_data.get_width(), app_data.get_height(), app_data, parent="__demo_texture_container")
                     dpg.add_text("Outputs frame buffer an mvBuffer object, creates a dynamic texture, and shows the texture registry (check final item)")
                     dpg.add_button(label="Output Framebuffer", callback=lambda:dpg.output_frame_buffer(callback=_framebuffer_callback))
+
+
+if __name__ == '__main__':
+    import dearpygui.dearpygui as dpg
+
+    dpg.create_context()
+    dpg.create_viewport(title='Custom Title', width=600, height=600)
+
+    show_demo()
+
+    dpg.setup_dearpygui()
+    dpg.show_viewport()
+    dpg.start_dearpygui()
+    dpg.destroy_context()


### PR DESCRIPTION
**Description:**

The `demo.py` file is currently part of the `dearpygui` package, but there's no way to execute it from the installed package itself.

By adding an `if __name__ == '__main__'` block, that makes the demo file directly executable from the package, by doing:

```bash
python -m dearpygui.demo
```

Which is probably the best way to run the package demo. I'd also recommend mentioning it as so in the README.