### PR TITLE
Avoid updating textures more often than needed

### DIFF
--- a/src/mvTextureItems.cpp
+++ b/src/mvTextureItems.cpp
@@ -114,6 +114,7 @@ PyObject* mvDynamicTexture::getPyValue()
 void mvDynamicTexture::setPyValue(PyObject* value)
 {
 	*_value = ToFloatVect(value);
+	_updateNeeded = true;
 }
 
 void mvDynamicTexture::setDataSource(mvUUID dataSource)
@@ -135,6 +136,7 @@ void mvDynamicTexture::setDataSource(mvUUID dataSource)
 		return;
 	}
 	_value = *static_cast<std::shared_ptr<std::vector<float>>*>(item->getValue());
+	_updateNeeded = true;
 }
 
 void mvDynamicTexture::draw(ImDrawList* drawlist, float x, float y)
@@ -151,8 +153,11 @@ void mvDynamicTexture::draw(ImDrawList* drawlist, float x, float y)
 		return;
 	}
 
-	UpdateTexture(_texture, _permWidth, _permHeight, *_value);
+	if (!_updateNeeded)
+		return;
 
+	UpdateTexture(_texture, _permWidth, _permHeight, *_value);
+	_updateNeeded = false;
 }
 
 void mvDynamicTexture::handleSpecificRequiredArgs(PyObject* dict)
@@ -165,6 +170,7 @@ void mvDynamicTexture::handleSpecificRequiredArgs(PyObject* dict)
 	_permHeight = ToInt(PyTuple_GetItem(dict, 1));
 	config.height = _permHeight;
 	*_value = ToFloatVect(PyTuple_GetItem(dict, 2));
+	_updateNeeded = true;
 }
 
 void mvDynamicTexture::handleSpecificKeywordArgs(PyObject* dict)
@@ -203,6 +209,7 @@ void mvRawTexture::setPyValue(PyObject* value)
 			{
 				mvThrowPythonError(mvErrorCode::mvTextureNotFound, GetEntityCommand(type), "Texture data not valid", this);
 			}
+			_updateNeeded = true;
 		}
 		PyBuffer_Release(&buffer_info);
 		if (_buffer)
@@ -238,9 +245,12 @@ void mvRawTexture::draw(ImDrawList* drawlist, float x, float y)
 		return;
 	}
 
+	if (!_updateNeeded)
+		return;
+
 	if (_componentType == ComponentType::MV_FLOAT_COMPONENT)
 		UpdateRawTexture(_texture, _permWidth, _permHeight, (float*)_value, _components);
-
+	_updateNeeded = false;
 }
 
 void mvRawTexture::handleSpecificRequiredArgs(PyObject* dict)

--- a/src/mvTextureItems.h
+++ b/src/mvTextureItems.h
@@ -75,6 +75,7 @@ public:
     void* _value = nullptr;
     void* _texture = nullptr;
     bool          _dirty = true;
+    bool          _updateNeeded = true;
     ComponentType _componentType = ComponentType::MV_FLOAT_COMPONENT;
     int           _components = 4;
     int           _permWidth = 0;
@@ -106,6 +107,7 @@ public:
     std::shared_ptr<std::vector<float>> _value = std::make_shared<std::vector<float>>(std::vector<float>{0.0f});
     void* _texture = nullptr;
     bool                      _dirty = true;
+    bool                      _updateNeeded = true;
     int                       _permWidth = 0;
     int                       _permHeight = 0;
 

--- a/src/mvUtilities_linux.cpp
+++ b/src/mvUtilities_linux.cpp
@@ -219,18 +219,6 @@ UpdateTexture(void* texture, unsigned width, unsigned height, std::vector<float>
 {
     auto textureId = (GLuint)(size_t)texture;
 
-    // start to copy from PBO to texture object ///////
-
-    // bind the texture and PBO
-    glBindTexture(GL_TEXTURE_2D, textureId);
-    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, PBO_ids[textureId]);
-
-    // copy pixels from PBO to texture object
-    // Use offset instead of ponter.
-    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, GL_FLOAT, 0);
-
-    ///////////////////////////////////////////////////
-
     // start to modify pixel values ///////////////////
 
     // bind PBO to update pixel values
@@ -256,6 +244,18 @@ UpdateTexture(void* texture, unsigned width, unsigned height, std::vector<float>
 
     ///////////////////////////////////////////////////
 
+    // start to copy from PBO to texture object ///////
+
+    // bind the texture and PBO
+    glBindTexture(GL_TEXTURE_2D, textureId);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, PBO_ids[textureId]);
+
+    // copy pixels from PBO to texture object
+    // Use offset instead of ponter.
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, GL_FLOAT, 0);
+
+    ///////////////////////////////////////////////////
+
     // it is good idea to release PBOs with ID 0 after use.
     // Once bound with 0, all pixel operations behave normal ways.
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
@@ -265,21 +265,6 @@ UpdateTexture(void* texture, unsigned width, unsigned height, std::vector<float>
 UpdateRawTexture(void* texture, unsigned width, unsigned height, float* data, int components)
 {
     auto textureId = (GLuint)(size_t)texture;
-
-    // start to copy from PBO to texture object ///////
-
-    // bind the texture and PBO
-    glBindTexture(GL_TEXTURE_2D, textureId);
-    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, PBO_ids[textureId]);
-
-    // copy pixels from PBO to texture object
-    // Use offset instead of ponter.
-    if(components == 4)
-        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, GL_FLOAT, 0);
-    else
-        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGB, GL_FLOAT, 0);
-
-    ///////////////////////////////////////////////////
 
     // start to modify pixel values ///////////////////
 
@@ -303,6 +288,21 @@ UpdateRawTexture(void* texture, unsigned width, unsigned height, float* data, in
 
         glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);  // release pointer to mapping buffer
     }
+
+    ///////////////////////////////////////////////////
+
+    // start to copy from PBO to texture object ///////
+
+    // bind the texture and PBO
+    glBindTexture(GL_TEXTURE_2D, textureId);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, PBO_ids[textureId]);
+
+    // copy pixels from PBO to texture object
+    // Use offset instead of ponter.
+    if(components == 4)
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, GL_FLOAT, 0);
+    else
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGB, GL_FLOAT, 0);
 
     ///////////////////////////////////////////////////
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Avoid updating textures more often than needed
assignees: @hoffstadt
---

**Description:**
Currently textures are updated more often than needed, which can slow frame rate.
I found this issue using image series with large textures.

This pull request ensures that dynamic textures and raw textures are only updated when needed.

In addition the linux backend has a small bug that is fixed in this pull request. Indeed the previous PBO content was uploaded to the texture. This could introduce artifacts on a single frame. But since the textures are not updated every frame anymore with the proposed change, this fix is mandatory to prevent staying with the wrong content. The windows and Apple code do not seem to have this issue based on my analysis of the code.

In my use-case, the changes result in a x4 speedup.

**Concerning Areas:**
The changes are pretty trivial, and should be easy to review.