### PR TITLE
A better version of split_frame

### DIFF
--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -1211,7 +1211,7 @@ def show_viewport(*, minimized: bool ='', maximized: bool ='') -> None:
 	"""Shows the main viewport."""
 	...
 
-def split_frame(*, delay: int ='') -> None:
+def split_frame() -> None:
 	"""Waits one frame."""
 	...
 

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -8688,16 +8688,16 @@ def show_viewport(**kwargs):
 
 	return internal_dpg.show_viewport(**kwargs)
 
-def split_frame(**kwargs):
+def split_frame():
 	"""	 Waits one frame.
 
 	Args:
-		delay (int, optional): Minimal delay in in milliseconds
+		delay (int, optional): (deprecated)Do not use it anymore, it has no effect.
 	Returns:
 		None
 	"""
 
-	return internal_dpg.split_frame(**kwargs)
+	return internal_dpg.split_frame()
 
 def stop_dearpygui():
 	"""	 Stops Dear PyGui

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -9661,16 +9661,22 @@ def show_viewport(*, minimized: bool =False, maximized: bool =False, **kwargs) -
 
 	return internal_dpg.show_viewport(minimized=minimized, maximized=maximized, **kwargs)
 
-def split_frame(*, delay: int =32, **kwargs) -> None:
+def split_frame(**kwargs) -> None:
 	"""	 Waits one frame.
 
 	Args:
-		delay (int, optional): Minimal delay in in milliseconds
+		delay (int, optional): (deprecated) Do not use it anymore, it has no effect.
 	Returns:
 		None
 	"""
 
-	return internal_dpg.split_frame(delay=delay, **kwargs)
+	if 'delay' in kwargs.keys():
+
+		warnings.warn('delay keyword removed', DeprecationWarning, 2)
+
+		kwargs.pop('delay', None)
+
+	return internal_dpg.split_frame(**kwargs)
 
 def stop_dearpygui(**kwargs) -> None:
 	"""	 Stops Dear PyGui

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -564,7 +564,7 @@ InsertParser_Block1(std::map<std::string, mvPythonParser>& parsers)
 
 	{
 		std::vector<mvPythonDataElement> args;
-		args.push_back({ mvPyDataType::Integer, "delay", mvArgType::KEYWORD_ARG, "32", "Minimal delay in in milliseconds" });
+		args.push_back({ mvPyDataType::Integer, "delay", mvArgType::DEPRECATED_REMOVE_KEYWORD_ARG, "32", "Do not use it anymore, it has no effect." });
 
 		mvPythonParserSetup setup;
 		setup.about = "Waits one frame.";

--- a/src/mvContext.h
+++ b/src/mvContext.h
@@ -102,7 +102,9 @@ struct mvIO
 
 struct mvContext
 {
-    std::atomic_bool    waitOneFrame       = false;
+    std::mutex          frameEndedMutex;
+    std::condition_variable frameEndedEvent;
+    bool                frameEnded         = false;
     // Indicates whether DPG has started at least once in this context, i.e. whether
     // associated Dear ImGui contexts exist and can be read from.
     std::atomic_bool    started            = false;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: A better version of split_frame, releases immediately after frame rendering has ended.
assignees: ''

---

**Description:**
This PR improves on how `split_frame` waits for a frame to get rendered: now there's no loop polling on `delay` intervals (and no `delay` argument at all), the function gets notified about the next frame immediately after its rendering has ended.

Another effect of this PR is that `destroy_context` causes any waiting `split_frame` to fail with an exception, whereas the earlier version would just hang up forever.

**Concerning Areas:**
Users might need to adapt their code to catch or suppress exceptions, though 99.9% of them probably won't notice the change.
