### PR TITLE
fix (demo): Corrected inconsistencies in the divergent bar stacks demo.

### DIFF
--- a/dearpygui/demo.py
+++ b/dearpygui/demo.py
@@ -2142,9 +2142,9 @@ def show_demo():
                         
                         def divergent_stack_cb(sender, app_data, user_data):
                             if app_data:
-                                dpg.configure_item("divergent_stack_series", values=data_div, label_ids=labels_div, group_size=len(labels_reg), group_width=0.75, shift=0, stacked=True, horizontal=True)
+                                dpg.configure_item("divergent_stack_series", values=data_div, label_ids=labels_div, group_size=len(labels_div), group_width=0.75, shift=0, stacked=True, horizontal=True)
                             else:
-                                dpg.configure_item("divergent_stack_series", values=data_reg, label_ids=labels_reg, group_size=len(labels_div), group_width=0.75, shift=0, stacked=True, horizontal=True)
+                                dpg.configure_item("divergent_stack_series", values=data_reg, label_ids=labels_reg, group_size=len(labels_reg), group_width=0.75, shift=0, stacked=True, horizontal=True)
                         
                         dpg.add_checkbox(label="Divergent", tag="divergent_stack_cb", default_value=True, callback=divergent_stack_cb)
                         with dpg.plot(label="PolitiFact: Who Lies More?", height=400, width=-1):


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Corrected inconsistencies in the divergent bar stacks demo.
assignees: @v-ein

---

**Description:**
The Bar Stacks section of demo.py contains incorrect references to `labels_div`/`labels_reg`, which leads to an exception when the user clicks the Divergent check box. Here's the error that occurs:

```
Message:   `values` size 120 must be a multiple of `group_size` 9
```

This PR corrects the references.

Kudos to @QuattroMusic for finding it!

**Concerning Areas:**
None.