### PR TITLE
Fix for issue-2570

### DIFF
--- a/src/mvUtilities_apple.mm
+++ b/src/mvUtilities_apple.mm
@@ -116,7 +116,13 @@ LoadTextureFromFile(const char* filename, int& width, int& height)
  bool
 UnloadTexture(const std::string& filename)
 {
+    if (texture == nullptr)
+        return;
 
+    auto out_srv = (GLuint)(size_t)texture;
+
+    if (out_srv == 0)
+        return;
 	return true;
 }
 

--- a/src/mvUtilities_linux.cpp
+++ b/src/mvUtilities_linux.cpp
@@ -206,7 +206,13 @@ UnloadTexture(const std::string& filename)
  void
 FreeTexture(void* texture)
 {
+    if (texture == nullptr)
+        return;
+
     auto out_srv = (GLuint)(size_t)texture;
+
+    if (out_srv == 0)
+        return;
 
     if(PBO_ids.count(out_srv) != 0)
         PBO_ids.erase(out_srv);

--- a/src/mvUtilities_win32.cpp
+++ b/src/mvUtilities_win32.cpp
@@ -450,6 +450,12 @@ FreeTexture(void* texture)
  bool
 UnloadTexture(const std::string& filename)
 {
-    // TODO : decide if cleanup is necessary
+    if (texture == nullptr)
+        return;
+
+    auto out_srv = (GLuint)(size_t)texture;
+
+    if (out_srv == 0)
+        return;
     return true;
 }


### PR DESCRIPTION
Added null free checking guards in UnloadTexture/FreeTexture

---
name: Pull Request
about: Create a pull request to help us improve
title: ''
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
Added null free checking to FreeTexture/UnloadTexture. There's a race condition where the renderer isn't up when the textures start getting added. 

Before fix:

<img width="1016" height="204" alt="image" src="https://github.com/user-attachments/assets/91653c6e-b467-431b-83ae-8881c9d3f5f2" />


After fix:

<img width="1282" height="254" alt="image" src="https://github.com/user-attachments/assets/ddeacc73-0347-4218-bb82-0ec50f62a3e7" />


