### PR TITLE
Added a scroll handler

### DIFF
--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -343,6 +343,10 @@ def add_item_resize_handler(*, label: str ='', user_data: Any ='', use_internal_
 	"""Adds a resize handler."""
 	...
 
+def add_item_scroll_handler(*, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', parent: Union[int, str] ='', callback: Callable ='', show: bool ='') -> Union[int, str]:
+	"""Adds a scroll handler."""
+	...
+
 def add_item_toggled_open_handler(*, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', parent: Union[int, str] ='', callback: Callable ='', show: bool ='') -> Union[int, str]:
 	"""Adds a togged open handler."""
 	...
@@ -1179,12 +1183,12 @@ def set_viewport_resize_callback(callback : Callable, *, user_data: Any ='') -> 
 	"""Sets a callback to run on viewport resize."""
 	...
 
-def set_x_scroll(item : Union[int, str], value : float) -> None:
-	"""Undocumented"""
+def set_x_scroll(item : Union[int, str], value : float, *, when: int ='') -> None:
+	"""Sets horizontal scroll position."""
 	...
 
-def set_y_scroll(item : Union[int, str], value : float) -> None:
-	"""Undocumented"""
+def set_y_scroll(item : Union[int, str], value : float, *, when: int ='') -> None:
+	"""Sets vertical scroll position."""
 	...
 
 def setup_dearpygui() -> None:
@@ -1434,6 +1438,13 @@ mvEventType_Off=0
 mvEventType_Enter=0
 mvEventType_On=0
 mvEventType_Leave=0
+mvSetScrollFlags_Now=0
+mvSetScrollFlags_Delayed=0
+mvSetScrollFlags_Both=0
+mvScrollDirection_XAxis=0
+mvScrollDirection_YAxis=0
+mvScrollDirection_Horizontal=0
+mvScrollDirection_Vertical=0
 mvPlatform_Windows=0
 mvPlatform_Apple=0
 mvPlatform_Linux=0
@@ -1856,6 +1867,7 @@ mvDeactivatedAfterEditHandler=0
 mvToggledOpenHandler=0
 mvClickedHandler=0
 mvDoubleClickedHandler=0
+mvScrollHandler=0
 mvDragPayload=0
 mvResizeHandler=0
 mvFont=0

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -5001,6 +5001,24 @@ def add_item_resize_handler(**kwargs):
 
 	return internal_dpg.add_item_resize_handler(**kwargs)
 
+def add_item_scroll_handler(**kwargs):
+	"""	 Adds a scroll handler.
+
+	Args:
+		label (str, optional): Overrides 'name' as label.
+		user_data (Any, optional): User data for callbacks
+		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
+		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
+		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
+		callback (Callable, optional): Registers a callback.
+		show (bool, optional): Attempt to render widget.
+		id (Union[int, str], optional): (deprecated)
+	Returns:
+		Union[int, str]
+	"""
+
+	return internal_dpg.add_item_scroll_handler(**kwargs)
+
 def add_item_toggled_open_handler(**kwargs):
 	"""	 Adds a togged open handler.
 
@@ -8600,29 +8618,31 @@ def set_viewport_resize_callback(callback, **kwargs):
 
 	return internal_dpg.set_viewport_resize_callback(callback, **kwargs)
 
-def set_x_scroll(item, value):
-	"""	 Undocumented
+def set_x_scroll(item, value, **kwargs):
+	"""	 Sets horizontal scroll position.
 
 	Args:
 		item (Union[int, str]): 
-		value (float): 
+		value (float): Scroll position
+		when (int, optional): Specifies whether the scroll position will be set in the nearest frame (mvSetScrollFlags_Now) or with a 1-frame delay (mvSetScrollFlags_Delayed).  The former prevents flickering, the latter works better if contents change in the same frame as when set_x_scroll called.  mvSetScrollFlags_Both can also be used to set the position twice.
 	Returns:
 		None
 	"""
 
-	return internal_dpg.set_x_scroll(item, value)
+	return internal_dpg.set_x_scroll(item, value, **kwargs)
 
-def set_y_scroll(item, value):
-	"""	 Undocumented
+def set_y_scroll(item, value, **kwargs):
+	"""	 Sets vertical scroll position.
 
 	Args:
 		item (Union[int, str]): 
-		value (float): 
+		value (float): Scroll position
+		when (int, optional): Specifies whether the scroll position will be set in the nearest frame (mvSetScrollFlags_Now) or with a 1-frame delay (mvSetScrollFlags_Delayed).  The former prevents flickering, the latter works better if contents change in the same frame as when set_x_scroll called.  mvSetScrollFlags_Both can also be used to set the position twice.
 	Returns:
 		None
 	"""
 
-	return internal_dpg.set_y_scroll(item, value)
+	return internal_dpg.set_y_scroll(item, value, **kwargs)
 
 def setup_dearpygui():
 	"""	 Sets up Dear PyGui
@@ -8989,6 +9009,13 @@ mvEventType_Off=internal_dpg.mvEventType_Off
 mvEventType_Enter=internal_dpg.mvEventType_Enter
 mvEventType_On=internal_dpg.mvEventType_On
 mvEventType_Leave=internal_dpg.mvEventType_Leave
+mvSetScrollFlags_Now=internal_dpg.mvSetScrollFlags_Now
+mvSetScrollFlags_Delayed=internal_dpg.mvSetScrollFlags_Delayed
+mvSetScrollFlags_Both=internal_dpg.mvSetScrollFlags_Both
+mvScrollDirection_XAxis=internal_dpg.mvScrollDirection_XAxis
+mvScrollDirection_YAxis=internal_dpg.mvScrollDirection_YAxis
+mvScrollDirection_Horizontal=internal_dpg.mvScrollDirection_Horizontal
+mvScrollDirection_Vertical=internal_dpg.mvScrollDirection_Vertical
 mvPlatform_Windows=internal_dpg.mvPlatform_Windows
 mvPlatform_Apple=internal_dpg.mvPlatform_Apple
 mvPlatform_Linux=internal_dpg.mvPlatform_Linux
@@ -9411,6 +9438,7 @@ mvDeactivatedAfterEditHandler=internal_dpg.mvDeactivatedAfterEditHandler
 mvToggledOpenHandler=internal_dpg.mvToggledOpenHandler
 mvClickedHandler=internal_dpg.mvClickedHandler
 mvDoubleClickedHandler=internal_dpg.mvDoubleClickedHandler
+mvScrollHandler=internal_dpg.mvScrollHandler
 mvDragPayload=internal_dpg.mvDragPayload
 mvResizeHandler=internal_dpg.mvResizeHandler
 mvFont=internal_dpg.mvFont

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -5552,6 +5552,28 @@ def add_item_resize_handler(*, label: str =None, user_data: Any =None, use_inter
 
 	return internal_dpg.add_item_resize_handler(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, callback=callback, show=show, **kwargs)
 
+def add_item_scroll_handler(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, callback: Callable =None, show: bool =True, **kwargs) -> Union[int, str]:
+	"""	 Adds a scroll handler.
+
+	Args:
+		label (str, optional): Overrides 'name' as label.
+		user_data (Any, optional): User data for callbacks
+		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
+		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
+		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
+		callback (Callable, optional): Registers a callback.
+		show (bool, optional): Attempt to render widget.
+		id (Union[int, str], optional): (deprecated) 
+	Returns:
+		Union[int, str]
+	"""
+
+	if 'id' in kwargs.keys():
+		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
+		tag=kwargs['id']
+
+	return internal_dpg.add_item_scroll_handler(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, callback=callback, show=show, **kwargs)
+
 def add_item_toggled_open_handler(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, callback: Callable =None, show: bool =True, **kwargs) -> Union[int, str]:
 	"""	 Adds a togged open handler.
 
@@ -9561,29 +9583,31 @@ def set_viewport_resize_callback(callback : Callable, *, user_data: Any =None, *
 
 	return internal_dpg.set_viewport_resize_callback(callback, user_data=user_data, **kwargs)
 
-def set_x_scroll(item : Union[int, str], value : float, **kwargs) -> None:
-	"""	 Undocumented
+def set_x_scroll(item : Union[int, str], value : float, *, when: int =internal_dpg.mvSetScrollFlags_Delayed, **kwargs) -> None:
+	"""	 Sets horizontal scroll position.
 
 	Args:
 		item (Union[int, str]): 
-		value (float): 
+		value (float): Scroll position
+		when (int, optional): Specifies whether the scroll position will be set in the nearest frame (mvSetScrollFlags_Now) or with a 1-frame delay (mvSetScrollFlags_Delayed).  The former prevents flickering, the latter works better if contents change in the same frame as when set_x_scroll called.  mvSetScrollFlags_Both can also be used to set the position twice.
 	Returns:
 		None
 	"""
 
-	return internal_dpg.set_x_scroll(item, value, **kwargs)
+	return internal_dpg.set_x_scroll(item, value, when=when, **kwargs)
 
-def set_y_scroll(item : Union[int, str], value : float, **kwargs) -> None:
-	"""	 Undocumented
+def set_y_scroll(item : Union[int, str], value : float, *, when: int =internal_dpg.mvSetScrollFlags_Delayed, **kwargs) -> None:
+	"""	 Sets vertical scroll position.
 
 	Args:
 		item (Union[int, str]): 
-		value (float): 
+		value (float): Scroll position
+		when (int, optional): Specifies whether the scroll position will be set in the nearest frame (mvSetScrollFlags_Now) or with a 1-frame delay (mvSetScrollFlags_Delayed).  The former prevents flickering, the latter works better if contents change in the same frame as when set_x_scroll called.  mvSetScrollFlags_Both can also be used to set the position twice.
 	Returns:
 		None
 	"""
 
-	return internal_dpg.set_y_scroll(item, value, **kwargs)
+	return internal_dpg.set_y_scroll(item, value, when=when, **kwargs)
 
 def setup_dearpygui(**kwargs) -> None:
 	"""	 Sets up Dear PyGui
@@ -9968,6 +9992,13 @@ mvEventType_Off=internal_dpg.mvEventType_Off
 mvEventType_Enter=internal_dpg.mvEventType_Enter
 mvEventType_On=internal_dpg.mvEventType_On
 mvEventType_Leave=internal_dpg.mvEventType_Leave
+mvSetScrollFlags_Now=internal_dpg.mvSetScrollFlags_Now
+mvSetScrollFlags_Delayed=internal_dpg.mvSetScrollFlags_Delayed
+mvSetScrollFlags_Both=internal_dpg.mvSetScrollFlags_Both
+mvScrollDirection_XAxis=internal_dpg.mvScrollDirection_XAxis
+mvScrollDirection_YAxis=internal_dpg.mvScrollDirection_YAxis
+mvScrollDirection_Horizontal=internal_dpg.mvScrollDirection_Horizontal
+mvScrollDirection_Vertical=internal_dpg.mvScrollDirection_Vertical
 mvPlatform_Windows=internal_dpg.mvPlatform_Windows
 mvPlatform_Apple=internal_dpg.mvPlatform_Apple
 mvPlatform_Linux=internal_dpg.mvPlatform_Linux
@@ -10390,6 +10421,7 @@ mvDeactivatedAfterEditHandler=internal_dpg.mvDeactivatedAfterEditHandler
 mvToggledOpenHandler=internal_dpg.mvToggledOpenHandler
 mvClickedHandler=internal_dpg.mvClickedHandler
 mvDoubleClickedHandler=internal_dpg.mvDoubleClickedHandler
+mvScrollHandler=internal_dpg.mvScrollHandler
 mvDragPayload=internal_dpg.mvDragPayload
 mvResizeHandler=internal_dpg.mvResizeHandler
 mvFont=internal_dpg.mvFont

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -74,6 +74,16 @@ GetModuleConstants()
 		ModuleConstants.push_back({"mvEventType_On", 	mvEventType_On });
 		ModuleConstants.push_back({"mvEventType_Leave", mvEventType_Leave });
 
+		// We're not adding 'None' because it's useless in the API
+		ModuleConstants.push_back({"mvSetScrollFlags_Now", mvSetScrollFlags_Now });
+		ModuleConstants.push_back({"mvSetScrollFlags_Delayed", mvSetScrollFlags_Delayed });
+		ModuleConstants.push_back({"mvSetScrollFlags_Both", mvSetScrollFlags_Both });
+
+		ModuleConstants.push_back({"mvScrollDirection_XAxis", mvScrollDirection_XAxis });
+		ModuleConstants.push_back({"mvScrollDirection_YAxis", mvScrollDirection_YAxis });
+		ModuleConstants.push_back({"mvScrollDirection_Horizontal", mvScrollDirection_Horizontal });
+		ModuleConstants.push_back({"mvScrollDirection_Vertical", mvScrollDirection_Vertical });
+
 		ModuleConstants.push_back({"mvPlatform_Windows", 0L });
 		ModuleConstants.push_back({"mvPlatform_Apple", 1L });
 		ModuleConstants.push_back({"mvPlatform_Linux", 2L });

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -207,9 +207,10 @@ set_x_scroll(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	PyObject* itemraw;
 	float value;
+	int when = (int)mvSetScrollFlags_Delayed;
 
 	if (!Parse((GetParsers())["set_x_scroll"], args, kwargs, __FUNCTION__,
-		&itemraw, &value))
+		&itemraw, &value, &when))
 		return GetPyNone();
 
 	mvPySafeLockGuard lk(GContext->mutex);
@@ -224,25 +225,10 @@ set_x_scroll(PyObject* self, PyObject* args, PyObject* kwargs)
 		return GetPyNone();
 	}
 
-	if (window->type == mvAppItemType::mvWindowAppItem)
+	if (DearPyGui::GetApplicableState(window->type) & MV_STATE_SCROLL)
 	{
-
-		auto pWindow = static_cast<mvWindowAppItem*>(window);
-
-		pWindow->configData.scrollX = value;
-		pWindow->configData._scrollXSet = true;
-	}
-	else if (window->type == mvAppItemType::mvChildWindow)
-	{
-		auto pChild = static_cast<mvChildWindow*>(window);
-		pChild->configData.scrollX = value;
-		pChild->configData._scrollXSet = true;
-	}
-	else if (window->type == mvAppItemType::mvTable)
-	{
-		auto pChild = static_cast<mvTable*>(window);
-		pChild->_scrollX = value;
-		pChild->_scrollXSet = true;
+		window->config.scrollX = value;
+		window->config.scrollXFlags = (mvSetScrollFlags)when;
 	}
 	else
 	{
@@ -259,9 +245,10 @@ set_y_scroll(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	PyObject* itemraw;
 	float value;
+	int when = (int)mvSetScrollFlags_Delayed;
 
 	if (!Parse((GetParsers())["set_y_scroll"], args, kwargs, __FUNCTION__,
-		&itemraw, &value))
+		&itemraw, &value, &when))
 		return GetPyNone();
 
 	mvPySafeLockGuard lk(GContext->mutex);
@@ -276,25 +263,10 @@ set_y_scroll(PyObject* self, PyObject* args, PyObject* kwargs)
 		return GetPyNone();
 	}
 
-	if (window->type == mvAppItemType::mvWindowAppItem)
+	if (DearPyGui::GetApplicableState(window->type) & MV_STATE_SCROLL)
 	{
-
-		auto pWindow = static_cast<mvWindowAppItem*>(window);
-
-		pWindow->configData.scrollY = value;
-		pWindow->configData._scrollYSet = true;
-	}
-	else if (window->type == mvAppItemType::mvChildWindow)
-	{
-		auto pChild = static_cast<mvChildWindow*>(window);
-		pChild->configData.scrollY = value;
-		pChild->configData._scrollYSet = true;
-	}
-	else if (window->type == mvAppItemType::mvTable)
-	{
-		auto pChild = static_cast<mvTable*>(window);
-		pChild->_scrollY = value;
-		pChild->_scrollYSet = true;
+		window->config.scrollY = value;
+		window->config.scrollYFlags = (mvSetScrollFlags)when;
 	}
 	else
 	{
@@ -327,24 +299,9 @@ get_x_scroll(PyObject* self, PyObject* args, PyObject* kwargs)
 		return GetPyNone();
 	}
 
-	if (window->type == mvAppItemType::mvWindowAppItem)
+	if (DearPyGui::GetApplicableState(window->type) & MV_STATE_SCROLL)
 	{
-
-		auto pWindow = static_cast<mvWindowAppItem*>(window);
-
-		return ToPyFloat(pWindow->configData.scrollX);
-	}
-	else if (window->type == mvAppItemType::mvChildWindow)
-	{
-		auto pChild = static_cast<mvChildWindow*>(window);
-
-		return ToPyFloat(pChild->configData.scrollX);
-	}
-	else if (window->type == mvAppItemType::mvTable)
-	{
-		auto pTable = static_cast<mvTable*>(window);
-
-		return ToPyFloat(pTable->_scrollX);
+		return ToPyFloat(window->state.scrollPos.x);
 	}
 	else
 	{
@@ -377,24 +334,9 @@ get_y_scroll(PyObject* self, PyObject* args, PyObject* kwargs)
 		return GetPyNone();
 	}
 
-	if (window->type == mvAppItemType::mvWindowAppItem)
+	if (DearPyGui::GetApplicableState(window->type) & MV_STATE_SCROLL)
 	{
-
-		auto pWindow = static_cast<mvWindowAppItem*>(window);
-
-		return ToPyFloat(pWindow->configData.scrollY);
-	}
-	else if (window->type == mvAppItemType::mvChildWindow)
-	{
-		auto pChild = static_cast<mvChildWindow*>(window);
-
-		return ToPyFloat(pChild->configData.scrollY);
-	}
-	else if (window->type == mvAppItemType::mvTable)
-	{
-		auto pTable = static_cast<mvTable*>(window);
-
-		return ToPyFloat(pTable->_scrollY);
+		return ToPyFloat(window->state.scrollPos.y);
 	}
 	else
 	{
@@ -427,24 +369,9 @@ get_x_scroll_max(PyObject* self, PyObject* args, PyObject* kwargs)
 		return GetPyNone();
 	}
 
-	if (window->type == mvAppItemType::mvWindowAppItem)
+	if (DearPyGui::GetApplicableState(window->type) & MV_STATE_SCROLL)
 	{
-
-		auto pWindow = static_cast<mvWindowAppItem*>(window);
-
-		return ToPyFloat(pWindow->configData.scrollMaxX);
-	}
-	else if (window->type == mvAppItemType::mvChildWindow)
-	{
-		auto pChild = static_cast<mvChildWindow*>(window);
-
-		return ToPyFloat(pChild->configData.scrollMaxX);
-	}
-	else if (window->type == mvAppItemType::mvTable)
-	{
-		auto pTable = static_cast<mvTable*>(window);
-
-		return ToPyFloat(pTable->_scrollMaxX);
+		return ToPyFloat(window->state.scrollMax.x);
 	}
 	else
 	{
@@ -477,28 +404,13 @@ get_y_scroll_max(PyObject* self, PyObject* args, PyObject* kwargs)
 		return GetPyNone();
 	}
 
-	if (window->type == mvAppItemType::mvWindowAppItem)
+	if (DearPyGui::GetApplicableState(window->type) & MV_STATE_SCROLL)
 	{
-
-		auto pWindow = static_cast<mvWindowAppItem*>(window);
-
-		return ToPyFloat(pWindow->configData.scrollMaxY);
-	}
-	else if (window->type == mvAppItemType::mvChildWindow)
-	{
-		auto pChild = static_cast<mvChildWindow*>(window);
-
-		return ToPyFloat(pChild->configData.scrollMaxY);
-	}
-	else if (window->type == mvAppItemType::mvTable)
-	{
-		auto pTable = static_cast<mvTable*>(window);
-
-		return ToPyFloat(pTable->_scrollMaxY);
+		return ToPyFloat(window->state.scrollMax.y);
 	}
 	else
 	{
-		mvThrowPythonError(mvErrorCode::mvIncompatibleType, "set_y_scroll_max",
+		mvThrowPythonError(mvErrorCode::mvIncompatibleType, "get_y_scroll_max",
 			"Incompatible type. Expected types include: mvWindowAppItem, mvChildWindow, mvTable", window);
 	}
 
@@ -3730,7 +3642,8 @@ get_item_info(PyObject* self, PyObject* args, PyObject* kwargs)
 		PyDict_SetItemString(pdict, "deactivatedae_handler_applicable", mvPyObject(ToPyBool(applicableState & MV_STATE_DEACTIVATEDAE)));
 		PyDict_SetItemString(pdict, "toggled_open_handler_applicable", mvPyObject(ToPyBool(applicableState & MV_STATE_TOGGLED_OPEN)));
 		PyDict_SetItemString(pdict, "resized_handler_applicable", mvPyObject(ToPyBool(applicableState & MV_STATE_RECT_SIZE)));
-		
+		PyDict_SetItemString(pdict, "scroll_handler_applicable", mvPyObject(ToPyBool(applicableState & MV_STATE_SCROLL)));
+
 	}
 
 	else

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -1784,9 +1784,15 @@ InsertParser_Block4(std::map<std::string, mvPythonParser>& parsers)
 	{
 		std::vector<mvPythonDataElement> args;
 		args.push_back({ mvPyDataType::UUID, "item" });
-		args.push_back({ mvPyDataType::Float, "value" });
+		args.push_back({ mvPyDataType::Float, "value", mvArgType::REQUIRED_ARG, "", "Scroll position"});
+		args.push_back({ mvPyDataType::Integer, "when", mvArgType::KEYWORD_ARG, "internal_dpg.mvSetScrollFlags_Delayed",
+			"Specifies whether the scroll position will be set in the nearest frame (mvSetScrollFlags_Now) or with "
+			"a 1-frame delay (mvSetScrollFlags_Delayed).  The former prevents flickering, the latter works better "
+			"if contents change in the same frame as when set_x_scroll called.  mvSetScrollFlags_Both can also be used "
+			"to set the position twice." });
 
 		mvPythonParserSetup setup;
+		setup.about = "Sets horizontal scroll position.";
 
 		mvPythonParser parser = FinalizeParser(setup, args);
 		parsers.insert({ "set_x_scroll", parser });
@@ -1795,8 +1801,16 @@ InsertParser_Block4(std::map<std::string, mvPythonParser>& parsers)
 	{
 		std::vector<mvPythonDataElement> args;
 		args.push_back({ mvPyDataType::UUID, "item" });
-		args.push_back({ mvPyDataType::Float, "value" });
+		args.push_back({ mvPyDataType::Float, "value", mvArgType::REQUIRED_ARG, "", "Scroll position"});
+		args.push_back({ mvPyDataType::Integer, "when", mvArgType::KEYWORD_ARG, "internal_dpg.mvSetScrollFlags_Delayed",
+			"Specifies whether the scroll position will be set in the nearest frame (mvSetScrollFlags_Now) or with "
+			"a 1-frame delay (mvSetScrollFlags_Delayed).  The former prevents flickering, the latter works better "
+			"if contents change in the same frame as when set_x_scroll called.  mvSetScrollFlags_Both can also be used "
+			"to set the position twice." });
+
 		mvPythonParserSetup setup;
+		setup.about = "Sets vertical scroll position.";
+
 		mvPythonParser parser = FinalizeParser(setup, args);
 		parsers.insert({ "set_y_scroll", parser });
 	}

--- a/src/mvAppItem.h
+++ b/src/mvAppItem.h
@@ -109,6 +109,14 @@ struct mvAppItemInfo
     bool dirtyPos   = false;
 };
 
+enum mvSetScrollFlags
+{
+    mvSetScrollFlags_None       = 0,
+    mvSetScrollFlags_Now        = 1 << 0,
+    mvSetScrollFlags_Delayed    = 1 << 1,
+    mvSetScrollFlags_Both       = mvSetScrollFlags_Now | mvSetScrollFlags_Delayed
+};
+
 struct mvAppItemConfig
 {
     mvUUID      source = 0;
@@ -134,6 +142,10 @@ struct mvAppItemConfig
     // the callback.  This is to pass user_data into mvAddCallback that comes from a
     // different source than the callback owner (required for the drag callback).
     std::shared_ptr<mvPyObject> user_data = std::make_shared<mvPyObject>(nullptr);
+    float       scrollX          = 0.0f;
+    float       scrollY          = 0.0f;
+    mvSetScrollFlags scrollXFlags = mvSetScrollFlags_None;
+    mvSetScrollFlags scrollYFlags = mvSetScrollFlags_None;
 };
 
 struct mvAppItemDrawInfo
@@ -244,7 +256,12 @@ public:
     // config setters
     //-----------------------------------------------------------------------------
     virtual void setDataSource(mvUUID value);
-       
+
+    //-----------------------------------------------------------------------------
+    // scrolling support
+    //-----------------------------------------------------------------------------
+    void handleImmediateScroll();
+    void handleDelayedScroll();
 };
 
 inline bool mvClipPoint(float clipViewport[6], mvVec4& point)
@@ -406,6 +423,7 @@ GetEntityCommand(mvAppItemType type)
     case mvAppItemType::mvDoubleClickedHandler:        return "add_item_double_clicked_handler";
     case mvAppItemType::mvDragPayload:                 return "add_drag_payload";
     case mvAppItemType::mvResizeHandler:               return "add_item_resize_handler";
+    case mvAppItemType::mvScrollHandler:               return "add_item_scroll_handler";
     case mvAppItemType::mvFont:                        return "add_font";
     case mvAppItemType::mvFontRegistry:                return "add_font_registry";
     case mvAppItemType::mvTheme:                       return "add_theme";

--- a/src/mvAppItemState.cpp
+++ b/src/mvAppItemState.cpp
@@ -23,6 +23,8 @@ ResetAppItemState(mvAppItemState& state)
     state.deactivatedAfterEdit = false;
     state.toggledOpen = false;
     state.mvRectSizeResized = false;
+    state.scrolledX = state.scrolledY = false;
+    state.isScrollingX = state.isScrollingY = false;
 }
 
 void
@@ -61,6 +63,17 @@ UpdateAppItemState(mvAppItemState& state)
     state.mvPrevRectSize = state.rectSize;
 }
 
+void
+UpdateAppItemScrollInfo(mvAppItemState& state)
+{
+    float scrollX = ImGui::GetScrollX();
+    float scrollY = ImGui::GetScrollY();
+    state.scrolledX = (scrollX != state.scrollPos.x);
+    state.scrolledY = (scrollY != state.scrollPos.y);
+    state.scrollPos = { scrollX, scrollY };
+    state.scrollMax = { ImGui::GetScrollMaxX(), ImGui::GetScrollMaxY() };
+}
+
 void 
 FillAppItemState(PyObject* dict, mvAppItemState& state, i32 applicableState)
 {
@@ -96,6 +109,14 @@ FillAppItemState(PyObject* dict, mvAppItemState& state, i32 applicableState)
         PyDict_SetItemString(dict, "resized", mvPyObject(ToPyBool(valid ? state.mvRectSizeResized : false)));
     }
     if(applicableState & MV_STATE_CONT_AVAIL) PyDict_SetItemString(dict, "content_region_avail", mvPyObject(ToPyPairII((i32)state.contextRegionAvail.x, (i32)state.contextRegionAvail.y)));
+
+    if(applicableState & MV_STATE_SCROLL)
+    {
+        PyDict_SetItemString(dict, "scrolled", mvPyObject(ToPyTPair(valid && state.scrolledX, valid && state.scrolledY)));
+        PyDict_SetItemString(dict, "is_scrolling", mvPyObject(ToPyTPair(valid && state.isScrollingX, valid && state.isScrollingY)));
+        PyDict_SetItemString(dict, "scroll_pos", mvPyObject(ToPyPair(state.scrollPos.x, state.scrollPos.y)));
+        PyDict_SetItemString(dict, "scroll_max", mvPyObject(ToPyPair(state.scrollMax.x, state.scrollMax.y)));
+    }
 
 }
 

--- a/src/mvAppItemState.h
+++ b/src/mvAppItemState.h
@@ -31,8 +31,9 @@ enum mvStateItems
     MV_STATE_RECT_MAX       = 1 << 12,
     MV_STATE_RECT_SIZE      = 1 << 13,
     MV_STATE_CONT_AVAIL     = 1 << 14,
+    MV_STATE_SCROLL         = 1 << 15,
     MV_STATE_ALL = MV_STATE_HOVER |MV_STATE_ACTIVE |MV_STATE_FOCUSED |MV_STATE_CLICKED |MV_STATE_VISIBLE |MV_STATE_EDITED |MV_STATE_ACTIVATED |MV_STATE_DEACTIVATED |MV_STATE_DEACTIVATEDAE |
-    MV_STATE_TOGGLED_OPEN | MV_STATE_RECT_MIN |MV_STATE_RECT_MAX |MV_STATE_RECT_SIZE |MV_STATE_CONT_AVAIL
+    MV_STATE_TOGGLED_OPEN | MV_STATE_RECT_MIN |MV_STATE_RECT_MAX |MV_STATE_RECT_SIZE |MV_STATE_CONT_AVAIL |MV_STATE_SCROLL
 };
 
 //-----------------------------------------------------------------------------
@@ -42,6 +43,10 @@ enum mvStateItems
 void FillAppItemState  (PyObject* dict, mvAppItemState& state, i32 applicableState); // fills python dict with applicable state values
 void ResetAppItemState (mvAppItemState& state);                                      // reset values to false
 void UpdateAppItemState(mvAppItemState& state);                                      // standard imgui update
+// Retrieves scroll info; only applicable to containers. Does NOT update state.lastFrameUpdate
+// and therefore MUST be called in the same branch where that variable is updated
+// by the caller (or where UpdateAppItemState() gets called).
+void UpdateAppItemScrollInfo(mvAppItemState& state);
 
 // return actual value if frame is active
 b8 IsItemHovered             (mvAppItemState& state, i32 frameDelay = 0);
@@ -81,12 +86,20 @@ struct mvAppItemState
     b8         deactivatedAfterEdit = false;
     b8         toggledOpen          = false;
     b8         mvRectSizeResized    = false;
+    b8         scrolledX            = false;
+    b8         scrolledY            = false;
+    // isScrolling flags are not implemented yet - we need support on ImGui side.
+    // They are here just as a reserved placeholder for future implementation.
+    b8         isScrollingX         = false;
+    b8         isScrollingY         = false;
     mvVec2     rectMin              = { 0.0f, 0.0f };
     mvVec2     rectMax              = { 0.0f, 0.0f };
     mvVec2     rectSize             = { 0.0f, 0.0f };
     mvVec2     mvPrevRectSize       = { 0.0f, 0.0f };
     mvVec2     pos                  = { 0.0f, 0.0f };
     mvVec2     contextRegionAvail   = { 0.0f, 0.0f };
+    mvVec2     scrollPos            = { 0.0f, 0.0f };
+    mvVec2     scrollMax            = { 0.0f, 0.0f };
     b8         ok                   = true;
     i32        lastFrameUpdate      = 0; // last frame update occured
     mvAppItem* parent               = nullptr; // hacky, but quick fix for widget handlers

--- a/src/mvAppItemTypes.inc
+++ b/src/mvAppItemTypes.inc
@@ -130,6 +130,7 @@
     X( mvToggledOpenHandler ) \
     X( mvClickedHandler ) \
     X( mvDoubleClickedHandler ) \
+    X( mvScrollHandler ) \
     X( mvDragPayload ) \
     X( mvResizeHandler ) \
     X( mvFont ) \

--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -927,6 +927,8 @@ DearPyGui::draw_child_window(ImDrawList* drawlist, mvAppItem& item, mvChildWindo
     {
         ScopedID id(item.uuid);
 
+        item.handleImmediateScroll();
+
         // TODO: Do we want to put an if statement to prevent further drawing if not shown?
         ImGui::BeginChild(item.info.internalLabel.c_str(), ImVec2(config.autosize_x ? 0 : (float)item.config.width, config.autosize_y ? 0 : (float)item.config.height), config.childFlags, config.windowflags);
         item.state.lastFrameUpdate = GContext->frame;
@@ -951,23 +953,8 @@ DearPyGui::draw_child_window(ImDrawList* drawlist, mvAppItem& item, mvChildWindo
 
         }
 
-        if (config._scrollXSet)
-        {
-            if (config.scrollX < 0.0f)
-                ImGui::SetScrollHereX(1.0f);
-            else
-                ImGui::SetScrollX(config.scrollX);
-            config._scrollXSet = false;
-        }
-
-        if (config._scrollYSet)
-        {
-            if (config.scrollY < 0.0f)
-                ImGui::SetScrollHereY(1.0f);
-            else
-                ImGui::SetScrollY(config.scrollY);
-            config._scrollYSet = false;
-        }
+        item.handleDelayedScroll();
+        item.config.scrollXFlags = item.config.scrollYFlags = mvSetScrollFlags_None;
 
         // allows this item to have a render callback
         if (ImGui::IsWindowFocused(ImGuiFocusedFlags_ChildWindows))
@@ -984,10 +971,7 @@ DearPyGui::draw_child_window(ImDrawList* drawlist, mvAppItem& item, mvChildWindo
 
         }
 
-        config.scrollX = ImGui::GetScrollX();
-        config.scrollY = ImGui::GetScrollY();
-        config.scrollMaxX = ImGui::GetScrollMaxX();
-        config.scrollMaxY = ImGui::GetScrollMaxY();
+        UpdateAppItemScrollInfo(item.state);
 
         ImGui::EndChild();
     }
@@ -1502,6 +1486,8 @@ DearPyGui::draw_window(ImDrawList* drawlist, mvAppItem& item, mvWindowAppItemCon
 
     ImGui::SetNextWindowSizeConstraints(config.min_size, config.max_size);
 
+    item.handleImmediateScroll();
+
     if (config.modal)
     {
         if (item.info.shownLastFrame)
@@ -1640,28 +1626,10 @@ DearPyGui::draw_window(ImDrawList* drawlist, mvAppItem& item, mvWindowAppItemCon
     // handle popping themes
     cleanup_local_theming(&item);
 
-    if (config._scrollXSet)
-    {
-        if (config.scrollX < 0.0f)
-            ImGui::SetScrollHereX(1.0f);
-        else
-            ImGui::SetScrollX(config.scrollX);
-        config._scrollXSet = false;
-    }
+    item.handleDelayedScroll();
+    item.config.scrollXFlags = item.config.scrollYFlags = mvSetScrollFlags_None;
 
-    if (config._scrollYSet)
-    {
-        if (config.scrollY < 0.0f)
-            ImGui::SetScrollHereY(1.0f);
-        else
-            ImGui::SetScrollY(config.scrollY);
-        config._scrollYSet = false;
-    }
-
-    config.scrollX = ImGui::GetScrollX();
-    config.scrollY = ImGui::GetScrollY();
-    config.scrollMaxX = ImGui::GetScrollMaxX();
-    config.scrollMaxY = ImGui::GetScrollMaxY();
+    UpdateAppItemScrollInfo(item.state);
 
     //-----------------------------------------------------------------------------
     // update state

--- a/src/mvContainers.h
+++ b/src/mvContainers.h
@@ -101,12 +101,6 @@ struct mvChildWindowConfig
     bool             autosize_x = false;
     bool             autosize_y = false;
     ImGuiWindowFlags windowflags = ImGuiWindowFlags_NoSavedSettings|ImGuiWindowFlags_NavFlattened;
-    float            scrollX = 0.0f;
-    float            scrollY = 0.0f;
-    float            scrollMaxX = 0.0f;
-    float            scrollMaxY = 0.0f;
-    bool             _scrollXSet = false;
-    bool             _scrollYSet = false;
 };
 
 struct mvTreeNodeConfig
@@ -173,13 +167,7 @@ struct mvWindowAppItemConfig
     mvPyObject       on_close = nullptr;
     mvVec2           min_size = { 100.0f, 100.0f };
     mvVec2           max_size = { 30000.0f, 30000.0f };
-    float            scrollX = 0.0f;
-    float            scrollY = 0.0f;
-    float            scrollMaxX = 0.0f;
-    float            scrollMaxY = 0.0f;
     bool             _collapsedDirty = true;
-    bool             _scrollXSet = false;
-    bool             _scrollYSet = false;
     ImGuiWindowFlags _oldWindowflags = ImGuiWindowFlags_None;
     float            _oldxpos = 200;
     float            _oldypos = 200;

--- a/src/mvItemHandlers.h
+++ b/src/mvItemHandlers.h
@@ -159,3 +159,23 @@ public:
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
 };
+
+enum mvScrollDirection
+{
+    // These constants can be used as a combination of flags
+    mvScrollDirection_XAxis = 1,
+    mvScrollDirection_Horizontal = 1,
+    mvScrollDirection_YAxis = 2,
+    mvScrollDirection_Vertical = 2,
+};
+
+class mvScrollHandler : public mvItemHandler
+{
+public:
+    explicit mvScrollHandler(mvUUID uuid) : mvItemHandler(uuid) {}
+    void draw(ImDrawList* drawlist, float x, float y) override {}
+    void customAction(void* data = nullptr) override;
+
+private:
+    static PyObject* makeAppData(mvUUID uuid, const std::string& alias, mvScrollDirection dir, bool isScrolling, float pos, float max);
+};

--- a/src/mvPyUtils.cpp
+++ b/src/mvPyUtils.cpp
@@ -571,6 +571,17 @@ ToPyPair(const std::string& x, const std::string& y)
 }
 
 PyObject*
+ToPyTPair(bool x, bool y)
+{
+    PyObject* result = PyTuple_New(2);
+
+    PyTuple_SetItem(result, 0, ToPyBool(x));
+    PyTuple_SetItem(result, 1, ToPyBool(y));
+
+    return result;
+}
+
+PyObject*
 ToPyList(const std::vector<int>& value)
 {
 

--- a/src/mvPyUtils.h
+++ b/src/mvPyUtils.h
@@ -151,6 +151,7 @@ PyObject*   ToPyPair  (float x, float y);
 PyObject*   ToPyPair  (double x, double y);
 PyObject*   ToPyPairII(int x, int y);
 PyObject*   ToPyPair  (const std::string& x, const std::string& y);
+PyObject*   ToPyTPair (bool x, bool y);         // tuple-based pair (unlike other pairs that are list-based)
 PyObject*   ToPyList  (const std::vector<mvVec2>& value);
 PyObject*   ToPyList  (const std::vector<mvVec4>& value);
 PyObject*   ToPyList  (const std::vector<int>& value);

--- a/src/mvTables.h
+++ b/src/mvTables.h
@@ -76,13 +76,6 @@ public:
     bool _tableHeader = true;
     bool _useClipper = false;
 
-    float            _scrollX = 0.0f;
-    float            _scrollY = 0.0f;
-    float            _scrollMaxX = 0.0f;
-    float            _scrollMaxY = 0.0f;
-    bool             _scrollXSet = false;
-    bool             _scrollYSet = false;
-
     std::vector<bool> _columnColorsSet;
     std::vector<bool> _rowColorsSet;
     std::vector<bool> _rowSelectionColorsSet;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Added a scroll handler
assignees: ''

---

**Description:**
This PR adds a scroll handler that fires every time the corresponding widget (a container) is scrolled, that is, when the position returned by `get_x_scroll` and/or `get_y_scroll` changes. With this handler, the "traditional" polling on `get_y_scroll` in `item_visible_handler` is not needed anymore.

Events for horizontal and vertical scroll are reported separately. If somehow the container has been scrolled in both directions (quite possible with touch screens, I think), there will be two handler calls in the frame.

The handler receives a tuple in `app_data` with the following contents: `(widget, direction, pos, max_pos, is_scrolling)`.
- `widget`: the container being scrolled (i.e. the item to which the handler registry is bound).
- `direction`: one of `dpg.mvScrollDirection_XAxis` or `dpg.mvScrollDirection_YAxis` - can be used to filter out just one direction (I bet most users will be interested in `YAxis` only). One can also use `dpg.mvScrollDirection_Horizontal` and `dpg.mvScrollDirection_Vertical`, they are just synonyms to `X/YAxis`.
- `pos`: current scroll position in pixels as returned by `get_x_scroll` or `get_y_scroll`. Note: this is the scroll position at the time the event occurred; since the handlers are queued and in a heavily loaded application may lag begind rendering, it's quite possible that `pos` will be different from what the `get` functions return. In this case, however, there will be more handler calls and they will eventually catch up with the `get` functions. Technically this applies to every handler, not just the scroll handler.
- `pos_max`: max scroll position as returned by `get_x_scroll_max` or `get_y_scroll_max`.
- `is_scrolling`: currently always False (supposed to be True while the user is holding the scrollbar). Reserved for future use - this needs support on the ImGui side, we'll see if we can add such support (technically it's trivial).

Another change in this PR is the `when` argument on `set_x/y_scroll` functions. There are two ways in ImGui to specify the scroll position; one works before rendering the container in the current frame starts, and therefore applies right in the current frame; the other sets scroll position immediately after rendering and therefore only takes effect in the next frame. Depending on how contents changes, one or the other may be necessary. Of course one could always use the former method, combined with `split_frame` as necessary, but I figured it would be easier to let ImGui do this on its own. The `when` argument lets the caller choose when to apply scroll position: right in the next frame (the former method) or with a 1-frame delay (the latter method). One can also "kill it twice" and specify `mvSetScrollFlags_Both`. The default is the `Delayed` method as it is more reliable; whereas the `Now` method can be used for flicker-free scrolling.

**Concerning Areas:**
None.
