### PR TITLE
Fix (mvThemes.cpp): Add missing ImGuiStyleVar_TabBarOverlineSize

### DIFF
--- a/src/mvThemes.cpp
+++ b/src/mvThemes.cpp
@@ -388,6 +388,7 @@ static const mvGuiStyleVarInfo GStyleVarInfo[] =
 	{ ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, TabRounding) },         // ImGuiStyleVar_TabRounding
 	{ ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, TabBorderSize) },        // ImGuiStyleVar_TabBorderSize
 	{ ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, TabBarBorderSize) },        // ImGuiStyleVar_TabBarBorderSize
+	{ ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, TabBarOverlineSize) },        // ImGuiStyleVar_TabBarOverlineSize
     { ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, TableAngledHeadersAngle)},    // ImGuiStyleVar_TableAngledHeadersAngle
     { ImGuiDataType_Float, 2, (ImU32)offsetof(ImGuiStyle, TableAngledHeadersTextAlign)},// ImGuiStyleVar_TableAngledHeadersTextAlign
 	{ ImGuiDataType_Float, 2, (ImU32)offsetof(ImGuiStyle, ButtonTextAlign) },         // ImGuiStyleVar_ButtonTextAlign


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: 'Fix (mvThemes.cpp): Add missing ImGuiStyleVar_TabBarOverlineSize'
assignees: @hoffstadt 

---

**Description:**
Add missing ImGuiStyleVar_TabBarOverlineSize (only for ImGuiStyleVar_TableAngledHeadersAngle to work).

fixing an issue about: TableAngledHeaderAngle does not work outside of Style Editor (https://discord.com/channels/736279277242417272/1424799834006884483)

**Concerning Areas:**
I was tinkering with TabBarOverlineSize in some other places (mvPyUtils.cpp, dearpygui.cpp), but it seem only work on docked windows, also seem imgui 1.91.8 improved it (DPG using 1.91.0).
So, this PR only for ImGuiStyleVar_TableAngledHeadersAngle to work.
