### PR TITLE
fix (win32): Invoking viewport_resize_callback at the very start

### DIFF
--- a/src/mvViewport_win32.cpp
+++ b/src/mvViewport_win32.cpp
@@ -223,7 +223,7 @@ mvHandleMsg(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) noexcept
 	case WM_SIZE:
 	case WM_SIZING:
 
-		if (graphicsData != nullptr && wParam != SIZE_MINIMIZED)
+		if (wParam != SIZE_MINIMIZED)
 		{
 			RECT rect;
 			RECT crect;
@@ -267,10 +267,13 @@ mvHandleMsg(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) noexcept
 			viewport->width = (UINT)LOWORD(lParam);
 			viewport->height = (UINT)HIWORD(lParam);
 
-			if (viewport->decorated)
-				resize_swapchain(graphics, (int)(UINT)LOWORD(lParam), (int)(UINT)HIWORD(lParam));
-			else
-				resize_swapchain(graphics, awidth, aheight);
+			if (graphicsData != nullptr)
+			{
+				if (viewport->decorated)
+					resize_swapchain(graphics, (int)(UINT)LOWORD(lParam), (int)(UINT)HIWORD(lParam));
+				else
+					resize_swapchain(graphics, awidth, aheight);
+			}
 		}
 		return 0;
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Invoking `viewport_resize_callback` at the very start
assignees: ''

---


**Description:**
This fixes a regression introduced in #2521. Prior to that PR, DPG was calling `viewport_resize_callback` at app start (on Windows), making it possible to dynamically resize GUI according to the actual client size of the viewport. It wasn't very stable and the callback was often called a dozen frames after startup, but was called anyway. PR 2521 changed that to a no-call. This PR brings the callback back, and also the call typically occurs on frame 1 (if Windows sends `WM_SIZE` in time, which it typically does do).

**Concerning Areas:**
None.