### PR TITLE
Add ability to change mouse cursor in groups and buttons

### DIFF
--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -38,7 +38,7 @@ def add_bool_value(*, label: str ='', user_data: Any ='', use_internal_label: bo
 	"""Adds a bool value."""
 	...
 
-def add_button(*, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', width: int ='', height: int ='', indent: int ='', parent: Union[int, str] ='', before: Union[int, str] ='', payload_type: str ='', callback: Callable ='', drag_callback: Callable ='', drop_callback: Callable ='', show: bool ='', enabled: bool ='', pos: Union[List[int], Tuple[int, ...]] ='', filter_key: str ='', tracked: bool ='', track_offset: float ='', small: bool ='', arrow: bool ='', direction: int ='', repeat: bool ='') -> Union[int, str]:
+def add_button(*, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', width: int ='', height: int ='', indent: int ='', parent: Union[int, str] ='', before: Union[int, str] ='', payload_type: str ='', callback: Callable ='', drag_callback: Callable ='', drop_callback: Callable ='', show: bool ='', enabled: bool ='', pos: Union[List[int], Tuple[int, ...]] ='', filter_key: str ='', tracked: bool ='', track_offset: float ='', small: bool ='', arrow: bool ='', direction: int ='', repeat: bool ='', cursor_on_hover: int ='') -> Union[int, str]:
 	"""Adds a button."""
 	...
 
@@ -230,7 +230,7 @@ def add_font_registry(*, label: str ='', user_data: Any ='', use_internal_label:
 	"""Adds a font registry."""
 	...
 
-def add_group(*, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', width: int ='', height: int ='', indent: int ='', parent: Union[int, str] ='', before: Union[int, str] ='', payload_type: str ='', drag_callback: Callable ='', drop_callback: Callable ='', show: bool ='', enabled: bool ='', pos: Union[List[int], Tuple[int, ...]] ='', filter_key: str ='', delay_search: bool ='', tracked: bool ='', track_offset: float ='', horizontal: bool ='', horizontal_spacing: float ='', xoffset: float ='') -> Union[int, str]:
+def add_group(*, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', width: int ='', height: int ='', indent: int ='', parent: Union[int, str] ='', before: Union[int, str] ='', payload_type: str ='', drag_callback: Callable ='', drop_callback: Callable ='', show: bool ='', enabled: bool ='', pos: Union[List[int], Tuple[int, ...]] ='', filter_key: str ='', delay_search: bool ='', tracked: bool ='', track_offset: float ='', horizontal: bool ='', horizontal_spacing: float ='', xoffset: float ='', cursor_on_hover: int ='') -> Union[int, str]:
 	"""Creates a group that other widgets can belong to. The group allows item commands to be issued for all of its members.
 Enable property acts in a special way enabling/disabling everything inside the group. (Use mvStyleVar_DisabledAlpha to edit colors within the disabled group.)"""
 	...
@@ -1492,6 +1492,16 @@ mvNode_PinShape_Triangle=0
 mvNode_PinShape_TriangleFilled=0
 mvNode_PinShape_Quad=0
 mvNode_PinShape_QuadFilled=0
+mvMouseCursor_None=0
+mvMouseCursor_Arrow=0
+mvMouseCursor_TextInput=0
+mvMouseCursor_ResizeAll=0
+mvMouseCursor_ResizeNS=0
+mvMouseCursor_ResizeEW=0
+mvMouseCursor_ResizeNESW=0
+mvMouseCursor_ResizeNWSE=0
+mvMouseCursor_Hand=0
+mvMouseCursor_NotAllowed=0
 mvNode_Attr_Input=0
 mvNode_Attr_Output=0
 mvNode_Attr_Static=0

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -1955,6 +1955,7 @@ Enable property acts in a special way enabling/disabling everything inside the g
 		horizontal (bool, optional): Forces child widgets to be added in a horizontal layout.
 		horizontal_spacing (float, optional): Spacing for the horizontal layout.
 		xoffset (float, optional): Offset from containing window x item location within group.
+		cursor_on_hover (int, optional): Select mouse cursor type when hovering the group (if supported).
 		id (Union[int, str], optional): (deprecated)
 	Yields:
 		Union[int, str]
@@ -3001,6 +3002,7 @@ def add_button(**kwargs):
 		arrow (bool, optional): Displays an arrow in place of the text string. This requires the direction keyword.
 		direction (int, optional): Sets the cardinal direction for the arrow by using constants mvDir_Left, mvDir_Up, mvDir_Down, mvDir_Right, mvDir_None. Arrow keyword must be set to True.
 		repeat (bool, optional): Hold to continuosly repeat the click.
+		cursor_on_hover (int, optional): Select mouse cursor type when hovering the button (if supported).
 		id (Union[int, str], optional): (deprecated)
 	Returns:
 		Union[int, str]
@@ -4282,6 +4284,7 @@ Enable property acts in a special way enabling/disabling everything inside the g
 		horizontal (bool, optional): Forces child widgets to be added in a horizontal layout.
 		horizontal_spacing (float, optional): Spacing for the horizontal layout.
 		xoffset (float, optional): Offset from containing window x item location within group.
+		cursor_on_hover (int, optional): Select mouse cursor type when hovering the group (if supported).
 		id (Union[int, str], optional): (deprecated)
 	Returns:
 		Union[int, str]
@@ -9045,6 +9048,16 @@ mvNode_PinShape_Triangle=internal_dpg.mvNode_PinShape_Triangle
 mvNode_PinShape_TriangleFilled=internal_dpg.mvNode_PinShape_TriangleFilled
 mvNode_PinShape_Quad=internal_dpg.mvNode_PinShape_Quad
 mvNode_PinShape_QuadFilled=internal_dpg.mvNode_PinShape_QuadFilled
+mvMouseCursor_None=internal_dpg.mvMouseCursor_None
+mvMouseCursor_Arrow=internal_dpg.mvMouseCursor_Arrow
+mvMouseCursor_TextInput=internal_dpg.mvMouseCursor_TextInput
+mvMouseCursor_ResizeAll=internal_dpg.mvMouseCursor_ResizeAll
+mvMouseCursor_ResizeNS=internal_dpg.mvMouseCursor_ResizeNS
+mvMouseCursor_ResizeEW=internal_dpg.mvMouseCursor_ResizeEW
+mvMouseCursor_ResizeNESW=internal_dpg.mvMouseCursor_ResizeNESW
+mvMouseCursor_ResizeNWSE=internal_dpg.mvMouseCursor_ResizeNWSE
+mvMouseCursor_Hand=internal_dpg.mvMouseCursor_Hand
+mvMouseCursor_NotAllowed=internal_dpg.mvMouseCursor_NotAllowed
 mvNode_Attr_Input=internal_dpg.mvNode_Attr_Input
 mvNode_Attr_Output=internal_dpg.mvNode_Attr_Output
 mvNode_Attr_Static=internal_dpg.mvNode_Attr_Static

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -1984,7 +1984,7 @@ def font_registry(*, label: str =None, user_data: Any =None, use_internal_label:
 		internal_dpg.pop_container_stack()
 
 @contextmanager
-def group(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, width: int =0, height: int =0, indent: int =-1, parent: Union[int, str] =0, before: Union[int, str] =0, payload_type: str ='$$DPG_PAYLOAD', drag_callback: Callable =None, drop_callback: Callable =None, show: bool =True, enabled: bool =True, pos: Union[List[int], Tuple[int, ...]] =[], filter_key: str ='', delay_search: bool =False, tracked: bool =False, track_offset: float =0.5, horizontal: bool =False, horizontal_spacing: float =-1, xoffset: float =0.0, **kwargs) -> Union[int, str]:
+def group(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, width: int =0, height: int =0, indent: int =-1, parent: Union[int, str] =0, before: Union[int, str] =0, payload_type: str ='$$DPG_PAYLOAD', drag_callback: Callable =None, drop_callback: Callable =None, show: bool =True, enabled: bool =True, pos: Union[List[int], Tuple[int, ...]] =[], filter_key: str ='', delay_search: bool =False, tracked: bool =False, track_offset: float =0.5, horizontal: bool =False, horizontal_spacing: float =-1, xoffset: float =0.0, cursor_on_hover: int =internal_dpg.mvMouseCursor_None, **kwargs) -> Union[int, str]:
 	"""	 Creates a group that other widgets can belong to. The group allows item commands to be issued for all of its members.
 Enable property acts in a special way enabling/disabling everything inside the group. (Use mvStyleVar_DisabledAlpha to edit colors within the disabled group.)
 
@@ -2011,6 +2011,7 @@ Enable property acts in a special way enabling/disabling everything inside the g
 		horizontal (bool, optional): Forces child widgets to be added in a horizontal layout.
 		horizontal_spacing (float, optional): Spacing for the horizontal layout.
 		xoffset (float, optional): Offset from containing window x item location within group.
+		cursor_on_hover (int, optional): Select mouse cursor type when hovering the group (if supported).
 		id (Union[int, str], optional): (deprecated) 
 	Yields:
 		Union[int, str]
@@ -2020,7 +2021,7 @@ Enable property acts in a special way enabling/disabling everything inside the g
 		if 'id' in kwargs.keys():
 			warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 			tag=kwargs['id']
-		widget = internal_dpg.add_group(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, width=width, height=height, indent=indent, parent=parent, before=before, payload_type=payload_type, drag_callback=drag_callback, drop_callback=drop_callback, show=show, enabled=enabled, pos=pos, filter_key=filter_key, delay_search=delay_search, tracked=tracked, track_offset=track_offset, horizontal=horizontal, horizontal_spacing=horizontal_spacing, xoffset=xoffset, **kwargs)
+		widget = internal_dpg.add_group(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, width=width, height=height, indent=indent, parent=parent, before=before, payload_type=payload_type, drag_callback=drag_callback, drop_callback=drop_callback, show=show, enabled=enabled, pos=pos, filter_key=filter_key, delay_search=delay_search, tracked=tracked, track_offset=track_offset, horizontal=horizontal, horizontal_spacing=horizontal_spacing, xoffset=xoffset, cursor_on_hover=cursor_on_hover, **kwargs)
 		internal_dpg.push_container_stack(widget)
 		yield widget
 	finally:
@@ -3196,7 +3197,7 @@ def add_bool_value(*, label: str =None, user_data: Any =None, use_internal_label
 
 	return internal_dpg.add_bool_value(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, source=source, default_value=default_value, parent=parent, **kwargs)
 
-def add_button(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, width: int =0, height: int =0, indent: int =-1, parent: Union[int, str] =0, before: Union[int, str] =0, payload_type: str ='$$DPG_PAYLOAD', callback: Callable =None, drag_callback: Callable =None, drop_callback: Callable =None, show: bool =True, enabled: bool =True, pos: Union[List[int], Tuple[int, ...]] =[], filter_key: str ='', tracked: bool =False, track_offset: float =0.5, small: bool =False, arrow: bool =False, direction: int =0, repeat: bool =False, **kwargs) -> Union[int, str]:
+def add_button(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, width: int =0, height: int =0, indent: int =-1, parent: Union[int, str] =0, before: Union[int, str] =0, payload_type: str ='$$DPG_PAYLOAD', callback: Callable =None, drag_callback: Callable =None, drop_callback: Callable =None, show: bool =True, enabled: bool =True, pos: Union[List[int], Tuple[int, ...]] =[], filter_key: str ='', tracked: bool =False, track_offset: float =0.5, small: bool =False, arrow: bool =False, direction: int =0, repeat: bool =False, cursor_on_hover: int =internal_dpg.mvMouseCursor_None, **kwargs) -> Union[int, str]:
 	"""	 Adds a button.
 
 	Args:
@@ -3223,6 +3224,7 @@ def add_button(*, label: str =None, user_data: Any =None, use_internal_label: bo
 		arrow (bool, optional): Displays an arrow in place of the text string. This requires the direction keyword.
 		direction (int, optional): Sets the cardinal direction for the arrow by using constants mvDir_Left, mvDir_Up, mvDir_Down, mvDir_Right, mvDir_None. Arrow keyword must be set to True.
 		repeat (bool, optional): Hold to continuosly repeat the click.
+		cursor_on_hover (int, optional): Select mouse cursor type when hovering the button (if supported).
 		id (Union[int, str], optional): (deprecated) 
 	Returns:
 		Union[int, str]
@@ -3232,7 +3234,7 @@ def add_button(*, label: str =None, user_data: Any =None, use_internal_label: bo
 		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 		tag=kwargs['id']
 
-	return internal_dpg.add_button(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, width=width, height=height, indent=indent, parent=parent, before=before, payload_type=payload_type, callback=callback, drag_callback=drag_callback, drop_callback=drop_callback, show=show, enabled=enabled, pos=pos, filter_key=filter_key, tracked=tracked, track_offset=track_offset, small=small, arrow=arrow, direction=direction, repeat=repeat, **kwargs)
+	return internal_dpg.add_button(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, width=width, height=height, indent=indent, parent=parent, before=before, payload_type=payload_type, callback=callback, drag_callback=drag_callback, drop_callback=drop_callback, show=show, enabled=enabled, pos=pos, filter_key=filter_key, tracked=tracked, track_offset=track_offset, small=small, arrow=arrow, direction=direction, repeat=repeat, cursor_on_hover=cursor_on_hover, **kwargs)
 
 def add_candle_series(dates : Union[List[float], Tuple[float, ...]], opens : Union[List[float], Tuple[float, ...]], closes : Union[List[float], Tuple[float, ...]], lows : Union[List[float], Tuple[float, ...]], highs : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, source: Union[int, str] =0, show: bool =True, bull_color: Union[List[int], Tuple[int, ...]] =(0, 255, 113, 255), bear_color: Union[List[int], Tuple[int, ...]] =(218, 13, 79, 255), weight: float =0.25, tooltip: bool =True, time_unit: int =5, **kwargs) -> Union[int, str]:
 	"""	 Adds a candle series to a plot.
@@ -4687,7 +4689,7 @@ def add_font_registry(*, label: str =None, user_data: Any =None, use_internal_la
 
 	return internal_dpg.add_font_registry(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, show=show, **kwargs)
 
-def add_group(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, width: int =0, height: int =0, indent: int =-1, parent: Union[int, str] =0, before: Union[int, str] =0, payload_type: str ='$$DPG_PAYLOAD', drag_callback: Callable =None, drop_callback: Callable =None, show: bool =True, enabled: bool =True, pos: Union[List[int], Tuple[int, ...]] =[], filter_key: str ='', delay_search: bool =False, tracked: bool =False, track_offset: float =0.5, horizontal: bool =False, horizontal_spacing: float =-1, xoffset: float =0.0, **kwargs) -> Union[int, str]:
+def add_group(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, width: int =0, height: int =0, indent: int =-1, parent: Union[int, str] =0, before: Union[int, str] =0, payload_type: str ='$$DPG_PAYLOAD', drag_callback: Callable =None, drop_callback: Callable =None, show: bool =True, enabled: bool =True, pos: Union[List[int], Tuple[int, ...]] =[], filter_key: str ='', delay_search: bool =False, tracked: bool =False, track_offset: float =0.5, horizontal: bool =False, horizontal_spacing: float =-1, xoffset: float =0.0, cursor_on_hover: int =internal_dpg.mvMouseCursor_None, **kwargs) -> Union[int, str]:
 	"""	 Creates a group that other widgets can belong to. The group allows item commands to be issued for all of its members.
 Enable property acts in a special way enabling/disabling everything inside the group. (Use mvStyleVar_DisabledAlpha to edit colors within the disabled group.)
 
@@ -4714,6 +4716,7 @@ Enable property acts in a special way enabling/disabling everything inside the g
 		horizontal (bool, optional): Forces child widgets to be added in a horizontal layout.
 		horizontal_spacing (float, optional): Spacing for the horizontal layout.
 		xoffset (float, optional): Offset from containing window x item location within group.
+		cursor_on_hover (int, optional): Select mouse cursor type when hovering the group (if supported).
 		id (Union[int, str], optional): (deprecated) 
 	Returns:
 		Union[int, str]
@@ -4723,7 +4726,7 @@ Enable property acts in a special way enabling/disabling everything inside the g
 		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 		tag=kwargs['id']
 
-	return internal_dpg.add_group(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, width=width, height=height, indent=indent, parent=parent, before=before, payload_type=payload_type, drag_callback=drag_callback, drop_callback=drop_callback, show=show, enabled=enabled, pos=pos, filter_key=filter_key, delay_search=delay_search, tracked=tracked, track_offset=track_offset, horizontal=horizontal, horizontal_spacing=horizontal_spacing, xoffset=xoffset, **kwargs)
+	return internal_dpg.add_group(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, width=width, height=height, indent=indent, parent=parent, before=before, payload_type=payload_type, drag_callback=drag_callback, drop_callback=drop_callback, show=show, enabled=enabled, pos=pos, filter_key=filter_key, delay_search=delay_search, tracked=tracked, track_offset=track_offset, horizontal=horizontal, horizontal_spacing=horizontal_spacing, xoffset=xoffset, cursor_on_hover=cursor_on_hover, **kwargs)
 
 def add_handler_registry(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, show: bool =True, **kwargs) -> Union[int, str]:
 	"""	 Adds a handler registry.
@@ -10018,6 +10021,16 @@ mvNode_PinShape_Triangle=internal_dpg.mvNode_PinShape_Triangle
 mvNode_PinShape_TriangleFilled=internal_dpg.mvNode_PinShape_TriangleFilled
 mvNode_PinShape_Quad=internal_dpg.mvNode_PinShape_Quad
 mvNode_PinShape_QuadFilled=internal_dpg.mvNode_PinShape_QuadFilled
+mvMouseCursor_None=internal_dpg.mvMouseCursor_None
+mvMouseCursor_Arrow=internal_dpg.mvMouseCursor_Arrow
+mvMouseCursor_TextInput=internal_dpg.mvMouseCursor_TextInput
+mvMouseCursor_ResizeAll=internal_dpg.mvMouseCursor_ResizeAll
+mvMouseCursor_ResizeNS=internal_dpg.mvMouseCursor_ResizeNS
+mvMouseCursor_ResizeEW=internal_dpg.mvMouseCursor_ResizeEW
+mvMouseCursor_ResizeNESW=internal_dpg.mvMouseCursor_ResizeNESW
+mvMouseCursor_ResizeNWSE=internal_dpg.mvMouseCursor_ResizeNWSE
+mvMouseCursor_Hand=internal_dpg.mvMouseCursor_Hand
+mvMouseCursor_NotAllowed=internal_dpg.mvMouseCursor_NotAllowed
 mvNode_Attr_Input=internal_dpg.mvNode_Attr_Input
 mvNode_Attr_Output=internal_dpg.mvNode_Attr_Output
 mvNode_Attr_Static=internal_dpg.mvNode_Attr_Static

--- a/dearpygui/demo.py
+++ b/dearpygui/demo.py
@@ -3252,6 +3252,21 @@ def show_demo():
             for handler in dpg.get_item_children("__demo_mouse_handler", 1):
                 dpg.set_item_callback(handler, _event_handler)
 
+            with dpg.tree_node(label="Mouse Cursors"):
+                cursors = [("Arrow", dpg.mvMouseCursor_Arrow), ("TextInput", dpg.mvMouseCursor_TextInput),
+                               ("ResizeAll", dpg.mvMouseCursor_ResizeAll), ("ResizeNS", dpg.mvMouseCursor_ResizeNS),
+                               ("ResizeEW", dpg.mvMouseCursor_ResizeEW), ("ResizeNESW", dpg.mvMouseCursor_ResizeNESW),
+                               ("ResizeNWSE", dpg.mvMouseCursor_ResizeNWSE), ("Hand", dpg.mvMouseCursor_Hand),
+                               ("NotAllowed", dpg.mvMouseCursor_NotAllowed)]
+                dpg.add_text("Hover to see mouse cursors:")
+                with dpg.tooltip(dpg.last_item()):
+                    dpg.add_text("Your application can render a different mouse cursor based on what ImGui::GetMouseCursor() returns.\n"
+                "If software cursor rendering (io.MouseDrawCursor) is set ImGui will draw the right cursor for you,\n"
+                "otherwise your backend needs to handle it.")
+                for i in range(len(cursors)):
+                    with dpg.group(horizontal=True, cursor_on_hover=cursors[i][1]):
+                        dpg.add_text(cursors[i][0], bullet=True)
+
         with dpg.collapsing_header(label="Drag & Drop"):
            
            with dpg.tree_node(label="Help"):

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -143,6 +143,17 @@ GetModuleConstants()
 		ModuleConstants.push_back({ "mvNode_PinShape_Quad", ImNodesPinShape_Quad });
 		ModuleConstants.push_back({ "mvNode_PinShape_QuadFilled", ImNodesPinShape_QuadFilled });
 
+		ModuleConstants.push_back({ "mvMouseCursor_None", ImGuiMouseCursor_None});
+		ModuleConstants.push_back({ "mvMouseCursor_Arrow", ImGuiMouseCursor_Arrow});
+		ModuleConstants.push_back({ "mvMouseCursor_TextInput", ImGuiMouseCursor_TextInput });
+		ModuleConstants.push_back({ "mvMouseCursor_ResizeAll", ImGuiMouseCursor_ResizeAll});
+		ModuleConstants.push_back({ "mvMouseCursor_ResizeNS", ImGuiMouseCursor_ResizeNS});
+		ModuleConstants.push_back({ "mvMouseCursor_ResizeEW", ImGuiMouseCursor_ResizeEW});
+		ModuleConstants.push_back({ "mvMouseCursor_ResizeNESW", ImGuiMouseCursor_ResizeNESW});
+		ModuleConstants.push_back({ "mvMouseCursor_ResizeNWSE", ImGuiMouseCursor_ResizeNWSE});
+		ModuleConstants.push_back({ "mvMouseCursor_Hand", ImGuiMouseCursor_Hand});
+		ModuleConstants.push_back({ "mvMouseCursor_NotAllowed", ImGuiMouseCursor_NotAllowed});
+
 		ModuleConstants.push_back({ "mvNode_Attr_Input", 0L });
 		ModuleConstants.push_back({ "mvNode_Attr_Output", 1L});
 		ModuleConstants.push_back({ "mvNode_Attr_Static", 2L});

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -1794,6 +1794,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         args.push_back({ mvPyDataType::Bool, "arrow", mvArgType::KEYWORD_ARG, "False", "Displays an arrow in place of the text string. This requires the direction keyword." });
         args.push_back({ mvPyDataType::Integer, "direction", mvArgType::KEYWORD_ARG, "0", "Sets the cardinal direction for the arrow by using constants mvDir_Left, mvDir_Up, mvDir_Down, mvDir_Right, mvDir_None. Arrow keyword must be set to True." });
         args.push_back({ mvPyDataType::Bool, "repeat", mvArgType::KEYWORD_ARG, "False", "Hold to continuosly repeat the click." });
+        args.push_back({ mvPyDataType::Integer, "cursor_on_hover", mvArgType::KEYWORD_ARG, "internal_dpg.mvMouseCursor_None", "Select mouse cursor type when hovering the button (if supported)." });
 
         setup.about = "Adds a button.";
         break;
@@ -2142,6 +2143,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         args.push_back({ mvPyDataType::Bool, "horizontal", mvArgType::KEYWORD_ARG, "False", "Forces child widgets to be added in a horizontal layout." });
         args.push_back({ mvPyDataType::Float, "horizontal_spacing", mvArgType::KEYWORD_ARG, "-1", "Spacing for the horizontal layout." });
         args.push_back({ mvPyDataType::Float, "xoffset", mvArgType::KEYWORD_ARG, "0.0", "Offset from containing window x item location within group." });
+        args.push_back({ mvPyDataType::Integer, "cursor_on_hover", mvArgType::KEYWORD_ARG, "internal_dpg.mvMouseCursor_None", "Select mouse cursor type when hovering the group (if supported)." });
 
         setup.about = "Creates a group that other widgets can belong to. The group allows item commands to be issued for all of its members.\nEnable property acts in a special way enabling/disabling everything inside the group. (Use mvStyleVar_DisabledAlpha to edit colors within the disabled group.)";
         setup.category = { "Containers", "Widgets" };

--- a/src/mvBasicWidgets.cpp
+++ b/src/mvBasicWidgets.cpp
@@ -36,12 +36,14 @@ DearPyGui::fill_configuration_dict(const mvButtonConfig& inConfig, PyObject* out
 	mvPyObject py_arrow = ToPyBool(inConfig.arrow);
 	mvPyObject py_direction = ToPyInt(inConfig.direction);
 	mvPyObject py_repeat = ToPyBool(inConfig.repeat);
+	mvPyObject py_cursor_on_hover = ToPyInt(inConfig.cursor_on_hover);
 
 
 	PyDict_SetItemString(outDict, "small", py_small);
 	PyDict_SetItemString(outDict, "arrow", py_arrow);
 	PyDict_SetItemString(outDict, "direction", py_direction);
 	PyDict_SetItemString(outDict, "repeat", py_repeat);
+	PyDict_SetItemString(outDict, "cursor_on_hover", py_cursor_on_hover);
 }
 
 void
@@ -714,6 +716,7 @@ DearPyGui::set_configuration(PyObject* inDict, mvButtonConfig& outConfig)
 	if (PyObject* item = PyDict_GetItemString(inDict, "arrow")) outConfig.arrow = ToBool(item);
 	if (PyObject* item = PyDict_GetItemString(inDict, "direction")) outConfig.direction = static_cast<ImGuiDir>(ToInt(item));
 	if (PyObject* item = PyDict_GetItemString(inDict, "repeat")) outConfig.repeat = ToBool(item);
+	if (PyObject* item = PyDict_GetItemString(inDict, "cursor_on_hover")) outConfig.cursor_on_hover = ToInt(item);
 }
 
 void
@@ -2754,6 +2757,9 @@ DearPyGui::draw_button(ImDrawList* drawlist, mvAppItem& item, const mvButtonConf
 			else
 				mvAddCallback(item.getCallback(false), item.config.alias, nullptr, item.config.user_data);
 		}
+
+		if (config.cursor_on_hover != ImGuiMouseCursor_None && ImGui::IsItemHovered())
+			ImGui::SetMouseCursor(config.cursor_on_hover);
 	}
 
 	//-----------------------------------------------------------------------------

--- a/src/mvBasicWidgets.h
+++ b/src/mvBasicWidgets.h
@@ -220,6 +220,7 @@ struct mvButtonConfig
     bool     small_button = false;
     bool     arrow = false;
     bool     repeat = false;
+    ImGuiMouseCursor cursor_on_hover = ImGuiMouseCursor_None;
 };
 
 struct mvComboConfig

--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -90,6 +90,7 @@ DearPyGui::fill_configuration_dict(const mvGroupConfig& inConfig, PyObject* outD
     PyDict_SetItemString(outDict, "horizontal", mvPyObject(ToPyBool(inConfig.horizontal)));
     PyDict_SetItemString(outDict, "horizontal_spacing", mvPyObject(ToPyFloat(inConfig.hspacing)));
     PyDict_SetItemString(outDict, "xoffset", mvPyObject(ToPyFloat(inConfig.xoffset)));
+    PyDict_SetItemString(outDict, "cursor_on_hover", mvPyObject(ToPyInt(inConfig.cursor_on_hover)));
 }
 
 void
@@ -310,6 +311,7 @@ DearPyGui::set_configuration(PyObject* inDict, mvGroupConfig& outConfig)
     if (PyObject* item = PyDict_GetItemString(inDict, "horizontal")) outConfig.horizontal = ToBool(item);
     if (PyObject* item = PyDict_GetItemString(inDict, "horizontal_spacing")) outConfig.hspacing = ToFloat(item);
     if (PyObject* item = PyDict_GetItemString(inDict, "xoffset")) outConfig.xoffset = ToFloat(item);
+    if (PyObject* item = PyDict_GetItemString(inDict, "cursor_on_hover")) outConfig.cursor_on_hover = ToInt(item);
 }
 
 void
@@ -1125,6 +1127,9 @@ DearPyGui::draw_group(ImDrawList* drawlist, mvAppItem& item, mvGroupConfig& conf
             ImGui::PopItemWidth();
 
         ImGui::EndGroup();
+
+        if (config.cursor_on_hover != ImGuiMouseCursor_None && ImGui::IsItemHovered())
+            ImGui::SetMouseCursor(config.cursor_on_hover);
 
         if (!item.config.enabled)
             ImGui::EndDisabled();

--- a/src/mvContainers.h
+++ b/src/mvContainers.h
@@ -113,6 +113,7 @@ struct mvGroupConfig
     bool  horizontal = false;
     float hspacing = -1.0f;
     float xoffset = 0.0f;
+    ImGuiMouseCursor    cursor_on_hover = ImGuiMouseCursor_None;
 };
 
 struct mvDragPayloadConfig


### PR DESCRIPTION
**Description:**
As described in #2248 I've implemented a way to change mouse cursor when hovering widgets. As suggested by @v-ein I've added it as a paramter to `add_group`, but also (for convenience IMO), I've added it to `add_button`.

In my Ubuntu 24 I wasn't able to render all the cursors, but I guess it's something related to the backend (actually you can set `io.MouseDrawCursor` to `True` to see all of them, but doing so degraded my performance a lot)

Closes #2248