### PR TITLE
fix: tables with zero columns break theme/font stack

### DIFF
--- a/src/mvTables.cpp
+++ b/src/mvTables.cpp
@@ -136,6 +136,22 @@ void mvTable::draw(ImDrawList* drawlist, float x, float y)
 	if (!config.show)
 		return;
 
+	// Validating column visibility: if there are no any visible/enabled columns,
+	// an attempt to render the table will corrupt data structures within ImGui,
+	// and will most probably lead to a crash on app shutdown.  On the other hand,
+	// if there are no visible columns, we don't have anything to draw, really.
+	bool all_hidden = true;
+	for (auto& item : childslots[0])
+	{
+		if (item->config.enabled && item->config.show)
+		{
+			all_hidden = false;
+			break;
+		}
+	}
+	if (all_hidden)
+		return;
+
 	// push font if a font object is attached
 	if (font)
 	{
@@ -148,25 +164,6 @@ void mvTable::draw(ImDrawList* drawlist, float x, float y)
 
 	{
 		ScopedID id(uuid);
-
-		if (_columns == 0)
-			return;
-
-		// Validating column visibility: if there are no any visible/enabled columns,
-		// an attempt to render the table will corrupt data structures within ImGui,
-		// and will most probably lead to a crash on app shutdown.  On the other hand,
-		// if there are no visible columns, we don't have anything to draw, really.
-		bool all_hidden = true;
-		for (auto& item : childslots[0])
-		{
-			if (item->config.enabled && item->config.show)
-			{
-				all_hidden = false;
-				break;
-			}
-		}
-		if (all_hidden)
-			return;
 
 		auto row_renderer = [&](mvAppItem* row, mvAppItem* prev_visible_row=nullptr)
 		{


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: A table without columns breaks font/theme stack
assignees: @hoffstadt 

---

Closes #2075

**Description:**
A table with no columns and a theme or font (however weird that sounds) puts the theme/font onto the stack but does not remove it, thus breaking styles everywhere else.

This PR moves the check for no-columns to the top of the `draw()` method (it actually checks for "no visible columns" -- this condition was added in DPG 2.0, we just need to perform the check earlier, before applying the theme/font).

**Concerning Areas:**
None.