### PR TITLE
Table contents not rendered if added to an initially empty table

### DIFF
--- a/src/mvTables.cpp
+++ b/src/mvTables.cpp
@@ -362,13 +362,17 @@ void mvTable::draw(ImDrawList* drawlist, float x, float y)
 
 			// columns
 			int columnnum = 0;
+			int last_row = ImGui::TableGetRowIndex();
 			for (auto& item : childslots[0])
 			{
 				ImGuiTableColumnFlags flags = ImGui::TableGetColumnFlags(columnnum);
 				item->state.lastFrameUpdate = GContext->frame;
 				item->state.visible = flags & ImGuiTableColumnFlags_IsVisible;
 				item->state.hovered = flags & ImGuiTableColumnFlags_IsHovered;
-                if (item->config.enabled)
+				// Note: when the table is empty, TableGetColumnFlags will incorrectly return
+				// zero status flags for all columns.  While this is fine for `visible` and `hovered`,
+				// we definitely don't want to push that zero into `show`.
+                if (item->config.enabled && last_row >= 0)
 				{
 					// Sync the flag with the actual column state controlled by the
 					// user via context menu.


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Table contents not rendered if added to an initially empty table
assignees: @hoffstadt 

---

Closes #2449

**Description:**
Currently, `mvTable` updates the `show` flag on columns from ImGui table state using `ImGui::TableGetColumnFlags()`. This is done to sync the user-controlled state of the columns (show flags in the context menu) with the actual state of DPG items.

Unfortunately on an empty table, that ImGui function returns uninitialized flags, leading to `show` being reset and all table columns becoming hidden. That is, if an empty table gets rendered at least once, all its columns become hidden, and in future its rendering is entirely skipped.

This PR adds a workaround where the `show` flags are only synced on non-empty tables. Of course it would be better to fix the issue in ImGui, but at least we can handle it quickly on DPG side.

**Concerning Areas:**
None.