### PR TITLE
perf: Optimized list conversions.

### DIFF
--- a/src/mvPyUtils.cpp
+++ b/src/mvPyUtils.cpp
@@ -380,6 +380,23 @@ isPyObject_Dict(PyObject* obj)
 }
 
 
+template<typename T>
+Py_ssize_t VecReserveForTuple(PyObject* value, std::vector<T>& vec)
+{
+    Py_ssize_t size = PyTuple_Size(value);
+    vec.reserve(size);
+    return size;
+}
+
+template<typename T>
+Py_ssize_t VecReserveForList(PyObject* value, std::vector<T>& vec)
+{
+    Py_ssize_t size = PyList_Size(value);
+    vec.reserve(size);
+    return size;
+}
+
+
 void
 UpdatePyIntList(PyObject* pyvalue, const std::vector<int>& value)
 {
@@ -394,10 +411,9 @@ UpdatePyIntList(PyObject* pyvalue, const std::vector<int>& value)
     }
 
 
-    for (Py_ssize_t i = 0; i < PyList_Size(pyvalue); ++i)
+    auto size = std::min(PyList_Size(pyvalue), (Py_ssize_t)value.size());
+    for (Py_ssize_t i = 0; i < size; ++i)
     {
-        if (static_cast<size_t>(i) == value.size())
-            break;
         PyList_SetItem(pyvalue, i, PyLong_FromLong(value[i]));
     }
 }
@@ -416,10 +432,9 @@ UpdatePyFloatList(PyObject* pyvalue, const std::vector<float>& value)
     }
 
 
-    for (Py_ssize_t i = 0; i < PyList_Size(pyvalue); ++i)
+    auto size = std::min(PyList_Size(pyvalue), (Py_ssize_t)value.size());
+    for (Py_ssize_t i = 0; i < size; ++i)
     {
-        if (static_cast<size_t>(i) == value.size())
-            break;
         PyList_SetItem(pyvalue, i, PyFloat_FromDouble(value[i]));
     }
 }
@@ -438,15 +453,13 @@ UpdatePyStringStringList(PyObject* pyvalue, const std::vector<std::vector<std::s
     }
 
 
-    for (Py_ssize_t i = 0; i < PyList_Size(pyvalue); ++i)
+    auto size = std::min(PyList_Size(pyvalue), (Py_ssize_t)value.size());
+    for (Py_ssize_t i = 0; i < size; ++i)
     {
-        if (static_cast<size_t>(i) == value.size())
-            break;
         PyObject* row = PyList_GetItem(pyvalue, i);
-        for (Py_ssize_t j = 0; j < PyList_Size(row); ++j)
+        auto rowsize = std::min(PyList_Size(row), (Py_ssize_t)value[i].size());
+        for (Py_ssize_t j = 0; j < rowsize; ++j)
         {
-            if (static_cast<size_t>(j) == value[i].size())
-                break;
             PyList_SetItem(row, i, PyUnicode_FromString(value[i][j].c_str()));
         }
     }
@@ -1091,8 +1104,8 @@ ToUCharVect(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        items.resize(PyTuple_Size(value));
-        for (Py_ssize_t i = 0; i < PyTuple_Size(value); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             items[i] = (unsigned char)PyLong_AsLong(PyTuple_GetItem(value, i));
         }
@@ -1100,8 +1113,8 @@ ToUCharVect(PyObject* value, const std::string& message)
 
     else if (PyList_Check(value))
     {
-        items.resize(PyList_Size(value));
-        for (Py_ssize_t i = 0; i < PyList_Size(value); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             items[i] = (unsigned char)PyLong_AsLong(PyList_GetItem(value, i));
         }
@@ -1144,8 +1157,8 @@ ToIntVect(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        items.resize(PyTuple_Size(value));
-        for (Py_ssize_t i = 0; i < PyTuple_Size(value); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             items[i] = PyLong_AsLong(PyTuple_GetItem(value, i));
         }
@@ -1153,8 +1166,8 @@ ToIntVect(PyObject* value, const std::string& message)
 
     else if (PyList_Check(value))
     {
-        items.resize(PyList_Size(value));
-        for (Py_ssize_t i = 0; i < PyList_Size(value); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             items[i] = PyLong_AsLong(PyList_GetItem(value, i));
         }
@@ -1198,8 +1211,8 @@ ToUUIDVect(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        items.resize(PyTuple_Size(value));
-        for (Py_ssize_t i = 0; i < PyTuple_Size(value); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             PyObject* item = PyTuple_GetItem(value, i);
             if (isPyObject_Int(item))
@@ -1211,8 +1224,8 @@ ToUUIDVect(PyObject* value, const std::string& message)
 
     else if (PyList_Check(value))
     {
-        items.resize(PyList_Size(value));
-        for (Py_ssize_t i = 0; i < PyList_Size(value); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             PyObject* item = PyList_GetItem(value, i);
             if (isPyObject_Int(item))
@@ -1229,34 +1242,6 @@ ToUUIDVect(PyObject* value, const std::string& message)
     return items;
 }
 
-template<typename T>
-Py_ssize_t GetSizeAndReserveMemoryVectVect(PyObject* value, std::vector<std::vector<T>>& vec, const std::string mode)
-{
-    assert((mode == "tuple" || mode == "list") && "mode parameter must be 'tuple' or 'list'");
-    Py_ssize_t size = 0;
-    if (mode == "tuple")
-        size = PyTuple_Size(value);
-    else if (mode == "list")
-        size = PyList_Size(value);
-
-    vec.reserve(size);
-    return size;
-}
-
-template<typename T>
-Py_ssize_t GetSizeAndReserveMemoryVect(PyObject* value, std::vector<T>& vec, const std::string mode)
-{
-    assert((mode == "tuple" || mode == "list") && "mode parameter must be 'tuple' or 'list'");
-    Py_ssize_t size = 0;
-    if (mode == "tuple")
-        size = PyTuple_Size(value);
-    else if (mode == "list")
-        size = PyList_Size(value);
-
-    vec.reserve(size);
-    return size;
-}
-
 std::vector<float>
 ToFloatVect(PyObject* value, const std::string& message)
 {
@@ -1268,7 +1253,8 @@ ToFloatVect(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVect(value, items, "tuple"); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             items.emplace_back((float)PyFloat_AsDouble(PyTuple_GetItem(value, i)));
         }
@@ -1276,7 +1262,8 @@ ToFloatVect(PyObject* value, const std::string& message)
 
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVect(value, items, "list"); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             items.emplace_back((float)PyFloat_AsDouble(PyList_GetItem(value, i)));
         }
@@ -1319,7 +1306,8 @@ ToDoubleVect(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVect(value, items, "tuple"); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             items.emplace_back(PyFloat_AsDouble(PyTuple_GetItem(value, i)));
         }
@@ -1327,7 +1315,8 @@ ToDoubleVect(PyObject* value, const std::string& message)
 
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVect(value, items, "list"); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             items.emplace_back(PyFloat_AsDouble(PyList_GetItem(value, i)));
         }
@@ -1369,7 +1358,8 @@ ToStringVect(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVect(value, items, "tuple"); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             PyObject* item = PyTuple_GetItem(value, i);
             if (PyUnicode_Check(item))
@@ -1385,7 +1375,8 @@ ToStringVect(PyObject* value, const std::string& message)
 
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVect(value, items, "list"); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             PyObject* item = PyList_GetItem(value, i);
             if (PyUnicode_Check(item))
@@ -1416,10 +1407,9 @@ ToColor(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyTuple_Size(value); ++i)
+        auto size = std::min(PyTuple_Size(value), (Py_ssize_t)std::size(color));
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
-            if (i >= 4)
-                break;
             PyObject* item = PyTuple_GetItem(value, i);
             if(PyNumber_Check(item))
                 color[i] = (float)PyFloat_AsDouble(item)/255.0f;
@@ -1428,10 +1418,9 @@ ToColor(PyObject* value, const std::string& message)
     }
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyList_Size(value); ++i)
+        auto size = std::min(PyList_Size(value), (Py_ssize_t)std::size(color));
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
-            if (i >= 4)
-                break;
             PyObject* item = PyList_GetItem(value, i);
             if (PyNumber_Check(item))
                 color[i] = (float)PyFloat_AsDouble(item)/255.0f;
@@ -1503,7 +1492,8 @@ ToVectPairString(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyTuple_Size(value); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             PyObject* item = PyTuple_GetItem(value, i);
             if (PyTuple_Size(item) == 2)
@@ -1514,7 +1504,8 @@ ToVectPairString(PyObject* value, const std::string& message)
     }
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyList_Size(value); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             PyObject* item = PyList_GetItem(value, i);
             if (PyList_Size(item) == 2)
@@ -1539,12 +1530,14 @@ ToVectVec2(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyTuple_Size(value); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.push_back(ToVec2(PyTuple_GetItem(value, i)));
     }
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyList_Size(value); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.push_back(ToVec2(PyList_GetItem(value, i)));
     }
 
@@ -1591,12 +1584,14 @@ ToVectVec4(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyTuple_Size(value); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.push_back(ToVec4(PyTuple_GetItem(value, i)));
     }
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyList_Size(value); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.push_back(ToVec4(PyList_GetItem(value, i)));
     }
 
@@ -1616,7 +1611,8 @@ ToVectInt2(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyTuple_Size(value); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             PyObject* point = PyTuple_GetItem(value, i);
             if(PyTuple_Check(point))
@@ -1642,7 +1638,8 @@ ToVectInt2(PyObject* value, const std::string& message)
 
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyList_Size(value); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             PyObject* point = PyList_GetItem(value, i);
             if(PyTuple_Check(point))
@@ -1683,13 +1680,15 @@ ToVectVectString(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVectVect(value, items, "tuple"); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.emplace_back(ToStringVect(PyTuple_GetItem(value, i), message));
     }
 
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVectVect(value, items, "list"); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.emplace_back(ToStringVect(PyList_GetItem(value, i), message));
     }
 
@@ -1706,7 +1705,8 @@ ToVectPairStringFloat(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyTuple_Size(value); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             PyObject* item = PyTuple_GetItem(value, i);
             if (PyTuple_Size(item) == 2 && PyNumber_Check(PyTuple_GetItem(item, 1)))
@@ -1717,7 +1717,8 @@ ToVectPairStringFloat(PyObject* value, const std::string& message)
     }
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < PyList_Size(value); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
         {
             PyObject* item = PyList_GetItem(value, i);
             if (PyList_Size(item) == 2 && PyNumber_Check(PyList_GetItem(item, 1)))
@@ -1742,13 +1743,15 @@ ToVectVectFloat(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVectVect(value, items, "tuple"); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.emplace_back(ToFloatVect(PyTuple_GetItem(value, i), message));
     }
 
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVectVect(value, items, "list"); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.emplace_back(ToFloatVect(PyList_GetItem(value, i), message));
     }
 
@@ -1765,13 +1768,15 @@ ToVectVectInt(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVectVect(value, items, "tuple"); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.emplace_back(ToIntVect(PyTuple_GetItem(value, i), message));
     }
 
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVectVect(value, items, "list"); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.emplace_back(ToIntVect(PyList_GetItem(value, i), message));
     }
 
@@ -1788,13 +1793,15 @@ ToVectVectDouble(PyObject* value, const std::string& message)
 
     if (PyTuple_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVectVect(value, items, "tuple"); ++i)
+        auto size = VecReserveForTuple(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.emplace_back(ToDoubleVect(PyTuple_GetItem(value, i), message));
     }
 
     else if (PyList_Check(value))
     {
-        for (Py_ssize_t i = 0; i < GetSizeAndReserveMemoryVectVect(value, items, "list"); ++i)
+        auto size = VecReserveForList(value, items);
+        for (Py_ssize_t i = 0; i < size; ++i)
             items.emplace_back(ToDoubleVect(PyList_GetItem(value, i), message));
     }
 
@@ -2128,7 +2135,8 @@ VerifyKeywordArguments(const mvPythonParser& parser, PyObject* args)
     PyObject* keys = PyDict_Keys(args);
 
     bool exists = false;
-    for (int i = 0; i < PyList_Size(keys); i++)
+    auto keycnt = PyList_Size(keys);
+    for (int i = 0; i < keycnt; i++)
     {
         PyObject* item = PyList_GetItem(keys, i);
         auto sitem = ToString(item);


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: perf: Optimized list conversions.
assignees: @hoffstadt 

---

**Description:**
This fix moves `PyTuple_Size`/`PyList_Size` and related functions out of `for` loops and thus improves performance on many list conversion functions like `ToVectVectDouble`, `ToFloatVect`, `ToUCharVect` and so on. This in turn makes faster `set_value` on plot series and textures, and should also improve `save_image`. On plot series, I got a 3x speedup on long enough data sequences.

Kudos to **martin_sistemi** for suggesting this fix on Discord.

**Concerning Areas:**
None.