### PR TITLE
fix (callbacks): Refcount mess in mvAddCallback() and mvRunCallback()

### DIFF
--- a/src/mvBasicWidgets.cpp
+++ b/src/mvBasicWidgets.cpp
@@ -2749,10 +2749,7 @@ DearPyGui::draw_button(ImDrawList* drawlist, mvAppItem& item, const mvButtonConf
 
 		if (activated)
 		{
-			if (item.config.alias.empty())
-				mvAddCallback(item.getCallback(false), item.uuid, nullptr, item.config.user_data);
-			else
-				mvAddCallback(item.getCallback(false), item.config.alias, nullptr, item.config.user_data);
+			item.submitCallback();
 		}
 	}
 
@@ -2857,12 +2854,7 @@ DearPyGui::draw_combo(ImDrawList* drawlist, mvAppItem& item, mvComboConfig& conf
 				{
 					if (item.config.enabled) { *config.value = name; }
 
-					auto value = *config.value;
-
-					if (item.config.alias.empty())
-						mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.uuid, ToPyString(value), item.config.user_data);});
-					else
-						mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyString(value), item.config.user_data);});
+					item.submitCallback(*config.value);
 				}
 
 				item.state.edited = ImGui::IsItemEdited();
@@ -2959,12 +2951,7 @@ DearPyGui::draw_checkbox(ImDrawList* drawlist, mvAppItem& item, mvCheckboxConfig
 
 		if (ImGui::Checkbox(item.info.internalLabel.c_str(), item.config.enabled ? config.value.get() : &config.disabled_value))
 		{
-			bool value = *config.value;
-
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.uuid, ToPyBool(value), item.config.user_data);});
-			else
-				mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyBool(value), item.config.user_data);});
+			item.submitCallback(*config.value);
 		}
 	}
 
@@ -3056,12 +3043,7 @@ DearPyGui::draw_drag_float(ImDrawList* drawlist, mvAppItem& item, mvDragFloatCon
 			item.config.enabled ? config.value.get() : &config.disabled_value,
 			config.speed, config.minv, config.maxv, config.format.c_str(), config.flags))
 		{
-			auto value = *config.value;
-
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.uuid, ToPyFloat(value), item.config.user_data);});
-			else
-				mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloat(value), item.config.user_data);});
+			item.submitCallback(*config.value);
 		}
 	}
 
@@ -3154,12 +3136,7 @@ DearPyGui::draw_drag_double(ImDrawList* drawlist, mvAppItem& item, mvDragDoubleC
 			item.config.enabled ? config.value.get() : &config.disabled_value,
 			config.speed, &config.minv, &config.maxv, config.format.c_str(), config.flags))
 		{
-			auto value = *config.value;
-
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.uuid, ToPyDouble(value), item.config.user_data); });
-			else
-				mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyDouble(value), item.config.user_data); });
+			item.submitCallback(*config.value);
 		}
 	}
 
@@ -3252,15 +3229,7 @@ DearPyGui::draw_drag_int(ImDrawList* drawlist, mvAppItem& item, mvDragIntConfig&
 			item.config.enabled ? config.value.get() : &config.disabled_value, config.speed,
 			config.minv, config.maxv, config.format.c_str(), config.flags))
 		{
-			auto value = *config.value;
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() {
-				mvAddCallback(item.getCallback(false), item.uuid, ToPyInt(value), item.config.user_data);
-					});
-			else
-				mvSubmitCallback([&item, value]() {
-				mvAddCallback(item.getCallback(false), item.config.alias, ToPyInt(value), item.config.user_data);
-					});
+			item.submitCallback(*config.value);
 		}
 	}
 
@@ -3369,15 +3338,7 @@ DearPyGui::draw_drag_intx(ImDrawList* drawlist, mvAppItem& item, mvDragIntMultiC
 
 		if (activated)
 		{
-			auto value = *config.value;
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() {
-				mvAddCallback(item.getCallback(false), item.uuid, ToPyIntList(value.data(), (int)value.size()), item.config.user_data);
-					});
-			else
-				mvSubmitCallback([&item, value]() {
-				mvAddCallback(item.getCallback(false), item.config.alias, ToPyIntList(value.data(), (int)value.size()), item.config.user_data);
-					});
+			item.submitCallback(*config.value);
 		}
 	}
 
@@ -3484,15 +3445,7 @@ DearPyGui::draw_drag_floatx(ImDrawList* drawlist, mvAppItem& item, mvDragFloatMu
 
 		if (activated)
 		{
-			auto value = *config.value;
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() {
-				mvAddCallback(item.getCallback(false), item.uuid, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data);
-					});
-			else
-				mvSubmitCallback([&item, value]() {
-				mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data);
-					});
+			item.submitCallback(*config.value);
 		}
 	}
 	//-----------------------------------------------------------------------------
@@ -3586,15 +3539,7 @@ DearPyGui::draw_drag_doublex(ImDrawList* drawlist, mvAppItem& item, mvDragDouble
 
 		if (activated)
 		{
-			auto value = *config.value;
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() {
-				mvAddCallback(item.getCallback(false), item.uuid, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data);
-					});
-			else
-				mvSubmitCallback([&item, value]() {
-				mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data);
-					});
+			item.submitCallback(*config.value);
 		}
 	}
 	//-----------------------------------------------------------------------------
@@ -3690,12 +3635,7 @@ DearPyGui::draw_slider_float(ImDrawList* drawlist, mvAppItem& item, mvSliderFloa
 
 			if (ImGui::VSliderFloat(item.info.internalLabel.c_str(), ImVec2((float)item.config.width, (float)item.config.height), item.config.enabled ? config.value.get() : &config.disabled_value, config.minv, config.maxv, config.format.c_str()))
 			{
-				auto value = *config.value;
-
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.uuid, ToPyFloat(value), item.config.user_data);});
-				else
-					mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloat(value), item.config.user_data);});
+				item.submitCallback(*config.value);
 			}
 
 		}
@@ -3703,11 +3643,7 @@ DearPyGui::draw_slider_float(ImDrawList* drawlist, mvAppItem& item, mvSliderFloa
 		{
 			if (ImGui::SliderFloat(item.info.internalLabel.c_str(), item.config.enabled ? config.value.get() : &config.disabled_value, config.minv, config.maxv, config.format.c_str(), config.flags))
 			{
-				auto value = *config.value;
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.uuid, ToPyFloat(value), item.config.user_data);});
-				else
-					mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloat(value), item.config.user_data);});
+				item.submitCallback(*config.value);
 			}
 
 		}
@@ -3806,12 +3742,7 @@ DearPyGui::draw_slider_double(ImDrawList* drawlist, mvAppItem& item, mvSliderDou
 
 			if (ImGui::VSliderScalar(item.info.internalLabel.c_str(), ImVec2((float)item.config.width, (float)item.config.height), ImGuiDataType_Double, item.config.enabled ? config.value.get() : &config.disabled_value, &config.minv, &config.maxv, config.format.c_str()))
 			{
-				auto value = *config.value;
-
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.uuid, ToPyDouble(value), item.config.user_data); });
-				else
-					mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyDouble(value), item.config.user_data); });
+				item.submitCallback(*config.value);
 			}
 
 		}
@@ -3819,11 +3750,7 @@ DearPyGui::draw_slider_double(ImDrawList* drawlist, mvAppItem& item, mvSliderDou
 		{
 			if (ImGui::SliderScalar(item.info.internalLabel.c_str(), ImGuiDataType_Double, item.config.enabled ? config.value.get() : &config.disabled_value, &config.minv, &config.maxv, config.format.c_str(), config.flags))
 			{
-				auto value = *config.value;
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.uuid, ToPyDouble(value), item.config.user_data); });
-				else
-					mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.config.alias, ToPyDouble(value), item.config.user_data); });
+				item.submitCallback(*config.value);
 			}
 
 		}
@@ -3932,12 +3859,7 @@ DearPyGui::draw_slider_floatx(ImDrawList* drawlist, mvAppItem& item, mvSliderFlo
 
 		if (activated)
 		{
-			auto value = *config.value;
-
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.uuid, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data);});
-			else
-				mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data);});
+			item.submitCallback(*config.value);
 		}
 	}
 
@@ -4032,12 +3954,7 @@ DearPyGui::draw_slider_doublex(ImDrawList* drawlist, mvAppItem& item, mvSliderDo
 
 		if (activated)
 		{
-			auto value = *config.value;
-
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.uuid, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data); });
-			else
-				mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data); });
+			item.submitCallback(*config.value);
 		}
 	}
 
@@ -4134,12 +4051,7 @@ DearPyGui::draw_slider_int(ImDrawList* drawlist, mvAppItem& item, mvSliderIntCon
 
 			if (ImGui::VSliderInt(item.info.internalLabel.c_str(), ImVec2((float)item.config.width, (float)item.config.height), item.config.enabled ? config.value.get() : &config.disabled_value, config.minv, config.maxv, config.format.c_str()))
 			{
-				auto value = *config.value;
-
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.uuid, ToPyInt(value), item.config.user_data);});
-				else
-					mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyInt(value), item.config.user_data);});
+				item.submitCallback(*config.value);
 			}
 
 		}
@@ -4147,11 +4059,7 @@ DearPyGui::draw_slider_int(ImDrawList* drawlist, mvAppItem& item, mvSliderIntCon
 		{
 			if (ImGui::SliderInt(item.info.internalLabel.c_str(), item.config.enabled ? config.value.get() : &config.disabled_value, config.minv, config.maxv, config.format.c_str(), config.flags))
 			{
-				auto value = *config.value;
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.uuid, ToPyInt(value), item.config.user_data);});
-				else
-					mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.config.alias, ToPyInt(value), item.config.user_data);});
+				item.submitCallback(*config.value);
 			}
 
 		}
@@ -4260,12 +4168,7 @@ DearPyGui::draw_slider_intx(ImDrawList* drawlist, mvAppItem& item, mvSliderIntMu
 
 		if (activated)
 		{
-			auto value = *config.value;
-
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.uuid, ToPyIntList(value.data(), (int)value.size()), item.config.user_data); });
-			else
-				mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.config.alias, ToPyIntList(value.data(), (int)value.size()), item.config.user_data); });
+			item.submitCallback(*config.value);
 		}
 	}
 
@@ -4366,16 +4269,7 @@ DearPyGui::draw_listbox(ImDrawList *drawlist, mvAppItem &item, mvListboxConfig &
         {
             *config.value = config.names[config.index];
             config.disabled_value = config.names[config.index];
-            auto value = *config.value;
-
-            if(item.config.alias.empty())
-                mvSubmitCallback([&item, value]() {
-                    mvAddCallback(item.getCallback(false), item.uuid, ToPyString(value), item.config.user_data);
-                });
-            else
-                mvSubmitCallback([&item, value]() {
-                    mvAddCallback(item.getCallback(false), item.config.alias, ToPyString(value), item.config.user_data);
-                });
+            item.submitCallback(*config.value);
         }
 
         ImGui::PopStyleColor();
@@ -4481,12 +4375,7 @@ DearPyGui::draw_radio_button(ImDrawList* drawlist, mvAppItem& item, mvRadioButto
 			{
 				*config.value = config.itemnames[config.index];
 				config.disabled_value = config.itemnames[config.index];
-				auto value = *config.value;
-
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.uuid, ToPyString(value), item.config.user_data);});
-				else
-					mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyString(value), item.config.user_data);});
+				item.submitCallback(*config.value);
 			}
 
 			item.state.edited = ImGui::IsItemEdited();
@@ -4615,15 +4504,7 @@ DearPyGui::draw_input_text(ImDrawList* drawlist, mvAppItem& item, mvInputTextCon
 
 		if (activated)
 		{
-			auto value = *config.value;
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() {
-				mvAddCallback(item.getCallback(false), item.uuid, ToPyString(value), item.config.user_data);
-					});
-			else
-				mvSubmitCallback([&item, value]() {
-				mvAddCallback(item.getCallback(false), item.config.alias, ToPyString(value), item.config.user_data);
-					});
+			item.submitCallback(*config.value);
 		}
 
 	}
@@ -4735,16 +4616,7 @@ DearPyGui::draw_input_int(ImDrawList* drawlist, mvAppItem& item, mvInputIntConfi
 			if (config.last_value != *config.value)
 			{
 				config.last_value = *config.value;
-				auto value = *config.value;
-
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.uuid, ToPyInt(value), item.config.user_data);
-						});
-				else
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.config.alias, ToPyInt(value), item.config.user_data);
-						});
+				item.submitCallback(*config.value);
 			}
 		}
 
@@ -4884,16 +4756,7 @@ DearPyGui::draw_input_floatx(ImDrawList* drawlist, mvAppItem& item, mvInputFloat
 			if (config.last_value != *config.value)
 			{
 				config.last_value = *config.value;
-				auto value = *config.value;
-
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.uuid, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data);
-						});
-				else
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data);
-						});
+				item.submitCallback(*config.value);
 			}
 		}
 
@@ -5007,16 +4870,7 @@ DearPyGui::draw_input_float(ImDrawList* drawlist, mvAppItem& item, mvInputFloatC
 			if (config.last_value != *config.value)
 			{
 				config.last_value = *config.value;
-				auto value = *config.value;
-
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.uuid, ToPyFloat(value), item.config.user_data);
-						});
-				else
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloat(value), item.config.user_data);
-						});
+				item.submitCallback(*config.value);
 			}
 		}
 	}
@@ -5108,13 +4962,7 @@ DearPyGui::draw_knob_float(ImDrawList* drawlist, mvAppItem& item, mvKnobFloatCon
 
 		if (KnobFloat(item.config.specifiedLabel.c_str(), item.config.enabled ? config.value.get() : &config.disabled_value, config.minv, config.maxv, config.step))
 		{
-			auto value = *config.value;
-			mvSubmitCallback([&item, value]() {
-				if (item.config.alias.empty())
-					mvAddCallback(item.getCallback(false), item.uuid, ToPyFloat(value), item.config.user_data);
-				else
-					mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloat(value), item.config.user_data);
-				});
+			item.submitCallback(*config.value);
 		}
 	}
 
@@ -5225,16 +5073,7 @@ DearPyGui::draw_input_double(ImDrawList* drawlist, mvAppItem& item, mvInputDoubl
 			if (config.last_value != *config.value)
 			{
 				config.last_value = *config.value;
-				auto value = *config.value;
-
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.uuid, ToPyDouble(value), item.config.user_data);
-						});
-				else
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.config.alias, ToPyDouble(value), item.config.user_data);
-						});
+				item.submitCallback(*config.value);
 			}
 		}
 	}
@@ -5361,16 +5200,7 @@ DearPyGui::draw_input_doublex(ImDrawList* drawlist, mvAppItem& item, mvInputDoub
 			if (config.last_value != *config.value)
 			{
 				config.last_value = *config.value;
-				auto value = *config.value;
-
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.uuid, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data);
-						});
-				else
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloatList(value.data(), (int)value.size()), item.config.user_data);
-						});
+				item.submitCallback(*config.value);
 			}
 		}
 
@@ -5511,16 +5341,7 @@ DearPyGui::draw_input_intx(ImDrawList* drawlist, mvAppItem& item, mvInputIntMult
 			{
 				config.last_value = *config.value;
 
-				auto value = *config.value;
-
-				if (item.config.alias.empty())
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.uuid, ToPyIntList(value.data(), (int)value.size()), item.config.user_data);
-						});
-				else
-					mvSubmitCallback([&item, value]() {
-					mvAddCallback(item.getCallback(false), item.config.alias, ToPyIntList(value.data(), (int)value.size()), item.config.user_data);
-						});
+				item.submitCallback(*config.value);
 			}
 		}
 	}
@@ -5743,12 +5564,7 @@ DearPyGui::draw_selectable(ImDrawList* drawlist, mvAppItem& item, mvSelectableCo
 
 		if (ImGui::Selectable(item.info.internalLabel.c_str(), config.value.get(), config.flags, ImVec2((float)item.config.width, (float)item.config.height)))
 		{
-			auto value = *config.value;
-
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.uuid, ToPyBool(value), item.config.user_data);});
-			else
-				mvSubmitCallback([&item, value]() {mvAddCallback(item.getCallback(false), item.config.alias, ToPyBool(value), item.config.user_data);});
+			item.submitCallback(*config.value);
 		}
 	}
 
@@ -5836,10 +5652,7 @@ DearPyGui::draw_tab_button(ImDrawList* drawlist, mvAppItem& item, mvTabButtonCon
 
 		if (ImGui::TabItemButton(item.info.internalLabel.c_str(), config.flags))
 		{
-			if (item.config.alias.empty())
-				mvAddCallback(item.getCallback(false), item.uuid, nullptr, item.config.user_data);
-			else
-				mvAddCallback(item.getCallback(false), item.config.alias, nullptr, item.config.user_data);
+			item.submitCallback();
 		}
 	}
 
@@ -5934,12 +5747,7 @@ DearPyGui::draw_menu_item(ImDrawList* drawlist, mvAppItem& item, mvMenuItemConfi
 		// create menu item and see if its selected
 		if (ImGui::MenuItem(item.info.internalLabel.c_str(), config.shortcut.c_str(), config.check ? config.value.get() : nullptr, item.config.enabled))
 		{
-			bool value = *config.value;
-
-			if (item.config.alias.empty())
-				mvAddCallback(item.config.callback, item.uuid, ToPyBool(value), item.config.user_data);
-			else
-				mvAddCallback(item.config.callback, item.config.alias, ToPyBool(value), item.config.user_data);
+			item.submitCallback(*config.value);
 		}
 
 		ImGui::PopStyleColor();
@@ -6259,10 +6067,7 @@ DearPyGui::draw_image_button(ImDrawList* drawlist, mvAppItem& item, mvImageButto
 				ImVec2(config.uv_min.x, config.uv_min.y), ImVec2(config.uv_max.x, config.uv_max.y),
 				config.backgroundColor, config.tintColor))
 			{
-				if (item.config.alias.empty())
-					mvAddCallback(item.getCallback(false), item.uuid, nullptr, item.config.user_data);
-				else
-					mvAddCallback(item.getCallback(false), item.config.alias, nullptr, item.config.user_data);
+				item.submitCallback();
 			}
 			ImGui::PopID();
 

--- a/src/mvCallbackRegistry.h
+++ b/src/mvCallbackRegistry.h
@@ -193,26 +193,25 @@ private:
 
 };
 
-static PyObject* SanitizeCallback(PyObject* callback)
-{
-	if (callback == Py_None)
-		return nullptr;
-
-	return callback;
-}
-
 struct mvCallbackJob
 {
-	mvUUID      sender    = 0;
-	PyObject*   callback  = nullptr;
-	PyObject*   app_data  = nullptr;
-	PyObject*   user_data = nullptr;
-	std::string sender_str;
+    std::weak_ptr<void> owner;
+    // Only valid if `owner` is alive; one must lock() the owner before accessing
+    // the callback.
+    PyObject* callback;
+    std::shared_ptr<mvPyObject> user_data;
+    mvUUID sender;
+    std::string alias;
+    std::function<PyObject*()> app_data_func;
+    // Either `callback` (and `owner`) or `ownerless_callback` must be set,
+    // but not both - otherwise one of them will be ignored.
+    std::shared_ptr<mvPyObject> ownerless_callback = nullptr;
 };
 
 struct mvCallbackRegistry
 {
-	const i32 maxNumberOfCalls = 50;
+    // TODO: ideally, it should be configurable (e.g. via configure_app)
+	const i32 maxNumberOfCalls = 500;
 
 	std::vector<mvCallbackJob> jobs;
 	mvQueue<mvFunctionWrapper> tasks;
@@ -221,22 +220,89 @@ struct mvCallbackRegistry
 	std::atomic<i32>           callCount = 0;
 
 	// callbacks
-	PyObject* resizeCallback          = nullptr;
-	PyObject* onCloseCallback         = nullptr;
-	PyObject* resizeCallbackUserData  = nullptr;
-	PyObject* onCloseCallbackUserData = nullptr;
+	std::shared_ptr<mvPyObject> resizeCallback          = std::make_shared<mvPyObject>(nullptr);
+    std::shared_ptr<mvPyObject> resizeCallbackUserData  = std::make_shared<mvPyObject>(nullptr);
+    std::shared_ptr<mvPyObject> onCloseCallback         = std::make_shared<mvPyObject>(nullptr);
+    std::shared_ptr<mvPyObject> onCloseCallbackUserData = std::make_shared<mvPyObject>(nullptr);
 
 	i32 highestFrame = 0;
-	std::unordered_map<i32, PyObject*> frameCallbacks;
-	std::unordered_map<i32, PyObject*> frameCallbacksUserData;
+	std::unordered_map<i32, mvPyObject> frameCallbacks;
+	std::unordered_map<i32, mvPyObject> frameCallbacksUserData;
 };
 
 void mvFrameCallback(i32 frame);
 void mvRunTasks();
-void mvRunCallback(PyObject* callback, mvUUID sender, PyObject* app_data, PyObject* user_data, bool decrementAppData = true);
-void mvRunCallback(PyObject* callback, const std::string& sender, PyObject* app_data, PyObject* user_data);
-void mvAddCallback(PyObject* callback, mvUUID sender, PyObject* app_data, PyObject* user_data, bool decrementAppData = true);
-void mvAddCallback(PyObject* callback, const std::string& sender, PyObject* app_data, PyObject* user_data);
+// All PyObject references here are borrowed references - caller must release them after this call
+void mvRunCallback(PyObject* callback, PyObject* user_data, mvUUID sender = 0, const std::string& sender_alias = "", PyObject* app_data = nullptr);
+
+// Note: We pass the `callback` and its `user_data` as two separate arguments (rather
+// than a single object) because, even though they only make sense together, `mvAppItem` may
+// combine the same `user_data` with different callbacks.  We don't want to spread `user_data`
+// instances all across `mvAppItem`.
+// The `callback` must be valid all the time while `owner` is alive.  This works for
+// the fields of `owner`; if `callback` is not a field of `owner`, the caller must make
+// sure that `callback`'s lifetime is at least as long as `owner`'s.
+// When the callback is about to be executed on the handlers thread, the callback queue
+// acquires a shared_ptr to `owner` and holds it while the callback is being executed.
+// If the `owner` is already lost by the moment the callback is fetched from the
+// queue, the callback will be silently ignored.  This effectively cleans the queue
+// from irrelevant callbacks - lingering there after `mvAppItem` deletion and such.
+template<typename AppDataFunc>
+void mvAddCallback(const std::weak_ptr<void>& owner,
+                   PyObject* callback,
+                   const std::shared_ptr<mvPyObject>& user_data,
+                   mvUUID sender,
+                   const std::string& alias,
+                   AppDataFunc&& app_data_func)
+{
+	if (GContext->IO.manualCallbacks)
+	{
+		GContext->callbackRegistry->jobs.push_back({owner, callback, user_data, sender, alias, std::forward<AppDataFunc>(app_data_func)});
+		return;
+	}
+	mvSubmitCallback([=, app_data_func = std::forward<AppDataFunc>(app_data_func)] () {
+        auto liveOwner = owner.lock();  // we need it to live through the mvRunCallback, hence constructing it separately rather than within "if"
+        if (liveOwner)
+    		mvRunCallback(callback, *user_data, sender, alias, mvPyObject(app_data_func()));
+    });
+}
+
+// This overload exists purely to provide default argument values - we can't do this
+// directly on the template version above because the compiler won't be able to deduce
+// `app_data_func` type if `app_data_func` is omitted (that is, we can't really use
+// the default on `app_data_func`).
+void mvAddCallback(const std::weak_ptr<void>& owner,
+                   PyObject* callback,
+                   const std::shared_ptr<mvPyObject>& user_data,
+                   mvUUID sender = 0,
+                   const std::string& alias = "");
+
+template<typename AppDataFunc>
+void mvAddOwnerlessCallback(const std::shared_ptr<mvPyObject>& callback,
+                            const std::shared_ptr<mvPyObject>& user_data,
+                            mvUUID sender,
+                            const std::string& alias,
+                            AppDataFunc&& app_data_func)
+{
+	if (GContext->IO.manualCallbacks)
+	{
+		GContext->callbackRegistry->jobs.push_back({{}, nullptr, user_data, sender, alias, std::forward<AppDataFunc>(app_data_func), callback});
+		return;
+	}
+	mvSubmitCallback([=, app_data_func = std::forward<AppDataFunc>(app_data_func)]() {
+		mvRunCallback(*callback, *user_data, sender, alias, mvPyObject(app_data_func()));
+    });
+}
+
+// This overload exists purely to provide default argument values - we can't do this
+// directly on the template version above because the compiler won't be able to deduce
+// `app_data_func` type if `app_data_func` is omitted (that is, we can't really use
+// the default on `app_data_func`).
+void mvAddOwnerlessCallback(const std::shared_ptr<mvPyObject>& callback,
+                            const std::shared_ptr<mvPyObject>& user_data,
+                            mvUUID sender = 0,
+                            const std::string& alias = "");
+
 bool mvRunCallbacks();
 
 template<typename F, typename ...Args>
@@ -247,7 +313,7 @@ std::future<typename std::invoke_result<F, Args...>::type> mvSubmitTask(F f)
 	std::packaged_task<result_type()> task(std::move(f));
 	std::future<result_type> res(task.get_future());
 
-	if (GContext->started)
+	if (GContext->running)
 		GContext->callbackRegistry->tasks.push(std::move(task));
 	else
 		task();
@@ -256,11 +322,12 @@ std::future<typename std::invoke_result<F, Args...>::type> mvSubmitTask(F f)
 }
 
 template<typename F, typename ...Args>
-std::future<typename std::invoke_result<F, Args...>::type> mvSubmitCallback(F f)
+std::future<typename std::invoke_result<F, Args...>::type> mvSubmitCallback(F f, bool ignore_limit = false)
 {
 
-	if (GContext->callbackRegistry->callCount > GContext->callbackRegistry->maxNumberOfCalls)
+	if (GContext->callbackRegistry->callCount > GContext->callbackRegistry->maxNumberOfCalls && !ignore_limit)
 	{
+        assert(false);
 		return {};
 	}
 

--- a/src/mvColors.cpp
+++ b/src/mvColors.cpp
@@ -66,10 +66,7 @@ DearPyGui::draw_color_button(ImDrawList* drawlist, mvAppItem& item, mvColorButto
 
 		if (ImGui::ColorButton(item.info.internalLabel.c_str(), col, config.flags, ImVec2((float)item.config.width, (float)item.config.height)))
 		{
-			if(item.config.alias.empty())
-				mvAddCallback(item.getCallback(false), item.uuid, nullptr, item.config.user_data);
-			else
-				mvAddCallback(item.getCallback(false), item.config.alias, nullptr, item.config.user_data);
+			item.submitCallback();
 		}
 	}
 
@@ -161,11 +158,7 @@ DearPyGui::draw_color_edit(ImDrawList* drawlist, mvAppItem& item, mvColorEditCon
 		if (ImGui::ColorEdit4(item.info.internalLabel.c_str(), item.config.enabled ? config.value->data() : &config.disabled_value[0], config.flags))
 		{
 			mvColor color = mvColor((*config.value)[0], (*config.value)[1], (*config.value)[2], (*config.value)[3]);
-
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, color]() { mvAddCallback(item.getCallback(false), item.uuid, ToPyColor(color), item.config.user_data); });
-			else
-				mvSubmitCallback([&item, color]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyColor(color), item.config.user_data); });
+			item.submitCallback(color);
 		}
 	}
 
@@ -261,10 +254,7 @@ DearPyGui::draw_color_map_button(ImDrawList* drawlist, mvAppItem& item, mvColorM
 		ScopedID id(item.uuid);
 		if (ImPlot::ColormapButton(item.info.internalLabel.c_str(), ImVec2((float)item.config.width, (float)item.config.height), config.colorMap))
 		{
-			if (item.config.alias.empty())
-				mvAddCallback(item.getCallback(false), item.uuid, nullptr, item.config.user_data);
-			else
-				mvAddCallback(item.getCallback(false), item.config.alias, nullptr, item.config.user_data);
+			item.submitCallback();
 		}
 	}
 
@@ -442,11 +432,7 @@ DearPyGui::draw_color_picker(ImDrawList* drawlist, mvAppItem& item, mvColorPicke
 		if (ImGui::ColorPicker4(item.info.internalLabel.c_str(), item.config.enabled ? config.value->data() : &config.disabled_value[0], config.flags))
 		{
 			mvColor color = mvColor((*config.value)[0], (*config.value)[1], (*config.value)[2], (*config.value)[3]);
-
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, color]() { mvAddCallback(item.getCallback(false), item.uuid, ToPyColor(color), item.config.user_data); });
-			else
-				mvSubmitCallback([&item, color]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyColor(color), item.config.user_data); });
+			item.submitCallback(color);
 		}
 	}
 
@@ -535,12 +521,7 @@ DearPyGui::draw_color_map_slider(ImDrawList* drawlist, mvAppItem& item, mvColorM
 
 		if (ImPlot::ColormapSlider(item.info.internalLabel.c_str(), config.value.get(), &config.color, "", config.colorMap))
 		{
-			auto value = *config.value;
-
-			if (item.config.alias.empty())
-				mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.uuid, ToPyFloat(value), item.config.user_data); });
-			else
-				mvSubmitCallback([&item, value]() { mvAddCallback(item.getCallback(false), item.config.alias, ToPyFloat(value), item.config.user_data); });
+			item.submitCallback(*config.value);
 		}
 	}
 

--- a/src/mvContext.cpp
+++ b/src/mvContext.cpp
@@ -202,6 +202,11 @@ GetParsers()
     return const_cast<std::map<std::string, mvPythonParser>&>(GetModuleParsers());
 }
 
+void StopRendering()
+{
+    GContext->running = false;
+}
+
 void 
 InsertConstants_mvContext(std::vector<std::pair<std::string, long>>& constants)
 {

--- a/src/mvContext.h
+++ b/src/mvContext.h
@@ -34,6 +34,8 @@ mvUUID                                 GenerateUUID();
 void                                   SetDefaultTheme();
 void                                   Render();
 std::map<std::string, mvPythonParser>& GetParsers();
+// Signals the rendering loop via GContext->running to quit.
+void                                   StopRendering();
 
 struct mvInput
 {
@@ -101,7 +103,11 @@ struct mvIO
 struct mvContext
 {
     std::atomic_bool    waitOneFrame       = false;
+    // Indicates whether DPG has started at least once in this context, i.e. whether
+    // associated Dear ImGui contexts exist and can be read from.
     std::atomic_bool    started            = false;
+    // If true, more frames are going to be rendered. Goes back to false on shutdown.
+    std::atomic_bool    running            = false;
     std::recursive_mutex mutex;
     std::future<bool>   future;
     float               deltaTime = 0.0f;   // time since last frame

--- a/src/mvDatePicker.cpp
+++ b/src/mvDatePicker.cpp
@@ -67,13 +67,7 @@ void mvDatePicker::draw(ImDrawList* drawlist, float x, float y)
 		{
 			ImPlot::GetGmtTime(*_imvalue, _value.get());
 			{
-				auto value = *_value;
-				mvSubmitCallback([=]() {
-					if(config.alias.empty())
-						mvAddCallback(getCallback(false), uuid, ToPyTime(value), config.user_data);
-					else
-						mvAddCallback(getCallback(false), config.alias, ToPyTime(value), config.user_data);
-					});
+				submitCallback(*_value);
 			}
 		}
 	}

--- a/src/mvDrawings.cpp
+++ b/src/mvDrawings.cpp
@@ -952,10 +952,7 @@ void mvDrawlist::draw(ImDrawList* drawlist, float x, float y)
 
 	if (ImGui::InvisibleButton(info.internalLabel.c_str(), ImVec2((float)config.width, (float)config.height), ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle))
 	{
-		if (config.alias.empty())
-			mvAddCallback(getCallback(false), uuid, nullptr, config.user_data);
-		else
-			mvAddCallback(getCallback(false), config.alias, nullptr, config.user_data);
+		submitCallback();
 	}
 
 	UpdateAppItemState(state);

--- a/src/mvFileDialog.h
+++ b/src/mvFileDialog.h
@@ -46,5 +46,5 @@ public:
     bool            _directory = false;
     mvVec2          _min_size = { 100.0f, 100.0f };
     mvVec2          _max_size = { 30000.0f, 30000.0f };
-	PyObject*	    _cancelCallback = nullptr;
+    mvPyObject      _cancelCallback = nullptr;
 };

--- a/src/mvGlobalHandlers.cpp
+++ b/src/mvGlobalHandlers.cpp
@@ -19,26 +19,14 @@ void mvKeyDownHandler::draw(ImDrawList* drawlist, float x, float y)
 			auto key = ImGui::GetKeyData(static_cast<ImGuiKey>(i));
 			if (key->Down)
 			{
-				mvSubmitCallback([=]()
-					{
-						if (config.alias.empty())
-							mvRunCallback(getCallback(false), uuid, ToPyMPair(i, key->DownDuration), config.user_data);
-						else
-							mvRunCallback(getCallback(false), config.alias, ToPyMPair(i, key->DownDuration), config.user_data);
-					});
+				submitCallbackEx([=]() { return ToPyMPair(i, key->DownDuration); });
 			}
 		}
 	}
 
 	else if (ImGui::IsKeyDown(_key))
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyMPair(_key, ImGui::GetKeyData(_key)->DownDuration), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyMPair(_key, ImGui::GetKeyData(_key)->DownDuration), config.user_data);
-			});
+		submitCallbackEx([=]() { return ToPyMPair(_key, ImGui::GetKeyData(_key)->DownDuration); });
 	}
 }
 
@@ -74,26 +62,14 @@ void mvKeyPressHandler::draw(ImDrawList* drawlist, float x, float y)
 		{
 			if (ImGui::IsKeyPressed(static_cast<ImGuiKey>(i)))
 			{
-				mvSubmitCallback([=]()
-					{
-						if (config.alias.empty())
-							mvRunCallback(getCallback(false), uuid, ToPyInt(i), config.user_data);
-						else
-							mvRunCallback(getCallback(false), config.alias, ToPyInt(i), config.user_data);
-					});
+				submitCallback(i);
 			}
 		}
 	}
 
 	else if (ImGui::IsKeyPressed(_key))
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyInt(_key), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyInt(_key), config.user_data);
-			});
+		submitCallback(_key);
 	}
 }
 
@@ -141,26 +117,14 @@ void mvKeyReleaseHandler::draw(ImDrawList* drawlist, float x, float y)
 		{
 			if (ImGui::IsKeyReleased(static_cast<ImGuiKey>(i)))
 			{
-				mvSubmitCallback([=]()
-					{
-						if (config.alias.empty())
-							mvRunCallback(getCallback(false), uuid, ToPyInt(i), config.user_data);
-						else
-							mvRunCallback(getCallback(false), config.alias, ToPyInt(i), config.user_data);
-					});
+				submitCallback(i);
 			}
 		}
 	}
 
 	else if (ImGui::IsKeyReleased(_key))
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyInt(_key), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyInt(_key), config.user_data);
-			});
+		submitCallback(_key);
 	}
 }
 
@@ -208,26 +172,14 @@ void mvMouseClickHandler::draw(ImDrawList* drawlist, float x, float y)
 		{
 			if (ImGui::IsMouseClicked(i))
 			{
-				mvSubmitCallback([=]()
-					{
-						if (config.alias.empty())
-							mvRunCallback(getCallback(false), uuid, ToPyInt(i), config.user_data);
-						else
-							mvRunCallback(getCallback(false), config.alias, ToPyInt(i), config.user_data);
-					});
+				submitCallback(i);
 			}
 		}
 	}
 
 	else if (ImGui::IsMouseClicked(_button))
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyInt(_button), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyInt(_button), config.user_data);
-			});
+		submitCallback(_button);
 	}
 }
 
@@ -275,26 +227,14 @@ void mvMouseDoubleClickHandler::draw(ImDrawList* drawlist, float x, float y)
 		{
 			if (ImGui::IsMouseDoubleClicked(i))
 			{
-				mvSubmitCallback([=]()
-					{
-						if (config.alias.empty())
-							mvRunCallback(getCallback(false), uuid, ToPyInt(i), config.user_data);
-						else
-							mvRunCallback(getCallback(false), config.alias, ToPyInt(i), config.user_data);
-					});
+				submitCallback(i);
 			}
 		}
 	}
 
 	else if (ImGui::IsMouseDoubleClicked(_button))
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyInt(_button), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyInt(_button), config.user_data);
-			});
+		submitCallback(_button);
 	}
 }
 
@@ -342,26 +282,14 @@ void mvMouseDownHandler::draw(ImDrawList* drawlist, float x, float y)
 		{
 			if (ImGui::GetIO().MouseDown[i])
 			{
-				mvSubmitCallback([=]()
-					{
-						if (config.alias.empty())
-							mvRunCallback(getCallback(false), uuid, ToPyMPair(i, ImGui::GetIO().MouseDownDuration[i]), config.user_data);
-						else
-							mvRunCallback(getCallback(false), config.alias, ToPyMPair(i, ImGui::GetIO().MouseDownDuration[i]), config.user_data);
-					});
+				submitCallbackEx([=]() { return ToPyMPair(i, ImGui::GetIO().MouseDownDuration[i]); });
 			}
 		}
 	}
 
 	else if (ImGui::GetIO().MouseDown[_button])
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyMPair(_button, ImGui::GetIO().MouseDownDuration[_button]), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyMPair(_button, ImGui::GetIO().MouseDownDuration[_button]), config.user_data);
-			});
+		submitCallbackEx([=]() { return ToPyMPair(_button, ImGui::GetIO().MouseDownDuration[_button]); });
 	}
 }
 
@@ -412,15 +340,7 @@ void mvMouseDragHandler::draw(ImDrawList* drawlist, float x, float y)
 
 			if (ImGui::IsMouseDragging(i, _threshold))
 			{
-				mvSubmitCallback([=]()
-					{
-						if (config.alias.empty())
-							mvRunCallback(getCallback(false), uuid,
-								ToPyMTrip(i, ImGui::GetMouseDragDelta(i).x, ImGui::GetMouseDragDelta(i).y), config.user_data);
-						else
-							mvRunCallback(getCallback(false), config.alias,
-								ToPyMTrip(i, ImGui::GetMouseDragDelta(i).x, ImGui::GetMouseDragDelta(i).y), config.user_data);
-					});
+				submitCallbackEx([=]() { return ToPyMTrip(i, ImGui::GetMouseDragDelta(i).x, ImGui::GetMouseDragDelta(i).y); });
 			}
 		}
 	}
@@ -429,15 +349,8 @@ void mvMouseDragHandler::draw(ImDrawList* drawlist, float x, float y)
 	{
 		if (ImGui::IsMouseReleased(_button))
 			ImGui::ResetMouseDragDelta(_button);
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid,
-						ToPyMTrip(_button, ImGui::GetMouseDragDelta(_button).x, ImGui::GetMouseDragDelta(_button).y), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias,
-						ToPyMTrip(_button, ImGui::GetMouseDragDelta(_button).x, ImGui::GetMouseDragDelta(_button).y), config.user_data);
-			});
+
+		submitCallbackEx([=]() { return ToPyMTrip(_button, ImGui::GetMouseDragDelta(_button).x, ImGui::GetMouseDragDelta(_button).y); });
 	}
 }
 
@@ -495,13 +408,7 @@ void mvMouseMoveHandler::draw(ImDrawList* drawlist, float x, float y)
 		{
 			_oldPos = mousepos;
 
-			mvSubmitCallback([=]()
-				{
-					if (config.alias.empty())
-						mvRunCallback(getCallback(false), uuid, ToPyPair(mousepos.x, mousepos.y), config.user_data);
-					else
-						mvRunCallback(getCallback(false), config.alias, ToPyPair(mousepos.x, mousepos.y), config.user_data);
-				});
+			submitCallback(mousepos);
 		}
 	}
 }
@@ -514,26 +421,14 @@ void mvMouseReleaseHandler::draw(ImDrawList* drawlist, float x, float y)
 		{
 			if (ImGui::IsMouseReleased(i))
 			{
-				mvSubmitCallback([=]()
-					{
-						if (config.alias.empty())
-							mvRunCallback(getCallback(false), uuid, ToPyInt(i), config.user_data);
-						else
-							mvRunCallback(getCallback(false), config.alias, ToPyInt(i), config.user_data);
-					});
+				submitCallback(i);
 			}
 		}
 	}
 
 	else if (ImGui::IsMouseReleased(_button))
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyInt(_button), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyInt(_button), config.user_data);
-			});
+		submitCallback(_button);
 	}
 }
 
@@ -578,14 +473,6 @@ void mvMouseWheelHandler::draw(ImDrawList* drawlist, float x, float y)
 	int wheel = (int)ImGui::GetIO().MouseWheel;
 	if (wheel)
 	{
-
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyInt(wheel), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyInt(wheel), config.user_data);
-			});
-
+		submitCallback(wheel);
 	}
 }

--- a/src/mvItemHandlers.cpp
+++ b/src/mvItemHandlers.cpp
@@ -124,19 +124,20 @@ void mvItemHandlerRegistry::onBind(mvAppItem* item)
 	}
 }
 
+void mvItemHandler::submitHandler(mvAppItem* parent)
+{
+	submitCallbackEx([uuid=parent->uuid, alias=parent->config.alias] () {
+		return ToPyUUID(uuid, alias);
+	});
+}
+
 void mvActivatedHandler::customAction(void* data)
 {
 
 	mvAppItemState* state = static_cast<mvAppItemState*>(data);
 	if (state->activated)
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyUUID(state->parent), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyUUID(state->parent), config.user_data);
-			});
+		submitHandler(state->parent);
 	}
 }
 
@@ -146,13 +147,7 @@ void mvActiveHandler::customAction(void* data)
 	mvAppItemState* state = static_cast<mvAppItemState*>(data);
 	if (state->active)
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyUUID(state->parent), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyUUID(state->parent), config.user_data);
-			});
+		submitHandler(state->parent);
 	}
 }
 
@@ -160,51 +155,25 @@ void mvClickedHandler::customAction(void* data)
 {
 
 	mvAppItemState* state = static_cast<mvAppItemState*>(data);
-	if (_button == -1 || _button == 0)
-		if (state->leftclicked)
-		{
-			mvSubmitCallback([=]()
-				{
-					mvPyObject pArgs(PyTuple_New(2));
-					PyTuple_SetItem(pArgs, 0, ToPyInt(0));
-					PyTuple_SetItem(pArgs, 1, ToPyUUID(state->parent)); // steals data, so don't deref
-					if (config.alias.empty())
-						mvRunCallback(getCallback(false), uuid, pArgs, config.user_data);
-					else
-						mvRunCallback(getCallback(false), config.alias, pArgs, config.user_data);
-				});
-		}
 
-	if (_button == -1 || _button == 1)
-		if (state->rightclicked)
-		{
-			mvSubmitCallback([=]()
-				{
-					mvPyObject pArgs(PyTuple_New(2));
-					PyTuple_SetItem(pArgs, 0, ToPyInt(1));
-					PyTuple_SetItem(pArgs, 1, ToPyUUID(state->parent)); // steals data, so don't deref
-					if (config.alias.empty())
-						mvRunCallback(getCallback(false), uuid, pArgs, config.user_data);
-					else
-						mvRunCallback(getCallback(false), config.alias, pArgs, config.user_data);
-				});
-		}
+	b8 clicked[] = {state->leftclicked, state->rightclicked, state->middleclicked};
 
-	if (_button == -1 || _button == 2)
-		if (state->middleclicked)
-		{
-			mvSubmitCallback([=]()
-				{
-					mvPyObject pArgs(PyTuple_New(2));
-					PyTuple_SetItem(pArgs, 0, ToPyInt(2));
-					PyTuple_SetItem(pArgs, 1, ToPyUUID(state->parent)); // steals data, so don't deref
-					if (config.alias.empty())
-						mvRunCallback(getCallback(false), uuid, pArgs, config.user_data);
-					else
-						mvRunCallback(getCallback(false), config.alias, pArgs, config.user_data);
-				});
-		}
+	int i = (_button < 0)? 0 : _button ;
+	int end = (_button < 0)? (int)std::size(clicked) : (i + 1);
 
+	for (; i < end; i++)
+	{
+		if (clicked[i])
+		{
+			mvAppItem* parent = state->parent;
+			submitCallbackEx([i, uuid=parent->uuid, alias=parent->config.alias] () {
+				PyObject* app_data = PyTuple_New(2);
+				PyTuple_SetItem(app_data, 0, ToPyInt(i));
+				PyTuple_SetItem(app_data, 1, ToPyUUID(uuid, alias));
+				return app_data;
+			});
+		}
+	}
 }
 
 void mvClickedHandler::handleSpecificRequiredArgs(PyObject* dict)
@@ -242,16 +211,13 @@ void mvDoubleClickedHandler::customAction(void* data)
 	{
 		if (state->doubleclicked[i])
 		{
-			mvSubmitCallback([=]()
-				{
-					mvPyObject pArgs(PyTuple_New(2));
-					PyTuple_SetItem(pArgs, 0, ToPyInt(i));
-					PyTuple_SetItem(pArgs, 1, ToPyUUID(state->parent)); // steals data, so don't deref
-					if (config.alias.empty())
-						mvRunCallback(getCallback(false), uuid, pArgs, config.user_data);
-					else
-						mvRunCallback(getCallback(false), config.alias, pArgs, config.user_data);
-				});
+			mvAppItem* parent = state->parent;
+			submitCallbackEx([i, uuid=parent->uuid, alias=parent->config.alias] () {
+				PyObject* app_data = PyTuple_New(2);
+				PyTuple_SetItem(app_data, 0, ToPyInt(i));
+				PyTuple_SetItem(app_data, 1, ToPyUUID(uuid, alias));
+				return app_data;
+			});
 		}
 	}
 }
@@ -286,13 +252,7 @@ void mvDeactivatedAfterEditHandler::customAction(void* data)
 	mvAppItemState* state = static_cast<mvAppItemState*>(data);
 	if (state->deactivatedAfterEdit)
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyUUID(state->parent), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyUUID(state->parent), config.user_data);
-			});
+		submitHandler(state->parent);
 	}
 }
 
@@ -301,13 +261,7 @@ void mvDeactivatedHandler::customAction(void* data)
 	mvAppItemState* state = static_cast<mvAppItemState*>(data);
 	if (state->deactivated)
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyUUID(state->parent), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyUUID(state->parent), config.user_data);
-			});
+		submitHandler(state->parent);
 	}
 }
 
@@ -317,13 +271,7 @@ void mvEditedHandler::customAction(void* data)
 	mvAppItemState* state = static_cast<mvAppItemState*>(data);
 	if (state->edited)
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyUUID(state->parent), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyUUID(state->parent), config.user_data);
-			});
+		submitHandler(state->parent);
 	}
 }
 
@@ -333,13 +281,7 @@ void mvFocusHandler::customAction(void* data)
 	mvAppItemState* state = static_cast<mvAppItemState*>(data);
 	if (state->focused)
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyUUID(state->parent), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyUUID(state->parent), config.user_data);
-			});
+		submitHandler(state->parent);
 	}
 }
 
@@ -348,13 +290,7 @@ void mvHoverHandler::customAction(void* data)
 	mvAppItemState* state = static_cast<mvAppItemState*>(data);
 	if (state->hovered)
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyUUID(state->parent), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyUUID(state->parent), config.user_data);
-			});
+		submitHandler(state->parent);
 	}
 }
 
@@ -363,42 +299,24 @@ void mvResizeHandler::customAction(void* data)
 	mvAppItemState* state = static_cast<mvAppItemState*>(data);
 	if (state->mvRectSizeResized)
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, ToPyUUID(state->parent), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, ToPyUUID(state->parent), config.user_data);
-			});
+		submitHandler(state->parent);
 	}
 }
 
 void mvToggledOpenHandler::customAction(void* data)
 {
-
-	if (static_cast<mvAppItemState*>(data)->toggledOpen)
+	mvAppItemState* state = static_cast<mvAppItemState*>(data);
+	if (state->toggledOpen)
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, GetPyNone(), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, GetPyNone(), config.user_data);
-			});
+		submitHandler(state->parent);
 	}
 }
 
 void mvVisibleHandler::customAction(void* data)
 {
-
+	mvAppItemState* state = static_cast<mvAppItemState*>(data);
 	if (static_cast<mvAppItemState*>(data)->visible)
 	{
-		mvSubmitCallback([=]()
-			{
-				if (config.alias.empty())
-					mvRunCallback(getCallback(false), uuid, GetPyNone(), config.user_data);
-				else
-					mvRunCallback(getCallback(false), config.alias, GetPyNone(), config.user_data);
-			});
+		submitHandler(state->parent);
 	}
 }

--- a/src/mvItemHandlers.h
+++ b/src/mvItemHandlers.h
@@ -14,29 +14,38 @@ public:
     void onBind(mvAppItem* item);
 };
 
-class mvActivatedHandler : public mvAppItem
+class mvItemHandler : public mvAppItem
 {
 public:
-    explicit mvActivatedHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvItemHandler(mvUUID uuid) : mvAppItem(uuid) {}
+
+protected:
+    void submitHandler(mvAppItem* parent);
+};
+
+class mvActivatedHandler : public mvItemHandler
+{
+public:
+    explicit mvActivatedHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 
 };
 
-class mvActiveHandler : public mvAppItem
+class mvActiveHandler : public mvItemHandler
 {
 public:
-    explicit mvActiveHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvActiveHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 
 };
 
-class mvClickedHandler : public mvAppItem
+class mvClickedHandler : public mvItemHandler
 {
 public:
     int _button = -1;
-    explicit mvClickedHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvClickedHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
     void handleSpecificRequiredArgs(PyObject* dict) override;
@@ -44,11 +53,11 @@ public:
     void getSpecificConfiguration(PyObject* dict) override;
 };
 
-class mvDoubleClickedHandler : public mvAppItem
+class mvDoubleClickedHandler : public mvItemHandler
 {
 public:
     int _button = -1;
-    explicit mvDoubleClickedHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvDoubleClickedHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
     void handleSpecificRequiredArgs(PyObject* dict) override;
@@ -56,66 +65,66 @@ public:
     void getSpecificConfiguration(PyObject* dict) override;
 };
 
-class mvDeactivatedAfterEditHandler : public mvAppItem
+class mvDeactivatedAfterEditHandler : public mvItemHandler
 {
 public:
-    explicit mvDeactivatedAfterEditHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvDeactivatedAfterEditHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 };
 
-class mvDeactivatedHandler : public mvAppItem
+class mvDeactivatedHandler : public mvItemHandler
 {
 public:
-    explicit mvDeactivatedHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvDeactivatedHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 };
 
-class mvEditedHandler : public mvAppItem
+class mvEditedHandler : public mvItemHandler
 {
 public:
-    explicit mvEditedHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvEditedHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 };
 
-class mvFocusHandler : public mvAppItem
+class mvFocusHandler : public mvItemHandler
 {
 public:
-    explicit mvFocusHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvFocusHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 };
 
-class mvHoverHandler : public mvAppItem
+class mvHoverHandler : public mvItemHandler
 {
 public:
-    explicit mvHoverHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvHoverHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 };
 
-class mvResizeHandler : public mvAppItem
+class mvResizeHandler : public mvItemHandler
 {
 public:
-    explicit mvResizeHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvResizeHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 };
 
-class mvToggledOpenHandler : public mvAppItem
+class mvToggledOpenHandler : public mvItemHandler
 {
 public:
-    explicit mvToggledOpenHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvToggledOpenHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 };
 
-class mvVisibleHandler : public mvAppItem
+class mvVisibleHandler : public mvItemHandler
 {
 public:
-    explicit mvVisibleHandler(mvUUID uuid) : mvAppItem(uuid) {}
+    explicit mvVisibleHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 };

--- a/src/mvItemRegistry.cpp
+++ b/src/mvItemRegistry.cpp
@@ -1075,7 +1075,7 @@ RenderItemRegistry(mvItemRegistry& registry)
         DebugItem("Enabled:", root->config.enabled ? ts : fs);
         DebugItem("Tracked:", root->config.tracked ? ts : fs);
         DebugItem("Callback:", root->config.callback ? ts : fs);
-        DebugItem("User Data:", root->config.user_data ? ts : fs);
+        DebugItem("User Data:", *(root->config.user_data) ? ts : fs);
         DebugItem("Drop Callback:", root->config.dropCallback ? ts : fs);
         DebugItem("Drag Callback:", root->config.dragCallback ? ts : fs);
 
@@ -1275,8 +1275,7 @@ AddItemWithRuntimeChecks(mvItemRegistry& registry, std::shared_ptr<mvAppItem> it
   
         // this is a unique situation in that the caller always has the GIL
         registry.capturedItem = item;
-        mvRunCallback(registry.captureCallback, registry.capturedItem->uuid, nullptr, nullptr);
-        Py_XDECREF(registry.captureCallback);
+        mvRunCallback(registry.captureCallback, nullptr, registry.capturedItem->uuid);
         registry.captureCallback = nullptr;
         return true;
     }

--- a/src/mvItemRegistry.h
+++ b/src/mvItemRegistry.h
@@ -83,8 +83,8 @@ struct mvItemRegistry
     b8                                      showImPlotDebug = false;
     std::vector<std::shared_ptr<mvAppItem>>           debugWindows;
     std::shared_ptr<mvAppItem>                        capturedItem = nullptr;
-    PyObject*                               captureCallback = nullptr;
-    PyObject*                               captureCallbackUserData = nullptr;
+    mvPyObject                              captureCallback = nullptr;
+    mvPyObject                              captureCallbackUserData = nullptr;
 
     // roots
     std::vector<std::shared_ptr<mvAppItem>> colormapRoots;

--- a/src/mvLayoutWindow.cpp
+++ b/src/mvLayoutWindow.cpp
@@ -210,7 +210,7 @@ void mvLayoutWindow::drawWidgets()
     DebugItem("Enabled:", _itemref->config.enabled ? ts : fs);
     DebugItem("Tracked:", _itemref->config.tracked ? ts : fs);
     DebugItem("Callback:", _itemref->config.callback ? ts : fs);
-    DebugItem("User Data:", _itemref->config.user_data ? ts : fs);
+    DebugItem("User Data:", *(_itemref->config.user_data) ? ts : fs);
     DebugItem("Drop Callback:", _itemref->config.dropCallback ? ts : fs);
     DebugItem("Drag Callback:", _itemref->config.dragCallback ? ts : fs);
 

--- a/src/mvNodes.cpp
+++ b/src/mvNodes.cpp
@@ -52,13 +52,7 @@ void mvNodeEditor::handleSpecificKeywordArgs(PyObject* dict)
 
     if (PyObject* item = PyDict_GetItemString(dict, "delink_callback"))
     {
-
-        if (_delinkCallback)
-            Py_XDECREF(_delinkCallback);
-        item = SanitizeCallback(item);
-        if (item)
-            Py_XINCREF(item);
-        _delinkCallback = item;
+        _delinkCallback = mvPyObject(item == Py_None? nullptr : item, true);
     }
 
     // helper for bit flipping
@@ -79,13 +73,7 @@ void mvNodeEditor::getSpecificConfiguration(PyObject* dict)
     if (dict == nullptr)
         return;
 
-    if (_delinkCallback)
-    {
-        Py_XINCREF(_delinkCallback);
-        PyDict_SetItemString(dict, "delink_callback", _delinkCallback);
-    }
-    else
-        PyDict_SetItemString(dict, "delink_callback", GetPyNone());
+    PyDict_SetItemString(dict, "delink_callback", _delinkCallback? (PyObject*)_delinkCallback : Py_None);
 
     // helper to check and set bit
     auto checkbitset = [dict](const char* keyword, int flag, const int& flags)
@@ -333,20 +321,12 @@ void mvNodeEditor::draw(ImDrawList* drawlist, float x, float y)
 
         if (config.callback)
         {
-            if (config.alias.empty())
-                mvSubmitCallback([=]() {
+            submitCallbackEx([=]() {
                 PyObject* link = PyTuple_New(2);
                 PyTuple_SetItem(link, 0, ToPyUUID(node1));
                 PyTuple_SetItem(link, 1, ToPyUUID(node2));
-                mvAddCallback(config.callback, uuid, link, config.user_data);
-                    });
-            else
-                mvSubmitCallback([=]() {
-                PyObject* link = PyTuple_New(2);
-                PyTuple_SetItem(link, 0, ToPyUUID(node1));
-                PyTuple_SetItem(link, 1, ToPyUUID(node2));
-                mvAddCallback(config.callback, config.alias, link, config.user_data);
-                    });
+                return link;
+            });
         }
     }
 
@@ -367,16 +347,7 @@ void mvNodeEditor::draw(ImDrawList* drawlist, float x, float y)
         }
         if (_delinkCallback)
         {
-            if (config.alias.empty())
-                mvSubmitCallback([=]() {
-                PyObject* link = ToPyUUID(name);
-                mvAddCallback(_delinkCallback, uuid, link, config.user_data);
-                    });
-            else
-                mvSubmitCallback([=]() {
-                PyObject* link = ToPyUUID(name);
-                mvAddCallback(_delinkCallback, config.alias, link, config.user_data);
-                    });
+            submitCallbackEx(_delinkCallback, [=]() { return ToPyUUID(name); });
         }
     }
 

--- a/src/mvNodes.h
+++ b/src/mvNodes.h
@@ -106,7 +106,7 @@ private:
     bool _clearNodes = false;
     bool _clearLinks = false;
 
-    PyObject*             _delinkCallback = nullptr;
+    mvPyObject            _delinkCallback = nullptr;
     ImNodesEditorContext* _context = nullptr;
 
     bool                   _minimap = false;

--- a/src/mvPyUtils.h
+++ b/src/mvPyUtils.h
@@ -30,7 +30,12 @@ class mvPyObject
 
 public:
 
-	mvPyObject(PyObject* rawObject, bool borrowed=false);
+    // With `borrowed=false`, the reference is meant for `mvPyObject` to take
+    // ownership of it. `mvPyObject` "steals" the reference from its previous owner;
+    // the reference count is not incremented.
+    // With `borrowed=true`, `mvPyObject` makes its own owned reference by incrementing
+    // the reference count; the original owner keeps ownership too.
+	mvPyObject(PyObject* rawObject, bool borrowed = false);
 	mvPyObject(mvPyObject&& other);
 	mvPyObject& operator=(mvPyObject&& other);
 
@@ -39,18 +44,16 @@ public:
 
 	~mvPyObject();
 
-	void addRef();
-	void delRef();
-	bool isOk() const { return m_ok; }
+	bool isOk() const { return (m_rawObject != nullptr); }
 
-	operator PyObject* ();
+	operator PyObject* () const
+    {
+        return m_rawObject;
+    }
 
 private:
 
 	PyObject* m_rawObject;
-	bool      m_borrowed;
-	bool      m_ok;
-	bool      m_del = false;
 
 };
 
@@ -92,6 +95,7 @@ bool isPyObject_Any           (PyObject* obj);
 PyObject*   GetPyNone ();
 PyObject*   ToPyUUID  (mvAppItem* item);
 PyObject*   ToPyUUID  (mvUUID value);
+PyObject*   ToPyUUID  (mvUUID uuid, const std::string& alias);
 PyObject*   ToPyLong  (long value);
 PyObject*   ToPyInt   (int value);
 PyObject*   ToPyFloat (float value);

--- a/src/mvSlider3D.cpp
+++ b/src/mvSlider3D.cpp
@@ -397,14 +397,7 @@ void mvSlider3D::draw(ImDrawList* drawlist, float x, float y)
 
 		if(SliderScalar3D(config.specifiedLabel.c_str(), &(*_value)[0], &(*_value)[1], &(*_value)[2], _minX, _maxX, _minY, _maxY, _minZ, _maxZ, _scale))
 		{
-			auto value = *_value;
-			mvSubmitCallback([=]() {
-
-				if(config.alias.empty())
-					mvAddCallback(getCallback(false), uuid, ToPyFloatList(value.data(), (int)value.size()), config.user_data);
-				else
-					mvAddCallback(getCallback(false), config.alias, ToPyFloatList(value.data(), (int)value.size()), config.user_data);
-				});
+			submitCallback(*_value);
 		}
 	}
 

--- a/src/mvTextureItems.cpp
+++ b/src/mvTextureItems.cpp
@@ -205,19 +205,13 @@ void mvRawTexture::setPyValue(PyObject* value)
 			}
 		}
 		PyBuffer_Release(&buffer_info);
-		if (_buffer)
-			Py_XDECREF(_buffer);
-		Py_XINCREF(value);
-		_buffer = value;
+		_buffer = mvPyObject(value, true);
 	}
 }
 
 mvRawTexture::~mvRawTexture()
 {
 	FreeTexture(_texture);
-
-	mvGlobalIntepreterLock gil;
-	Py_XDECREF(_buffer);
 }
 
 void mvRawTexture::draw(ImDrawList* drawlist, float x, float y)

--- a/src/mvTextureItems.h
+++ b/src/mvTextureItems.h
@@ -71,7 +71,7 @@ public:
 
 public:
 
-    PyObject* _buffer = nullptr;
+    mvPyObject _buffer = nullptr;
     void* _value = nullptr;
     void* _texture = nullptr;
     bool          _dirty = true;

--- a/src/mvTimePicker.cpp
+++ b/src/mvTimePicker.cpp
@@ -69,13 +69,7 @@ void mvTimePicker::draw(ImDrawList* drawlist, float x, float y)
 		{
 			ImPlot::GetGmtTime(*_imvalue, _value.get());
 			{
-				auto value = *_value;
-				mvSubmitCallback([=]() {
-					if(config.alias.empty())
-						mvAddCallback(getCallback(false), uuid, ToPyTime(value), config.user_data);
-					else
-						mvAddCallback(getCallback(false), config.alias, ToPyTime(value), config.user_data);
-					});
+				submitCallback(*_value);
 			}
 		}
 	}

--- a/src/mvViewport.h
+++ b/src/mvViewport.h
@@ -65,13 +65,24 @@ void        mvToggleFullScreen(mvViewport& viewport);
 
 static void mvOnResize()
 {
-	mvSubmitCallback([=]() {
-		PyObject* dimensions = PyTuple_New(4);
-		PyTuple_SetItem(dimensions, 0, PyLong_FromLong(GContext->viewport->actualWidth));
-		PyTuple_SetItem(dimensions, 1, PyLong_FromLong(GContext->viewport->actualHeight));
-		PyTuple_SetItem(dimensions, 2, PyLong_FromLong(GContext->viewport->clientWidth));
-		PyTuple_SetItem(dimensions, 3, PyLong_FromLong(GContext->viewport->clientHeight));
-		mvAddCallback(
-			GContext->callbackRegistry->resizeCallback, MV_APP_UUID, dimensions, GContext->callbackRegistry->resizeCallbackUserData);
-		});
+	auto v = GContext->viewport;
+	mvAddOwnerlessCallback(
+		GContext->callbackRegistry->resizeCallback,
+		GContext->callbackRegistry->resizeCallbackUserData,
+		MV_APP_UUID, "",
+		[
+			actualWidth  = v->actualWidth,
+			actualHeight = v->actualHeight,
+			clientWidth  = v->clientWidth,
+			clientHeight = v->clientHeight
+		]
+		() {
+			PyObject* dimensions = PyTuple_New(4);
+			PyTuple_SetItem(dimensions, 0, PyLong_FromLong(actualWidth));
+			PyTuple_SetItem(dimensions, 1, PyLong_FromLong(actualHeight));
+			PyTuple_SetItem(dimensions, 2, PyLong_FromLong(clientWidth));
+			PyTuple_SetItem(dimensions, 3, PyLong_FromLong(clientHeight));
+			return dimensions;
+		}
+	);
 }

--- a/src/mvViewport_apple.mm
+++ b/src/mvViewport_apple.mm
@@ -22,12 +22,10 @@ static void
 window_close_callback(GLFWwindow* window)
 {
     if (GContext->viewport->disableClose) {
-        mvSubmitCallback([=]() {
-            mvRunCallback(GContext->callbackRegistry->onCloseCallback, 0, nullptr, GContext->callbackRegistry->onCloseCallbackUserData);
-            });
+        mvAddOwnerlessCallback(GContext->callbackRegistry->onCloseCallback, GContext->callbackRegistry->onCloseCallbackUserData);
     }
     else {
-        GContext->started = false;
+        StopRendering();
     }
 }
 

--- a/src/mvViewport_linux.cpp
+++ b/src/mvViewport_linux.cpp
@@ -21,12 +21,10 @@ static void
 window_close_callback(GLFWwindow* window)
 {
     if (GContext->viewport->disableClose) {
-        mvSubmitCallback([=]() {
-            mvRunCallback(GContext->callbackRegistry->onCloseCallback, 0, nullptr, GContext->callbackRegistry->onCloseCallbackUserData);
-            });
+        mvAddOwnerlessCallback(GContext->callbackRegistry->onCloseCallback, GContext->callbackRegistry->onCloseCallbackUserData);
     }
     else {
-        GContext->started = false;
+        StopRendering();
     }
 }
 
@@ -125,7 +123,7 @@ mvCleanupViewport(mvViewport& viewport)
 
     glfwDestroyWindow(viewportData->handle);
     glfwTerminate();
-    GContext->started = false;
+    StopRendering();
 
     delete viewportData;
     viewportData = nullptr;

--- a/src/mvViewport_win32.cpp
+++ b/src/mvViewport_win32.cpp
@@ -276,12 +276,10 @@ mvHandleMsg(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) noexcept
 		break;
 	case WM_CLOSE:
 		if (GContext->viewport->disableClose) {
-			mvSubmitCallback([=]() {
-				mvRunCallback(GContext->callbackRegistry->onCloseCallback, 0, nullptr, GContext->callbackRegistry->onCloseCallbackUserData);
-				});
+			mvAddOwnerlessCallback(GContext->callbackRegistry->onCloseCallback, GContext->callbackRegistry->onCloseCallbackUserData);
 			return 0;
 		}
-		GContext->started = false;
+		StopRendering();
 		DestroyWindow(hWnd);
 		::PostQuitMessage(0);
 		return 0;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Refcount mess in mvAddCallback() and mvRunCallback()
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->
Closes #2036

**Description:**
This fix looks remarkably similar to PR #2282 by @bzczb, who deserves recognition for finding all the hidden ~~gems~~ quirks and overall for great job on fixing the issue (trust me, this rabbit hole was **deep**). However, in fact this PR is the result of "parallel evolution" of my own fix, and therefore bears some differences, too. One of them is how callbacks in the queue are handled when their "parent" `mvAppItem` gets deleted - currently both fixes have some visible side effects in this case. I'm going to add yet another fix on top of this (as a separate PR but still the same release) and try to keep `delete_item` behavior backward compatible for most scenarios/users.

This PR also includes some changes that got mixed with it over time and I decided to bring them along rather than waste time trying to separate things:
- It adds `on_close` call to popup windows - this fixes #2372.
- The `item_visible` handler now passes the ID of the widget in `app_data`, like other handlers do.
- `destroy_context` now works way better and waits for all callbacks to complete before shutting down everything - fixes #2020.

Also, the PR fixes some other issues that are not directly related to reference counting but are related to the callback mechanism:
- It removes the two-step callback scheduling in `set_frame_callback` - this fixes #2269.
- Callbacks now honor the "manual callback management" mode - fixes #2208.
- It fixes a race condition between the callback queue and item deletion (when the item gets deleted but its callback is still in the queue) - fixes #2427.

**Concerning Areas:**
After merging this PR, `delete_item` will behave a bit differently: if a callback for the item being deleted is running (including the case where you call `dpg.delete_item(sender)` from the callback), the item will be kept alive until the callback completes. All subsequent callbacks waiting in the queue will be thrown away, but the current callback will work as if the item never got deleted. Well, you won't be able to actually _access_ the item, but it will prevent creation of another one with the same tag/UUID 😅.

I'm going to add yet another PR to reduce some unexpected side effects of this change in behavior.
