### PR TITLE
fix (mvPlot): Query rects no longer affect auto-fitting

### DIFF
--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -550,7 +550,7 @@ DearPyGui::draw_plot(ImDrawList* drawlist, mvAppItem& item, mvPlotConfig& config
         for (int i = 0; i < config.rects.size(); ++i) {
 			// TODO: Implement flags
 			bool hovered = false;
-			query_dirty |= ImPlot::DragRect(i,&config.rects[i].X.Min,&config.rects[i].Y.Min,&config.rects[i].X.Max,&config.rects[i].Y.Max, config.query_color, ImPlotDragToolFlags_None, nullptr, &hovered);
+			query_dirty |= ImPlot::DragRect(i,&config.rects[i].X.Min,&config.rects[i].Y.Min,&config.rects[i].X.Max,&config.rects[i].Y.Max, config.query_color, ImPlotDragToolFlags_NoFit, nullptr, &hovered);
 			if (config.rects.size() > config.min_query_rects) {
 				if (hovered && ImGui::IsMouseDoubleClicked(config.select_cancel))
 				{


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: ''
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
This PR adds the "no fit" flag on query rects so that auto-fit functions ignore the query rect.

**Concerning Areas:**
None.