### PR TITLE
Add "load init file" after initial setup

### DIFF
--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -1184,11 +1184,6 @@ def set_init_file(file="dpg.ini"):
     """ deprecated function """
     internal_dpg.configure_app(init_file=file)
 
-@deprecated("Use 'configure_app(init_file=file, load_init_file=True)'.")
-def load_init_file(file):
-    """ deprecated function """
-    internal_dpg.configure_app(init_file=file, load_init_file=True)
-
 @deprecated("Use: `is_viewport_ok(...)`")
 def is_viewport_created():
     """ deprecated function """
@@ -8993,6 +8988,18 @@ def save_init_file(file : str, **kwargs) -> None:
 	"""
 
 	return internal_dpg.save_init_file(file, **kwargs)
+
+def load_init_file(file: str, **kwargs) -> None:
+    """	 Load dpg.ini file.
+
+	Args:
+		file (str): 
+	Returns:
+		None
+	"""
+
+    return internal_dpg.load_init_file(file, **kwargs)
+
 
 def set_axis_limits(axis : Union[int, str], ymin : float, ymax : float, **kwargs) -> None:
 	"""	 Sets limits on the axis for pan and zoom.

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -602,6 +602,7 @@ PyInit__dearpygui(void)
 	MV_ADD_COMMAND(is_dearpygui_running);
 	MV_ADD_COMMAND(generate_uuid);
 	MV_ADD_COMMAND(save_init_file);
+	MV_ADD_COMMAND(load_init_file);
 	MV_ADD_COMMAND(output_frame_buffer);
 	MV_ADD_COMMAND(load_image);
 	MV_ADD_COMMAND(save_image);

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -2152,6 +2152,25 @@ save_init_file(PyObject* self, PyObject* args, PyObject* kwargs)
 	return GetPyNone();
 }
 
+
+static PyObject*
+load_init_file(PyObject* self, PyObject* args, PyObject* kwargs)
+{
+	const char* file;
+
+	if (!Parse((GetParsers())["load_init_file"], args, kwargs, __FUNCTION__, &file))
+		return GetPyNone();
+
+	if (GContext->started)
+		ImGui::LoadIniSettingsFromDisk(file);
+	else
+		mvThrowPythonError(mvErrorCode::mvNone, "Dear PyGui must be started to use \"load_init_file\".");
+
+	return GetPyNone();
+}
+
+
+
 static PyObject*
 split_frame(PyObject* self, PyObject* args, PyObject* kwargs)
 {

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -522,6 +522,20 @@ InsertParser_Block1(std::map<std::string, mvPythonParser>& parsers)
 
 	{
 		std::vector<mvPythonDataElement> args;
+		args.push_back({ mvPyDataType::String, "file" });
+
+		mvPythonParserSetup setup;
+		setup.about = "Load dpg.ini file.";
+		setup.category = { "General" };
+
+		mvPythonParser parser = FinalizeParser(setup, args);
+		parsers.insert({ "load_init_file", parser });
+	}
+
+
+
+	{
+		std::vector<mvPythonDataElement> args;
 		args.push_back({ mvPyDataType::Integer, "delay", mvArgType::KEYWORD_ARG, "32", "Minimal delay in in milliseconds" });
 
 		mvPythonParserSetup setup;


### PR DESCRIPTION
---
name: Add load init file
about: Expose the underlying imgui function that allow loading of init file after initial setup   
assignees: ''
---
<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->
Currently DPG doesn't allow the user to load the init file after setting up the viewport, this PR exposes the imgui function, this is a very small change that I hope we can squeeze in so we can use the upstream version which updates all the backend libraries. 

**Concerning Areas:**
<!--A clear and concise description of any concerning areas that may need extra attention during the pull request.-->
This is a very small change so I don't see it breaking anything immediately. But I have only tested this on Windows and Mac, and I don't have a linux machine with me atm, but I can sort it out if required. 