### PR TITLE
Remove `deprecated`'s decorator immunity to global `warnings` filters

### DIFF
--- a/dearpygui/_deprecated.py
+++ b/dearpygui/_deprecated.py
@@ -14,13 +14,12 @@ def deprecated(reason):
 
 			@functools.wraps(func1)
 			def new_func1(*args, **kwargs):
-				warnings.simplefilter('always', DeprecationWarning)
 				warnings.warn(
 					fmt1.format(name=func1.__name__, reason=reason),
 					category=DeprecationWarning,
 					stacklevel=2
 				)
-				warnings.simplefilter('default', DeprecationWarning)
+
 				return func1(*args, **kwargs)
 
 			return new_func1
@@ -34,13 +33,12 @@ def deprecated(reason):
 
 		@functools.wraps(func2)
 		def new_func2(*args, **kwargs):
-			warnings.simplefilter('always', DeprecationWarning)
 			warnings.warn(
 				fmt2.format(name=func2.__name__),
 				category=DeprecationWarning,
 				stacklevel=2
 			)
-			warnings.simplefilter('default', DeprecationWarning)
+
 			return func2(*args, **kwargs)
 
 		return new_func2


### PR DESCRIPTION
**Description:**
Removed the code parts where the deprecation warning could ignore any filters from the `warnings` module.

**Concerning Areas:**
As long as the developer knows what he's doing, none.
