### PR TITLE
Update node-editor.rst to fix broken link by removing expired token

### DIFF
--- a/docs/source/documentation/node-editor.rst
+++ b/docs/source/documentation/node-editor.rst
@@ -7,7 +7,7 @@ It allows you to view, modify, and create new node connections.
 
 You can see an example below
 
-.. image:: https://raw.githubusercontent.com/Nelarius/imnodes/master/img/imnodes.gif?token=ADH_jEpqbBrw0nH-BUmOip490dyO2CnRks5cVZllwA%3D%3D
+.. image:: https://raw.githubusercontent.com/Nelarius/imnodes/master/img/imnodes.gif
 
 **There are 4 main components**
 


### PR DESCRIPTION
<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
<!-- A clear and concise description of what the pull request contains. -->
The link to the node editor GIF is currently broken due to an accidentally included authentication token in the URL. This token appears to have expired, causing the link to fail. Removing the token from the URL should resolve the issue.

The broken link can be seen here: [https://dearpygui.readthedocs.io/en/latest/documentation/node-editor.html](url)

Other similar GIF links in the documentation work correctly and don't include tokens in their URLs


