### PR TITLE
Tables: ability to get column width as well as bind a resize handler to the column

### DIFF
--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -881,6 +881,7 @@ CanItemTypeHaveRectSize(mvAppItemType type)
     case mvAppItemType::mvNode:
     case mvAppItemType::mvNodeEditor:
     case mvAppItemType::mvPlot:
+    case mvAppItemType::mvTableColumn:
     case mvAppItemType::mvButton: return true;
     default: return false;
     }

--- a/src/mvTables.cpp
+++ b/src/mvTables.cpp
@@ -356,6 +356,8 @@ void mvTable::draw(ImDrawList* drawlist, float x, float y)
 			}
 
 			// columns
+			ImGuiContext& g = *GImGui;
+			auto table = g.CurrentTable;
 			int columnnum = 0;
 			int last_row = ImGui::TableGetRowIndex();
 			for (auto& item : childslots[0])
@@ -374,6 +376,20 @@ void mvTable::draw(ImDrawList* drawlist, float x, float y)
 					// user via context menu.
 					item->config.show = flags & ImGuiTableColumnFlags_IsEnabled;
 				}
+
+				// Note: we're not using rect height because we're actually not
+				// inside any live cell; row Y coordinates are invalid here.
+				// Even if we were inside a cell, we'd need Y coordinates of the
+				// entire table here, which are less trivial to obtain.  So we
+				// just nullify the height.
+				const ImGuiTableColumn* column = &table->Columns[columnnum];
+				item->state.rectSize = { column->WorkMaxX - column->WorkMinX, 0.0f };
+				item->state.mvRectSizeResized = (item->state.mvPrevRectSize.x != item->state.rectSize.x ||
+												 item->state.mvPrevRectSize.y != item->state.rectSize.y);
+				item->state.mvPrevRectSize = item->state.rectSize;
+				if (item->handlerRegistry)
+					item->handlerRegistry->checkEvents(&item->state);
+
 				columnnum++;
 			}
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Tables: ability to get column width as well as bind a resize handler to the column
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
This PR adds the `rectSize` property to mvTableColumn, with rect width reflecting the actual column width (without cell padding, which horizontally doesn't belong to columns anyway), and rect height set to zero due to difficulties in obtaining table height.

It also adds event handling and an `item_resize` handler to table columns. As a side effect this also fixes #2587. 

**Concerning Areas:**
ImGuiTableColumn is internal API in Dear ImGui and might change in future. We do use internal APIs here and there, looks like for column width it's worthwhile because some applications really need to get width and resize events without clumsy workarounds. Worst case if API changes, we'll find a new way to obtain the width.