### PR TITLE
Exposing Item Type Information in Python

### DIFF
--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -895,6 +895,10 @@ def get_item_state(item : Union[int, str]) -> dict:
 	"""Returns an item's state."""
 	...
 
+def get_item_type_parents() -> dict:
+	"""Return all item type names and collections of applicable parenting types as a mapping."""
+	...
+
 def get_item_types() -> dict:
 	"""Returns an item types."""
 	...

--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -895,6 +895,10 @@ def get_item_state(item : Union[int, str]) -> dict:
 	"""Returns an item's state."""
 	...
 
+def get_item_type_children() -> dict:
+	"""Return all item type names and collections of applicable child types as a mapping."""
+	...
+
 def get_item_type_parents() -> dict:
 	"""Return all item type names and collections of applicable parenting types as a mapping."""
 	...

--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -999,6 +999,10 @@ def is_dearpygui_running() -> bool:
 	"""Checks if Dear PyGui is running"""
 	...
 
+def is_item_type_container(item_type : int) -> bool:
+	"""Return `True` if items of the provided item type can parent other items."""
+	...
+
 def is_key_down(key : int) -> bool:
 	"""Checks if key is down."""
 	...

--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -899,6 +899,10 @@ def get_item_type_children() -> dict:
 	"""Return all item type names and collections of applicable child types as a mapping."""
 	...
 
+def get_item_type_commands() -> dict:
+	"""Return the names of item types and their associated functions as a mapping."""
+	...
+
 def get_item_type_parents() -> dict:
 	"""Return all item type names and collections of applicable parenting types as a mapping."""
 	...

--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -903,6 +903,10 @@ def get_item_type_parents() -> dict:
 	"""Return all item type names and collections of applicable parenting types as a mapping."""
 	...
 
+def get_item_type_states() -> dict:
+	"""Return all item type names and collections of supported states as a mapping."""
+	...
+
 def get_item_types() -> dict:
 	"""Returns an item types."""
 	...

--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -1003,6 +1003,10 @@ def is_item_type_container(item_type : int) -> bool:
 	"""Return `True` if items of the provided item type can parent other items."""
 	...
 
+def is_item_type_root_container(item_type : int) -> bool:
+	"""Return `True` if items of the provided item type can parent other items."""
+	...
+
 def is_key_down(key : int) -> bool:
 	"""Checks if key is down."""
 	...

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -7833,6 +7833,16 @@ def get_item_type_children():
 
 	return internal_dpg.get_item_type_children()
 
+def get_item_type_commands():
+	"""	 Return the names of item types and their associated functions as a mapping.
+
+	Args:
+	Returns:
+		dict
+	"""
+
+	return internal_dpg.get_item_type_commands()
+
 def get_item_type_parents():
 	"""	 Return all item type names and collections of applicable parenting types as a mapping.
 

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -7823,6 +7823,16 @@ def get_item_state(item):
 
 	return internal_dpg.get_item_state(item)
 
+def get_item_type_parents():
+	"""	 Return all item type names and collections of applicable parenting types as a mapping.
+
+	Args:
+	Returns:
+		dict
+	"""
+
+	return internal_dpg.get_item_type_parents()
+
 def get_item_types():
 	"""	 Returns an item types.
 

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -8118,6 +8118,17 @@ def is_item_type_container(item_type):
 
 	return internal_dpg.is_item_type_container(item_type)
 
+def is_item_type_root_container(item_type):
+	"""	 Return `True` if items of the provided item type can parent other items.
+
+	Args:
+		item_type (int): 
+	Returns:
+		bool
+	"""
+
+	return internal_dpg.is_item_type_root_container(item_type)
+
 def is_key_down(key):
 	"""	 Checks if key is down.
 

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -7843,6 +7843,16 @@ def get_item_type_parents():
 
 	return internal_dpg.get_item_type_parents()
 
+def get_item_type_states():
+	"""	 Return all item type names and collections of supported states as a mapping.
+
+	Args:
+	Returns:
+		dict
+	"""
+
+	return internal_dpg.get_item_type_states()
+
 def get_item_types():
 	"""	 Returns an item types.
 

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -7823,6 +7823,16 @@ def get_item_state(item):
 
 	return internal_dpg.get_item_state(item)
 
+def get_item_type_children():
+	"""	 Return all item type names and collections of applicable child types as a mapping.
+
+	Args:
+	Returns:
+		dict
+	"""
+
+	return internal_dpg.get_item_type_children()
+
 def get_item_type_parents():
 	"""	 Return all item type names and collections of applicable parenting types as a mapping.
 

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -8107,6 +8107,17 @@ def is_dearpygui_running():
 
 	return internal_dpg.is_dearpygui_running()
 
+def is_item_type_container(item_type):
+	"""	 Return `True` if items of the provided item type can parent other items.
+
+	Args:
+		item_type (int): 
+	Returns:
+		bool
+	"""
+
+	return internal_dpg.is_item_type_container(item_type)
+
 def is_key_down(key):
 	"""	 Checks if key is down.
 

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -9194,6 +9194,17 @@ def is_dearpygui_running(**kwargs) -> bool:
 
 	return internal_dpg.is_dearpygui_running(**kwargs)
 
+def is_item_type_container(item_type : int, **kwargs) -> bool:
+	"""	 Return `True` if items of the provided item type can parent other items.
+
+	Args:
+		item_type (int): 
+	Returns:
+		bool
+	"""
+
+	return internal_dpg.is_item_type_container(item_type, **kwargs)
+
 def is_key_down(key : int, **kwargs) -> bool:
 	"""	 Checks if key is down.
 

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -8910,6 +8910,16 @@ def get_item_state(item : Union[int, str], **kwargs) -> dict:
 
 	return internal_dpg.get_item_state(item, **kwargs)
 
+def get_item_type_children(**kwargs) -> dict:
+	"""	 Return all item type names and collections of applicable child types as a mapping.
+
+	Args:
+	Returns:
+		dict
+	"""
+
+	return internal_dpg.get_item_type_children(**kwargs)
+
 def get_item_type_parents(**kwargs) -> dict:
 	"""	 Return all item type names and collections of applicable parenting types as a mapping.
 

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -8920,6 +8920,16 @@ def get_item_type_children(**kwargs) -> dict:
 
 	return internal_dpg.get_item_type_children(**kwargs)
 
+def get_item_type_commands(**kwargs) -> dict:
+	"""	 Return the names of item types and their associated functions as a mapping.
+
+	Args:
+	Returns:
+		dict
+	"""
+
+	return internal_dpg.get_item_type_commands(**kwargs)
+
 def get_item_type_parents(**kwargs) -> dict:
 	"""	 Return all item type names and collections of applicable parenting types as a mapping.
 

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -9205,6 +9205,17 @@ def is_item_type_container(item_type : int, **kwargs) -> bool:
 
 	return internal_dpg.is_item_type_container(item_type, **kwargs)
 
+def is_item_type_root_container(item_type : int, **kwargs) -> bool:
+	"""	 Return `True` if items of the provided item type can parent other items.
+
+	Args:
+		item_type (int): 
+	Returns:
+		bool
+	"""
+
+	return internal_dpg.is_item_type_root_container(item_type, **kwargs)
+
 def is_key_down(key : int, **kwargs) -> bool:
 	"""	 Checks if key is down.
 

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -8930,6 +8930,16 @@ def get_item_type_parents(**kwargs) -> dict:
 
 	return internal_dpg.get_item_type_parents(**kwargs)
 
+def get_item_type_states(**kwargs) -> dict:
+	"""	 Return all item type names and collections of supported states as a mapping.
+
+	Args:
+	Returns:
+		dict
+	"""
+
+	return internal_dpg.get_item_type_states(**kwargs)
+
 def get_item_types(**kwargs) -> dict:
 	"""	 Returns an item types.
 

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -8910,6 +8910,16 @@ def get_item_state(item : Union[int, str], **kwargs) -> dict:
 
 	return internal_dpg.get_item_state(item, **kwargs)
 
+def get_item_type_parents(**kwargs) -> dict:
+	"""	 Return all item type names and collections of applicable parenting types as a mapping.
+
+	Args:
+	Returns:
+		dict
+	"""
+
+	return internal_dpg.get_item_type_parents(**kwargs)
+
 def get_item_types(**kwargs) -> dict:
 	"""	 Returns an item types.
 

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -701,6 +701,7 @@ PyInit__dearpygui(void)
 	MV_ADD_COMMAND(get_item_type_parents);
 	MV_ADD_COMMAND(get_item_type_children);
 	MV_ADD_COMMAND(get_item_type_states);
+	MV_ADD_COMMAND(get_item_type_commands);
 	MV_ADD_COMMAND(get_item_configuration);
 	MV_ADD_COMMAND(get_item_state);
 	MV_ADD_COMMAND(configure_item);

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -700,6 +700,7 @@ PyInit__dearpygui(void)
 	MV_ADD_COMMAND(get_item_types);
 	MV_ADD_COMMAND(get_item_type_parents);
 	MV_ADD_COMMAND(get_item_type_children);
+	MV_ADD_COMMAND(get_item_type_states);
 	MV_ADD_COMMAND(get_item_configuration);
 	MV_ADD_COMMAND(get_item_state);
 	MV_ADD_COMMAND(configure_item);

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -15,7 +15,7 @@
 
 #define MV_ADD_COMMAND(x) methods.push_back({ #x, (PyCFunction)x, METH_VARARGS | METH_KEYWORDS, GetParsers()[#x].documentation.c_str() });
 
-const std::map<std::string, mvPythonParser>& 
+const std::map<std::string, mvPythonParser>&
 GetModuleParsers()
 {
 
@@ -176,7 +176,7 @@ GetModuleConstants()
 		ModuleConstants.push_back({ "mvYAxis", ImAxis_Y1});
 		ModuleConstants.push_back({ "mvYAxis2", ImAxis_Y2});
 		ModuleConstants.push_back({ "mvYAxis3", ImAxis_Y3});
-    
+
 		ModuleConstants.push_back({ "mvPlotScale_Linear", ImPlotScale_Linear});  // default linear scale
 		ModuleConstants.push_back({ "mvPlotScale_Time", ImPlotScale_Time});  // date/time scale
 		ModuleConstants.push_back({ "mvPlotScale_Log10", ImPlotScale_Log10});  // base 10 logartithmic scale
@@ -367,7 +367,7 @@ GetModuleConstants()
 		ModuleConstants.push_back({ "mvStyleVar_SeparatorTextBorderSize", ImGuiStyleVar_SeparatorTextBorderSize });	// float     SeparatorTextBorderSize
 		ModuleConstants.push_back({ "mvStyleVar_SeparatorTextAlign", ImGuiStyleVar_SeparatorTextAlign });    		// ImVec2    SeparatorTextAlign
 		ModuleConstants.push_back({ "mvStyleVar_SeparatorTextPadding", ImGuiStyleVar_SeparatorTextPadding });    	// ImVec2    SeparatorTextPadding
-		ModuleConstants.push_back({ "mvStyleVar_DockingSeparatorSize", ImGuiStyleVar_DockingSeparatorSize });    	// float     DockingSeparatorSize    
+		ModuleConstants.push_back({ "mvStyleVar_DockingSeparatorSize", ImGuiStyleVar_DockingSeparatorSize });    	// float     DockingSeparatorSize
 
 		// item styling variables
 		ModuleConstants.push_back({ "mvPlotStyleVar_LineWeight",         ImPlotStyleVar_LineWeight });         // float,  plot item line weight in pixels
@@ -698,6 +698,7 @@ PyInit__dearpygui(void)
 	MV_ADD_COMMAND(set_item_alias);
 	MV_ADD_COMMAND(get_item_alias);
 	MV_ADD_COMMAND(get_item_types);
+	MV_ADD_COMMAND(get_item_type_parents);
 	MV_ADD_COMMAND(get_item_configuration);
 	MV_ADD_COMMAND(get_item_state);
 	MV_ADD_COMMAND(configure_item);

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -699,6 +699,7 @@ PyInit__dearpygui(void)
 	MV_ADD_COMMAND(get_item_alias);
 	MV_ADD_COMMAND(get_item_types);
 	MV_ADD_COMMAND(get_item_type_parents);
+	MV_ADD_COMMAND(get_item_type_children);
 	MV_ADD_COMMAND(get_item_configuration);
 	MV_ADD_COMMAND(get_item_state);
 	MV_ADD_COMMAND(configure_item);

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -703,6 +703,7 @@ PyInit__dearpygui(void)
 	MV_ADD_COMMAND(get_item_type_states);
 	MV_ADD_COMMAND(get_item_type_commands);
 	MV_ADD_COMMAND(is_item_type_container);
+	MV_ADD_COMMAND(is_item_type_root_container);
 	MV_ADD_COMMAND(get_item_configuration);
 	MV_ADD_COMMAND(get_item_state);
 	MV_ADD_COMMAND(configure_item);

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -702,6 +702,7 @@ PyInit__dearpygui(void)
 	MV_ADD_COMMAND(get_item_type_children);
 	MV_ADD_COMMAND(get_item_type_states);
 	MV_ADD_COMMAND(get_item_type_commands);
+	MV_ADD_COMMAND(is_item_type_container);
 	MV_ADD_COMMAND(get_item_configuration);
 	MV_ADD_COMMAND(get_item_state);
 	MV_ADD_COMMAND(configure_item);

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -1895,7 +1895,7 @@ show_tool(PyObject* self, PyObject* args, PyObject* kwargs)
 	return GetPyNone();
 }
 
-/* 
+/*
 static PyObject*
 set_decimal_point(PyObject* self, PyObject* args, PyObject* kwargs)
 {
@@ -1906,7 +1906,7 @@ set_decimal_point(PyObject* self, PyObject* args, PyObject* kwargs)
 		return GetPyNone();
 
 	mvPySafeLockGuard lk(GContext->mutex);
-	
+
 	GContext->IO.decimalPoint = *point;
 	ImGui::GetIO().PlatformLocaleDecimalPoint = GContext->IO.decimalPoint;
 	return GetPyNone();
@@ -2302,7 +2302,7 @@ load_image(PyObject* self, PyObject* args, PyObject* kwargs)
 }
 
 /*  returns 1 iff str ends with suffix  */
-static int 
+static int
 str_ends_with(const char * str, const char * suffix) {
 
   /*  note - it would be better to abort or return an error code here; see the comments  */
@@ -4004,6 +4004,35 @@ get_item_types(PyObject* self, PyObject* args, PyObject* kwargs)
 	#undef X
 
 	return pdict;
+}
+
+static PyObject*
+get_item_type_parents(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	#define X(el) {#el, mvAppItemType::el},
+	#define ITEM_NAME_TYPE_PAIRS static std::vector<std::pair<std::string, mvAppItemType>> name_type_pairs = { MV_ITEM_TYPES };
+	ITEM_NAME_TYPE_PAIRS
+	#undef X
+	#undef ITEM_NAME_TYPE_PAIRS
+
+
+	mvPySafeLockGuard lk(GContext->mutex);
+
+	PyObject *out_dict = PyDict_New();
+
+	for (const auto& name_type_pair : name_type_pairs) {
+		auto name_id_pairs = DearPyGui::GetAllowableParents(name_type_pair.second);
+
+		PyObject *entry_dict = PyDict_New();
+
+		for (const auto& name_id_pair : name_id_pairs) {
+			PyDict_SetItemString(entry_dict, name_id_pair.first.c_str(), PyLong_FromLong((int)name_id_pair.second));
+		}
+
+		PyDict_SetItemString(out_dict, name_type_pair.first.c_str(), entry_dict);
+	}
+
+	return out_dict;
 }
 
 static PyObject*

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -4123,6 +4123,19 @@ get_item_type_states(PyObject *self, PyObject *args, PyObject *kwargs)
 	return out_dict;
 }
 
+static PyObject *
+get_item_type_commands(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	mvPySafeLockGuard lk(GContext->mutex);
+
+	PyObject* out_dict = PyDict_New();
+
+	#define X(el) PyDict_SetItemString(out_dict, #el, ToPyString(GetEntityCommand(mvAppItemType::el)));
+	MV_ITEM_TYPES
+	#undef X
+
+	return out_dict;
+}
 
 static PyObject*
 configure_item(PyObject* self, PyObject* args, PyObject* kwargs)

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -4035,6 +4035,36 @@ get_item_type_parents(PyObject *self, PyObject *args, PyObject *kwargs)
 	return out_dict;
 }
 
+static PyObject *
+get_item_type_children(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+#define X(el) {#el, mvAppItemType::el},
+#define ITEM_NAME_TYPE_PAIRS static std::vector<std::pair<std::string, mvAppItemType>> name_type_pairs = {MV_ITEM_TYPES};
+	ITEM_NAME_TYPE_PAIRS
+#undef X
+#undef ITEM_NAME_TYPE_PAIRS
+
+	mvPySafeLockGuard lk(GContext->mutex);
+
+	PyObject *out_dict = PyDict_New();
+
+	for (const auto &name_type_pair : name_type_pairs)
+	{
+		auto name_id_pairs = DearPyGui::GetAllowableChildren(name_type_pair.second);
+
+		PyObject *entry_dict = PyDict_New();
+
+		for (const auto &name_id_pair : name_id_pairs)
+		{
+			PyDict_SetItemString(entry_dict, name_id_pair.first.c_str(), PyLong_FromLong((int)name_id_pair.second));
+		}
+
+		PyDict_SetItemString(out_dict, name_type_pair.first.c_str(), entry_dict);
+	}
+
+	return out_dict;
+}
+
 static PyObject*
 configure_item(PyObject* self, PyObject* args, PyObject* kwargs)
 {

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -4164,6 +4164,32 @@ is_item_type_container(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject*
+is_item_type_root_container(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	int type_uuid;
+
+	if (!Parse((GetParsers())["is_item_type_container"], args, kwargs, __FUNCTION__, &type_uuid))
+		return nullptr;
+
+	mvPySafeLockGuard lk(GContext->mutex);
+
+	if (type_uuid < 0 || type_uuid >= (int)mvAppItemType::ItemTypeCount) {
+		mvThrowPythonError(
+			mvErrorCode::mvNone, "is_item_type_container",
+			"item type not found: " + std::to_string(type_uuid), nullptr
+		);
+		return nullptr;
+	}
+
+	const auto item_type = static_cast<mvAppItemType>(type_uuid);
+
+	if (DearPyGui::GetEntityDesciptionFlags(item_type) & MV_ITEM_DESC_ROOT) {
+		return ToPyBool(true);
+	}
+	return ToPyBool(false);
+}
+
+static PyObject*
 configure_item(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -4138,6 +4138,32 @@ get_item_type_commands(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject*
+is_item_type_container(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	int type_uuid;
+
+	if (!Parse((GetParsers())["is_item_type_container"], args, kwargs, __FUNCTION__, &type_uuid))
+		return nullptr;
+
+	mvPySafeLockGuard lk(GContext->mutex);
+
+	if (type_uuid < 0 || type_uuid >= (int)mvAppItemType::ItemTypeCount) {
+		mvThrowPythonError(
+			mvErrorCode::mvNone, "is_item_type_container",
+			"item type not found: " + std::to_string(type_uuid), nullptr
+		);
+		return nullptr;
+	}
+
+	const auto item_type = static_cast<mvAppItemType>(type_uuid);
+
+	if (DearPyGui::GetEntityDesciptionFlags(item_type) & MV_ITEM_DESC_CONTAINER) {
+		return ToPyBool(true);
+	}
+	return ToPyBool(false);
+}
+
+static PyObject*
 configure_item(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -4035,27 +4035,26 @@ get_item_type_parents(PyObject *self, PyObject *args, PyObject *kwargs)
 	return out_dict;
 }
 
-static PyObject *
+static PyObject*
 get_item_type_children(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-#define X(el) {#el, mvAppItemType::el},
-#define ITEM_NAME_TYPE_PAIRS static std::vector<std::pair<std::string, mvAppItemType>> name_type_pairs = {MV_ITEM_TYPES};
+	#define X(el) {#el, mvAppItemType::el},
+	#define ITEM_NAME_TYPE_PAIRS static std::vector<std::pair<std::string, mvAppItemType>> name_type_pairs = { MV_ITEM_TYPES };
 	ITEM_NAME_TYPE_PAIRS
-#undef X
-#undef ITEM_NAME_TYPE_PAIRS
+	#undef X
+	#undef ITEM_NAME_TYPE_PAIRS
+
 
 	mvPySafeLockGuard lk(GContext->mutex);
 
 	PyObject *out_dict = PyDict_New();
 
-	for (const auto &name_type_pair : name_type_pairs)
-	{
+	for (const auto& name_type_pair : name_type_pairs) {
 		auto name_id_pairs = DearPyGui::GetAllowableChildren(name_type_pair.second);
 
 		PyObject *entry_dict = PyDict_New();
 
-		for (const auto &name_id_pair : name_id_pairs)
-		{
+		for (const auto& name_id_pair : name_id_pairs) {
 			PyDict_SetItemString(entry_dict, name_id_pair.first.c_str(), PyLong_FromLong((int)name_id_pair.second));
 		}
 
@@ -4064,6 +4063,66 @@ get_item_type_children(PyObject *self, PyObject *args, PyObject *kwargs)
 
 	return out_dict;
 }
+
+static PyObject*
+get_item_type_states(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	#define X(el) {#el, mvAppItemType::el},
+	#define ITEM_NAME_TYPE_PAIRS static std::vector<std::pair<std::string, mvAppItemType>> name_type_pairs = { MV_ITEM_TYPES };
+	ITEM_NAME_TYPE_PAIRS
+	#undef X
+	#undef ITEM_NAME_TYPE_PAIRS
+
+
+	mvPySafeLockGuard lk(GContext->mutex);
+
+	PyObject *out_dict = PyDict_New();
+
+	for (const auto& name_type_pair : name_type_pairs) {
+
+		const auto &state_flags = DearPyGui::GetApplicableState(name_type_pair.second);
+		std::vector<PyObject *> state_names = {ToPyString("ok"), ToPyString("pos")};
+
+		if (state_flags & MV_STATE_HOVER) state_names.push_back(ToPyString("hovered"));
+		if (state_flags & MV_STATE_ACTIVE) state_names.push_back(ToPyString("active"));
+		if (state_flags & MV_STATE_FOCUSED) state_names.push_back(ToPyString("focused"));
+		if (state_flags & MV_STATE_CLICKED) {
+			state_names.push_back(ToPyString("clicked"));
+			state_names.push_back(ToPyString("left_clicked"));
+			state_names.push_back(ToPyString("right_clicked"));
+			state_names.push_back(ToPyString("middle_clicked"));
+		}
+		if (state_flags & MV_STATE_VISIBLE) state_names.push_back(ToPyString("visible"));
+		if (state_flags & MV_STATE_EDITED) state_names.push_back(ToPyString("edited"));
+		if (state_flags & MV_STATE_ACTIVATED) state_names.push_back(ToPyString("activated"));
+		if (state_flags & MV_STATE_DEACTIVATED) state_names.push_back(ToPyString("deactivated"));
+		if (state_flags & MV_STATE_DEACTIVATEDAE) state_names.push_back(ToPyString("deactivated_after_edit"));
+		if (state_flags & MV_STATE_TOGGLED_OPEN) state_names.push_back(ToPyString("toggled_open"));
+		if (state_flags & MV_STATE_RECT_MIN) state_names.push_back(ToPyString("rect_min"));
+		if (state_flags & MV_STATE_RECT_MAX) state_names.push_back(ToPyString("rect_max"));
+		if (state_flags & MV_STATE_RECT_SIZE) {
+			state_names.push_back(ToPyString("rect_size"));
+			state_names.push_back(ToPyString("resized"));
+		}
+		if (state_flags & MV_STATE_CONT_AVAIL) state_names.push_back(ToPyString("content_region_avail"));
+		if (state_flags & MV_STATE_SCROLL) {
+			state_names.push_back(ToPyString("scrolled"));
+			state_names.push_back(ToPyString("is_scrolling"));
+			state_names.push_back(ToPyString("scroll_pos"));
+			state_names.push_back(ToPyString("scroll_max"));
+		}
+
+		PyObject *entries = PyTuple_New((Py_ssize_t)state_names.size());
+		for (int i = 0; i < state_names.size(); i++) {
+			PyTuple_SET_ITEM(entries, i, state_names[i]);
+		}
+
+		PyDict_SetItemString(out_dict, name_type_pair.first.c_str(), entries);
+	}
+
+	return out_dict;
+}
+
 
 static PyObject*
 configure_item(PyObject* self, PyObject* args, PyObject* kwargs)

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -1365,6 +1365,16 @@ InsertParser_Block3(std::map<std::string, mvPythonParser>& parsers)
 
 	{
 		mvPythonParserSetup setup;
+		setup.about = "Return all item type names and collections of supported states as a mapping.";
+		setup.category = {"App Item Operations"};
+		setup.returnType = mvPyDataType::Dict;
+
+		mvPythonParser parser = FinalizeParser(setup, {});
+		parsers.insert({"get_item_type_states", parser});
+	}
+
+	{
+		mvPythonParserSetup setup;
 		setup.about = "Return all item type names and collections of applicable child types as a mapping.";
 		setup.category = {"App Item Operations"};
 		setup.returnType = mvPyDataType::Dict;

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -1364,6 +1364,16 @@ InsertParser_Block3(std::map<std::string, mvPythonParser>& parsers)
 	}
 
 	{
+		mvPythonParserSetup setup;
+		setup.about = "Return all item type names and collections of applicable child types as a mapping.";
+		setup.category = {"App Item Operations"};
+		setup.returnType = mvPyDataType::Dict;
+
+		mvPythonParser parser = FinalizeParser(setup, {});
+		parsers.insert({"get_item_type_children", parser});
+	}
+
+	{
 		std::vector<mvPythonDataElement> args;
 		args.reserve(3);
 		args.push_back({ mvPyDataType::UUID, "item" });

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -1395,6 +1395,19 @@ InsertParser_Block3(std::map<std::string, mvPythonParser>& parsers)
 
 	{
 		std::vector<mvPythonDataElement> args;
+		args.push_back({mvPyDataType::Integer, "item_type"});
+
+		mvPythonParserSetup setup;
+		setup.about = "Return `True` if items of the provided item type can parent other items.";
+		setup.category = {"App Item Operations"};
+		setup.returnType = mvPyDataType::Bool;
+
+		mvPythonParser parser = FinalizeParser(setup, args);
+		parsers.insert({"is_item_type_container", parser});
+	}
+
+	{
+		std::vector<mvPythonDataElement> args;
 		args.reserve(3);
 		args.push_back({ mvPyDataType::UUID, "item" });
 		args.push_back({ mvPyDataType::UUID, "source" });

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -1408,6 +1408,19 @@ InsertParser_Block3(std::map<std::string, mvPythonParser>& parsers)
 
 	{
 		std::vector<mvPythonDataElement> args;
+		args.push_back({mvPyDataType::Integer, "item_type"});
+
+		mvPythonParserSetup setup;
+		setup.about = "Return `True` if items of the provided item type can parent other items.";
+		setup.category = {"App Item Operations"};
+		setup.returnType = mvPyDataType::Bool;
+
+		mvPythonParser parser = FinalizeParser(setup, args);
+		parsers.insert({"is_item_type_root_container", parser});
+	}
+
+	{
+		std::vector<mvPythonDataElement> args;
 		args.reserve(3);
 		args.push_back({ mvPyDataType::UUID, "item" });
 		args.push_back({ mvPyDataType::UUID, "source" });

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -633,7 +633,7 @@ InsertParser_Block1(std::map<std::string, mvPythonParser>& parsers)
 		mvPythonParserSetup setup;
 		setup.about = "Change the default decimal_point. Use only single character strings.";
 		setup.category = { "Utilities" };
-	
+
 		mvPythonParser parser = FinalizeParser(setup, args);
 		parsers.insert({ "set_decimal_point", parser });
 	} */
@@ -1351,6 +1351,16 @@ InsertParser_Block3(std::map<std::string, mvPythonParser>& parsers)
 
 		mvPythonParser parser = FinalizeParser(setup, {});
 		parsers.insert({ "get_item_types", parser });
+	}
+
+	{
+		mvPythonParserSetup setup;
+		setup.about = "Return all item type names and collections of applicable parenting types as a mapping.";
+		setup.category = {"App Item Operations"};
+		setup.returnType = mvPyDataType::Dict;
+
+		mvPythonParser parser = FinalizeParser(setup, {});
+		parsers.insert({"get_item_type_parents", parser});
 	}
 
 	{

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -1375,6 +1375,16 @@ InsertParser_Block3(std::map<std::string, mvPythonParser>& parsers)
 
 	{
 		mvPythonParserSetup setup;
+		setup.about = "Return the names of item types and their associated functions as a mapping.";
+		setup.category = {"App Item Operations"};
+		setup.returnType = mvPyDataType::Dict;
+
+		mvPythonParser parser = FinalizeParser(setup, {});
+		parsers.insert({"get_item_type_commands", parser});
+	}
+
+	{
+		mvPythonParserSetup setup;
 		setup.about = "Return all item type names and collections of applicable child types as a mapping.";
 		setup.category = {"App Item Operations"};
 		setup.returnType = mvPyDataType::Dict;


### PR DESCRIPTION

**Description:**
This PR adds a few new functions in `dearpygui.dearpygui` that expose system-level item type information that only exists in C++ source code, documentation context, or at runtime via DearPyGui error messages. This information is very useful for generating documentation, writing unit tests, and to anyone building on top of the library (wrappers, custom widgets, etc). 

New Functions:
- `get_item_type_parents()`: Returns the result of `DearPyGui::GetAllowableParents()` for all item types as `dict[str, dict[str, int]]`. Strings in the outer dictionary are qualified item type names, where the inner dictionaries contain the type information (as type name to enum value pairs) of items that can parent items of that type. 
- `get_item_type_children()`: Similar to `get_item_type_parents()`, but returns child type information instead using `DearPyGui::GetAllowableChildren()`. 
- `get_item_type_states()`: Returns a mapping of qualified item type names and tuples containing applicable/supported states. 
- `get_item_type_commands()`: Returns a mapping of qualified item type names and names of their associated item command in `dearpygui.dearpygui`. 
- `is_item_type_container(*item_type*)`: Returns `True` if *item_type* has the `MV_ITEM_DESC_CONTAINER` flag, and `False` otherwise.
- `is_item_type_root_container(*item_type*)`: Returns `True` if *item_type* has the `MV_ITEM_DESC_ROOT` flag, and `False` otherwise. 

**Concerning Areas:**
The functions added in this PR only expose information from already-existing structures, and does not affect existing code nor does it implement any new systems or structures. The only function that may require maintenance is `get_item_type_states()`, when new states are implemented (like those added in 2.2 related to scrolling).
