### PR TITLE
Move data type of axes limits and mouse plot pos from `float` to `double`

### DIFF
--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -1109,8 +1109,8 @@ static PyObject*
 set_axis_limits_constraints(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	PyObject* axisraw;
-	float vmin;
-	float vmax;
+	double vmin;
+	double vmax;
 	auto tag = "set_axis_limits_constraints";
 
 	if (!Parse((GetParsers())[tag], args, kwargs, __FUNCTION__, &axisraw, &vmin, &vmax))
@@ -1137,7 +1137,7 @@ set_axis_limits_constraints(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	mvPlotAxis* graph = static_cast<mvPlotAxis*>(aplot);
 	graph->configData.setLimitsRange = true;
-	graph->configData.constraints_range = ImVec2(vmin, vmax);
+	graph->configData.constraints_range = ImPlotRange(vmin, vmax);
 	return GetPyNone();
 }
 
@@ -1249,8 +1249,8 @@ static PyObject*
 set_axis_limits(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	PyObject* axisraw;
-	float ymin;
-	float ymax;
+	double ymin;
+	double ymax;
 
 	if (!Parse((GetParsers())["set_axis_limits"], args, kwargs, __FUNCTION__, &axisraw, &ymin, &ymax))
 		return GetPyNone();
@@ -1276,7 +1276,7 @@ set_axis_limits(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	mvPlotAxis* graph = static_cast<mvPlotAxis*>(aplot);
 	graph->configData.setLimits = true;
-	graph->configData.limits = ImVec2(ymin, ymax);
+	graph->configData.limits = ImPlotRange(ymin, ymax);
 	return GetPyNone();
 }
 
@@ -1379,8 +1379,8 @@ get_axis_limits(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	mvPlotAxis* graph = static_cast<mvPlotAxis*>(aplot);
 
-	const ImVec2& lim = graph->configData.limits_actual;
-	return ToPyPair(lim.x, lim.y);
+	const ImPlotRange& lim = graph->configData.limits_actual;
+	return ToPyPair(lim.Min, lim.Max);
 }
 
 static PyObject*
@@ -2854,9 +2854,7 @@ get_plot_mouse_pos(PyObject* self, PyObject* args, PyObject* kwargs)
 	if (!Parse((GetParsers())["get_plot_mouse_pos"], args, kwargs, __FUNCTION__))
 		return GetPyNone();
 
-	mvVec2 pos = { (f32)GContext->input.mousePlotPos.x, (f32)GContext->input.mousePlotPos.y };
-
-	return ToPyPair(pos.x, pos.y);
+	return ToPyPair(GContext->input.mousePlotPos.x, GContext->input.mousePlotPos.y);
 }
 
 static PyObject*

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -268,8 +268,8 @@ InsertParser_Block0(std::map<std::string, mvPythonParser>& parsers)
 		std::vector<mvPythonDataElement> args;
 		args.reserve(3);
 		args.push_back({ mvPyDataType::UUID, "axis" });
-		args.push_back({ mvPyDataType::Float, "vmin" });
-		args.push_back({ mvPyDataType::Float, "vmax" });
+		args.push_back({ mvPyDataType::Double, "vmin" });
+		args.push_back({ mvPyDataType::Double, "vmax" });
 
 		mvPythonParserSetup setup;
 		setup.about = "Sets an axis' limits constraints so that users can't pan beyond a min or max value";
@@ -320,8 +320,8 @@ InsertParser_Block0(std::map<std::string, mvPythonParser>& parsers)
 		std::vector<mvPythonDataElement> args;
 		args.reserve(3);
 		args.push_back({ mvPyDataType::UUID, "axis" });
-		args.push_back({ mvPyDataType::Float, "ymin" });
-		args.push_back({ mvPyDataType::Float, "ymax" });
+		args.push_back({ mvPyDataType::Double, "ymin" });
+		args.push_back({ mvPyDataType::Double, "ymax" });
 
 		mvPythonParserSetup setup;
 		setup.about = "Sets limits on the axis for pan and zoom.";

--- a/src/mvContext.h
+++ b/src/mvContext.h
@@ -49,9 +49,15 @@ struct mvInput
         std::atomic<float> y;
     };
 
+    struct AtomicDoubleVec2
+    {
+        std::atomic<double> x;
+        std::atomic<double> y;
+    };
+
     AtomicVec2       mousePos = { 0, 0 };
     AtomicVec2       mouseGlobalPos = { 0, 0 };
-    AtomicFloatVec2  mousePlotPos = { 0, 0 };
+    AtomicDoubleVec2 mousePlotPos = { 0, 0 };
     AtomicVec2       mouseDrawingPos = { 0, 0 };
     std::atomic_int  mouseDragThreshold = 20;
     AtomicVec2       mouseDragDelta = { 0, 0 };

--- a/src/mvMetricsWindow.cpp
+++ b/src/mvMetricsWindow.cpp
@@ -168,7 +168,7 @@ void mvMetricsWindow::drawWidgets()
             //DebugItem("Active Window: ", GContext->itemRegistry->getActiveWindow().c_str());
             DebugItem("Local Mouse Position:", (float)GContext->input.mousePos.x, (float)GContext->input.mousePos.y);
             DebugItem("Global Mouse Position:", (float)io.MousePos.x, (float)io.MousePos.y);
-            DebugItem("Plot Mouse Position:", (float)GContext->input.mousePlotPos.x, (float)GContext->input.mousePlotPos.y);
+            DebugItem("Plot Mouse Position:", (double)GContext->input.mousePlotPos.x, (double)GContext->input.mousePlotPos.y);
             DebugItem("Mouse Drag Delta:", (float)GContext->input.mouseDragDelta.x, (float)GContext->input.mouseDragDelta.y);
             DebugItem("Mouse Drag Threshold:", (float)GContext->input.mouseDragThreshold);
 

--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -453,7 +453,7 @@ DearPyGui::draw_plot(ImDrawList* drawlist, mvAppItem& item, mvPlotConfig& config
 				ImPlot::SetupAxis(id_axis, axis->config.specifiedLabel.c_str(), flags);
 				if (axis->configData.setLimits || axis->configData._dirty)
 				{
-					ImPlot::SetupAxisLimits(id_axis, axis->configData.limits.x, axis->configData.limits.y, ImGuiCond_Always);
+					ImPlot::SetupAxisLimits(id_axis, axis->configData.limits.Min, axis->configData.limits.Max, ImGuiCond_Always);
 					axis->configData._dirty = false;  // TODO: Check if this is it really useful
 				}
 				if (!axis->configData.formatter.empty())
@@ -462,7 +462,7 @@ DearPyGui::draw_plot(ImDrawList* drawlist, mvAppItem& item, mvPlotConfig& config
 				ImPlot::SetupAxisScale(id_axis, axis->configData.scale);
 
 				if (axis->configData.setLimitsRange)
-					ImPlot::SetupAxisLimitsConstraints(id_axis, axis->configData.constraints_range.x, axis->configData.constraints_range.y);
+					ImPlot::SetupAxisLimitsConstraints(id_axis, axis->configData.constraints_range.Min, axis->configData.constraints_range.Max);
 				if (axis->configData.setZoomRange)
 					ImPlot::SetupAxisZoomConstraints(id_axis, axis->configData.zoom_range.x, axis->configData.zoom_range.y);
 
@@ -702,19 +702,11 @@ DearPyGui::draw_plot_axis(ImDrawList* drawlist, mvAppItem& item, mvPlotAxisConfi
 
 	// x axis
 	if (config.axis <= ImAxis_X3)
-	{
-		auto plotLimits = ImPlot::GetPlotLimits(config.axis, IMPLOT_AUTO);
-		config.limits_actual.x = (float)plotLimits.X.Min;
-		config.limits_actual.y = (float)plotLimits.X.Max;
-	}
+		config.limits_actual = ImPlot::GetPlotLimits(config.axis, IMPLOT_AUTO).X;
 
 	// y axis
 	else
-	{
-		auto plotLimits = ImPlot::GetPlotLimits(IMPLOT_AUTO, config.axis);
-		config.limits_actual.x = (float)plotLimits.Y.Min;
-		config.limits_actual.y = (float)plotLimits.Y.Max;
-	}
+		config.limits_actual = ImPlot::GetPlotLimits(config.axis, IMPLOT_AUTO).Y;
 
 	config.flags = ImPlot::GetCurrentContext()->CurrentPlot->Axes[config.axis].Flags;
 
@@ -2323,8 +2315,8 @@ DearPyGui::draw_custom_series(ImDrawList* drawlist, mvAppItem& item, mvCustomSer
 			static int extras = 4;
 			mvSubmitCallback([&, mouse, mouse2]() {
 				PyObject* helperData = PyDict_New();
-				PyDict_SetItemString(helperData, "MouseX_PlotSpace", ToPyFloat(mouse.x));
-				PyDict_SetItemString(helperData, "MouseY_PlotSpace", ToPyFloat(mouse.y));
+				PyDict_SetItemString(helperData, "MouseX_PlotSpace", ToPyDouble(mouse.x));
+				PyDict_SetItemString(helperData, "MouseY_PlotSpace", ToPyDouble(mouse.y));
 				PyDict_SetItemString(helperData, "MouseX_PixelSpace", ToPyFloat(mouse2.x));
 				PyDict_SetItemString(helperData, "MouseY_PixelSpace", ToPyFloat(mouse2.y));
 				PyObject* appData = PyTuple_New(config.channelCount + extras);

--- a/src/mvPlotting.h
+++ b/src/mvPlotting.h
@@ -394,9 +394,9 @@ struct mvPlotAxisConfig
     bool                     setZoomRange = false;
     ImPlotScale              scale = ImPlotScale_Linear;
     std::string              formatter;
-    ImVec2                   limits;
-    ImVec2                   limits_actual;
-    ImVec2                   constraints_range;
+    ImPlotRange              limits;
+    ImPlotRange              limits_actual;
+    ImPlotRange              constraints_range;
     ImVec2                   zoom_range;
     std::vector<std::string> labels;
     std::vector<double>      labelLocations;


### PR DESCRIPTION
**Description:**
Lately this topic has been discussed more than usual (like [here](https://discord.com/channels/736279277242417272/1291192785608769536))  so I decided to make public what I've done some time ago. It's a simple and probably naive solution, so I'm open to improvements. 

This solution actually closes #1847 (I've tested the example) and hopefully it should close #2067, #386 but on the other side I think it's still not enough precision for this #2157

**Concerning areas:**
I've also read that @v-ein has (rightly) made the point of performance, but it shouldn't really be a problem (as far as I read, both from @axeldavy and the internet) also because `double` type has been already used in a while by ImPlot. 

**Notes:**
I've also changed the data structures from `ImVec2` to `ImPlotRange`, I hope it's not a problem.