### PR TITLE
Fix for a build error on modern MSVC

### DIFF
--- a/src/mvLoadingIndicatorCustom.cpp
+++ b/src/mvLoadingIndicatorCustom.cpp
@@ -96,7 +96,7 @@ void LoadingIndicatorCircle2(const char* label, float indicatorRadiusFactor, flo
 
     int num_segments = 30;
 
-    int start = abs(ImSin(g.Time * 1.8f) * (num_segments - 5));
+    int start = abs((int)(ImSin(g.Time * 1.8f) * (num_segments - 5)));
 
     const float a_min = IM_PI * 2.0f * ((float)start) / (float)num_segments;
     const float a_max = IM_PI * 2.0f * ((float)num_segments - 3) / (float)num_segments;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Fix for a build error on modern MSVC
assignees: ''

---

**Description:**
GitHub is having issues with building DPG for Windows. In particular, the compiler can't resolve an ambiguous `abs()` call where the argument is `float` (and `abs` is an integer function). While we could simply change `start` to `float`, I preferred to keep the current logic because I'm going to add another PR in future that will fix more issues in the loading indicator, so no need to change the behavior now. I'm only helping the compiler choose the right `abs` overload :).

**Concerning Areas:**
None.
