### PR TITLE
Fix `ToPyList` with `mvVec2/4` values

### DIFF
--- a/src/mvPyUtils.cpp
+++ b/src/mvPyUtils.cpp
@@ -624,7 +624,7 @@ ToPyList(const std::vector<mvVec2>& value)
         PyObject* item = PyList_New(2);
         PyList_SetItem(item, 0, PyFloat_FromDouble (value[i].x));
         PyList_SetItem(item, 1, PyFloat_FromDouble (value[i].y));
-        PyList_SetItem(item, i, item);
+        PyList_SetItem(result, i, item);
     }
 
     return result;
@@ -644,7 +644,7 @@ ToPyList(const std::vector<mvVec4>& value)
         PyList_SetItem(item, 1, PyFloat_FromDouble(value[i].y));
         PyList_SetItem(item, 2, PyFloat_FromDouble(value[i].z));
         PyList_SetItem(item, 3, PyFloat_FromDouble(value[i].w));
-        PyList_SetItem(item, i, item);
+        PyList_SetItem(result, i, item);
     }
 
     return result;


### PR DESCRIPTION
---
name: Pull Request
about: Fixing a bug
title: Fix `ToPyList` with `mvVec2/4` values

---

**Description:**
The function `ToPyList` had a problem inside of it, where the actual output was never filled the values but left empty. This explains the errors in #2462 where the list of points was left empty and used to throw error when filled with more than 4 points.

Simply replacing the name of the variables fixed the problem.

Closes #2462
