### PR TITLE
Store new axis ID when automatically deduced

### DIFF
--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -446,16 +446,15 @@ DearPyGui::draw_plot(ImDrawList* drawlist, mvAppItem& item, mvPlotConfig& config
 					{
 						id_axis = static_cast<ImAxis_>(next_y_axis);
 						flags |= ImPlotAxisFlags_Opposite;
+						axis->configData.axis = next_y_axis;
 					}
 					++next_y_axis;
 				}
 
 				ImPlot::SetupAxis(id_axis, axis->config.specifiedLabel.c_str(), flags);
-				if (axis->configData.setLimits || axis->configData._dirty)
-				{
+				if (axis->configData.setLimits)
 					ImPlot::SetupAxisLimits(id_axis, axis->configData.limits.x, axis->configData.limits.y, ImGuiCond_Always);
-					axis->configData._dirty = false;  // TODO: Check if this is it really useful
-				}
+
 				if (!axis->configData.formatter.empty())
 					ImPlot::SetupAxisFormat(id_axis, axis->configData.formatter.c_str());
 

--- a/src/mvPlotting.h
+++ b/src/mvPlotting.h
@@ -401,7 +401,6 @@ struct mvPlotAxisConfig
     std::vector<std::string> labels;
     std::vector<double>      labelLocations;
     std::vector<const char*> clabels; // to prevent conversion from string to char* every frame
-    bool                     _dirty = false;
 };
 
 struct mvPlotConfig


### PR DESCRIPTION
**Description:**
After v2.0.0, it's been introduced the nomination `mvYAxis1/2/3` instead of the classical one `mvYAxis`. To preserve legacy code it's been implemented a way to support both. This had a little problem because it didn't save the new axis id in `configData.axis` as pointed out by @v-ein. This has been now fixed.

Closes #2412 