### PR TITLE
fix: Restored item aliases in node editor and other places #2122

### DIFF
--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -2685,7 +2685,7 @@ get_frame_rate(PyObject* self, PyObject* args, PyObject* kwargs)
 static PyObject*
 generate_uuid(PyObject* self, PyObject* args, PyObject* kwargs)
 {
-	return ToPyUUID(GenerateUUID());
+	return ToPyUUID(GenerateUUID(), "");
 }
 
 static PyObject*
@@ -2936,10 +2936,7 @@ pop_container_stack(PyObject* self, PyObject* args, PyObject* kwargs)
 	mvAppItem* item = containers.top();
 	containers.pop();
 
-	if (item)
-		return ToPyUUID(item);
-	else
-		return GetPyNone();
+	return ToPyUUIDOrNone(item);
 
 }
 
@@ -2963,10 +2960,7 @@ top_container_stack(PyObject* self, PyObject* args, PyObject* kwargs)
 	if (!containers.empty())
 		item = containers.top();
 
-	if (item)
-		return ToPyUUID(item);
-	else
-		return GetPyNone();
+	return ToPyUUIDOrNone(item);
 }
 
 static PyObject*
@@ -2974,7 +2968,7 @@ last_item(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	mvPySafeLockGuard lk(GContext->mutex);
 
-	return ToPyUUID(mvItemRegistry::threadContext.lastItemAdded);
+	return PyUUIDFromItem(mvItemRegistry::threadContext.lastItemAdded);
 }
 
 static PyObject*
@@ -2982,7 +2976,7 @@ last_container(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	mvPySafeLockGuard lk(GContext->mutex);
 
-	return ToPyUUID(mvItemRegistry::threadContext.lastContainerAdded);
+	return PyUUIDFromItem(mvItemRegistry::threadContext.lastContainerAdded);
 }
 
 static PyObject*
@@ -2990,7 +2984,7 @@ last_root(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	mvPySafeLockGuard lk(GContext->mutex);
 
-	return ToPyUUID(mvItemRegistry::threadContext.lastRootAdded);
+	return PyUUIDFromItem(mvItemRegistry::threadContext.lastRootAdded);
 }
 
 static PyObject*
@@ -3110,7 +3104,7 @@ get_active_window(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	mvPySafeLockGuard lk(GContext->mutex);
 
-	return ToPyUUID(GContext->activeWindow);
+	return PyUUIDFromItem(GContext->activeWindow);
 }
 
 static PyObject*
@@ -3118,7 +3112,7 @@ get_focused_item(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	mvPySafeLockGuard lk(GContext->mutex);
 
-	return ToPyUUID(GContext->focusedItem);
+	return PyUUIDFromItem(GContext->focusedItem);
 }
 
 static PyObject*
@@ -3497,7 +3491,7 @@ get_alias_id(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	mvUUID result = GetIdFromAlias((*GContext->itemRegistry), alias);
 
-	return ToPyUUID(result);
+	return ToPyUUID(result, "");
 }
 
 static PyObject*
@@ -3633,20 +3627,9 @@ get_item_info(PyObject* self, PyObject* args, PyObject* kwargs)
 	PyDict_SetItemString(pdict, "type", mvPyObject(ToPyString(DearPyGui::GetEntityTypeString(appitem->type))));
 	PyDict_SetItemString(pdict, "target", mvPyObject(ToPyInt(DearPyGui::GetEntityTargetSlot(appitem->type))));
 
-	if (appitem->info.parentPtr)
-		PyDict_SetItemString(pdict, "parent", mvPyObject(ToPyUUID(appitem->info.parentPtr->uuid)));
-	else
-		PyDict_SetItemString(pdict, "parent", mvPyObject(GetPyNone()));
-
-	if (appitem->theme)
-		PyDict_SetItemString(pdict, "theme", mvPyObject(ToPyUUID(appitem->theme->uuid)));
-	else
-		PyDict_SetItemString(pdict, "theme", mvPyObject(GetPyNone()));
-
-	if (appitem->font)
-		PyDict_SetItemString(pdict, "font", mvPyObject(ToPyUUID(appitem->font->uuid)));
-	else
-		PyDict_SetItemString(pdict, "font", mvPyObject(GetPyNone()));
+	PyDict_SetItemString(pdict, "parent", mvPyObject(ToPyUUIDOrNone(appitem->info.parentPtr)));
+	PyDict_SetItemString(pdict, "theme", mvPyObject(ToPyUUIDOrNone(appitem->theme.get())));
+	PyDict_SetItemString(pdict, "font", mvPyObject(ToPyUUIDOrNone(appitem->font.get())));
 
 	if (DearPyGui::GetEntityDesciptionFlags(appitem->type) & MV_ITEM_DESC_CONTAINER)
 		PyDict_SetItemString(pdict, "container", mvPyObject(ToPyBool(true)));
@@ -3697,7 +3680,7 @@ get_item_configuration(PyObject* self, PyObject* args, PyObject* kwargs)
 	mvPyObject py_payload_type = ToPyString(appitem->config.payloadType);
 	mvPyObject py_label = ToPyString(appitem->config.specifiedLabel);
 	mvPyObject py_use_internal_label = ToPyBool(appitem->config.useInternalLabel);
-	mvPyObject py_source = ToPyUUID(appitem->config.source);
+	mvPyObject py_source = PyUUIDFromItem(appitem->config.source);
 	mvPyObject py_show = ToPyBool(appitem->config.show);
 	mvPyObject py_enabled = ToPyBool(appitem->config.enabled);
 	mvPyObject py_tracked = ToPyBool(appitem->config.tracked);

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -111,7 +111,7 @@ void mvAppItem::submitCallback(mvColor app_data)
 }
 
 template<>
-void mvAppItem::submitCallback(mvUUID app_data)
+void mvAppItem::submitCallback(mvAppItem* app_data)
 {
     submitCallbackEx([=]() { return ToPyUUID(app_data); });
 }

--- a/src/mvBasicWidgets.cpp
+++ b/src/mvBasicWidgets.cpp
@@ -664,7 +664,7 @@ DearPyGui::fill_configuration_dict(const mvImageConfig& inConfig, PyObject* outD
 	PyDict_SetItemString(outDict, "uv_max", mvPyObject(ToPyPair(inConfig.uv_max.x, inConfig.uv_max.y)));
 	PyDict_SetItemString(outDict, "tint_color", mvPyObject(ToPyColor(inConfig.tintColor)));
 	PyDict_SetItemString(outDict, "border_color", mvPyObject(ToPyColor(inConfig.borderColor)));
-	PyDict_SetItemString(outDict, "texture_tag", mvPyObject(ToPyUUID(inConfig.textureUUID)));
+	PyDict_SetItemString(outDict, "texture_tag", mvPyObject(ToPyUUID(inConfig.texture.get())));
 }
 
 void
@@ -677,7 +677,7 @@ DearPyGui::fill_configuration_dict(const mvImageButtonConfig& inConfig, PyObject
 	PyDict_SetItemString(outDict, "uv_max", mvPyObject(ToPyPair(inConfig.uv_max.x, inConfig.uv_max.y)));
 	PyDict_SetItemString(outDict, "tint_color", mvPyObject(ToPyColor(inConfig.tintColor)));
 	PyDict_SetItemString(outDict, "background_color", mvPyObject(ToPyColor(inConfig.backgroundColor)));
-	PyDict_SetItemString(outDict, "texture_tag", mvPyObject(ToPyUUID(inConfig.textureUUID)));
+	PyDict_SetItemString(outDict, "texture_tag", mvPyObject(ToPyUUID(inConfig.texture.get())));
 	PyDict_SetItemString(outDict, "frame_padding", mvPyObject(ToPyInt(inConfig.framePadding)));
 }
 
@@ -1469,14 +1469,14 @@ DearPyGui::set_configuration(PyObject* inDict, mvImageConfig& outConfig)
 	if (PyObject* item = PyDict_GetItemString(inDict, "border_color")) outConfig.borderColor = ToColor(item);
 	if (PyObject* item = PyDict_GetItemString(inDict, "texture_tag"))
 	{
-		outConfig.textureUUID = GetIDFromPyObject(item);
-		if (outConfig.textureUUID == MV_ATLAS_UUID)
+		mvUUID textureUUID = GetIDFromPyObject(item);
+		if (textureUUID == MV_ATLAS_UUID)
 		{
-			outConfig.texture = std::make_shared<mvStaticTexture>(outConfig.textureUUID);
+			outConfig.texture = std::make_shared<mvStaticTexture>(textureUUID);
 		}
 		else
 		{
-			outConfig.texture = GetRefItem(*GContext->itemRegistry, outConfig.textureUUID);
+			outConfig.texture = GetRefItem(*GContext->itemRegistry, textureUUID);
 			if (!outConfig.texture)
 				mvThrowPythonError(mvErrorCode::mvTextureNotFound, GetEntityCommand(mvAppItemType::mvImage), "Texture not found.", nullptr);
 		}
@@ -1496,14 +1496,14 @@ DearPyGui::set_configuration(PyObject* inDict, mvImageButtonConfig& outConfig)
 	if (PyObject* item = PyDict_GetItemString(inDict, "frame_padding")) outConfig.framePadding = ToInt(item);
 	if (PyObject* item = PyDict_GetItemString(inDict, "texture_tag"))
 	{
-		outConfig.textureUUID = GetIDFromPyObject(item);
-		if (outConfig.textureUUID == MV_ATLAS_UUID)
+		mvUUID textureUUID = GetIDFromPyObject(item);
+		if (textureUUID == MV_ATLAS_UUID)
 		{
-			outConfig.texture = std::make_shared<mvStaticTexture>(outConfig.textureUUID);
+			outConfig.texture = std::make_shared<mvStaticTexture>(textureUUID);
 		}
 		else
 		{
-			outConfig.texture = GetRefItem(*GContext->itemRegistry, outConfig.textureUUID);
+			outConfig.texture = GetRefItem(*GContext->itemRegistry, textureUUID);
 			if (!outConfig.texture)
 				mvThrowPythonError(mvErrorCode::mvTextureNotFound, GetEntityCommand(mvAppItemType::mvImageButton), "Texture not found.", nullptr);
 		}
@@ -1549,14 +1549,14 @@ DearPyGui::set_required_configuration(PyObject* inDict, mvImageConfig& outConfig
 	if (!VerifyRequiredArguments(GetParsers()[GetEntityCommand(mvAppItemType::mvImage)], inDict))
 		return;
 
-	outConfig.textureUUID = GetIDFromPyObject(PyTuple_GetItem(inDict, 0));
-	if (outConfig.textureUUID == MV_ATLAS_UUID)
+	mvUUID textureUUID = GetIDFromPyObject(PyTuple_GetItem(inDict, 0));
+	if (textureUUID == MV_ATLAS_UUID)
 	{
-		outConfig.texture = std::make_shared<mvStaticTexture>(outConfig.textureUUID);
+		outConfig.texture = std::make_shared<mvStaticTexture>(textureUUID);
 	}
 	else
 	{
-		outConfig.texture = GetRefItem(*GContext->itemRegistry, outConfig.textureUUID);
+		outConfig.texture = GetRefItem(*GContext->itemRegistry, textureUUID);
 		if (!outConfig.texture)
 			mvThrowPythonError(mvErrorCode::mvTextureNotFound, GetEntityCommand(mvAppItemType::mvImage), "Texture not found.", nullptr);
 	}
@@ -1568,14 +1568,14 @@ DearPyGui::set_required_configuration(PyObject* inDict, mvImageButtonConfig& out
 	if (!VerifyRequiredArguments(GetParsers()[GetEntityCommand(mvAppItemType::mvImageButton)], inDict))
 		return;
 
-	outConfig.textureUUID = GetIDFromPyObject(PyTuple_GetItem(inDict, 0));
-	if (outConfig.textureUUID == MV_ATLAS_UUID)
+	mvUUID textureUUID = GetIDFromPyObject(PyTuple_GetItem(inDict, 0));
+	if (textureUUID == MV_ATLAS_UUID)
 	{
-		outConfig.texture = std::make_shared<mvStaticTexture>(outConfig.textureUUID);
+		outConfig.texture = std::make_shared<mvStaticTexture>(textureUUID);
 	}
 	else
 	{
-		outConfig.texture = GetRefItem(*GContext->itemRegistry, outConfig.textureUUID);
+		outConfig.texture = GetRefItem(*GContext->itemRegistry, textureUUID);
 		if (!outConfig.texture)
 			mvThrowPythonError(mvErrorCode::mvTextureNotFound, GetEntityCommand(mvAppItemType::mvImageButton), "Texture not found.", nullptr);
 	}

--- a/src/mvBasicWidgets.h
+++ b/src/mvBasicWidgets.h
@@ -530,7 +530,6 @@ struct mvImageConfig
 {
     // pointer to existing item or internal
     std::shared_ptr<mvAppItem> texture = nullptr;
-    mvUUID                     textureUUID = 0;
     mvVec2                     uv_min = { 0.0f, 0.0f };
     mvVec2                     uv_max = { 1.0f, 1.0f };
     mvColor                    tintColor = { 1.0f, 1.0f, 1.0f, 1.0f };
@@ -541,7 +540,6 @@ struct mvImageButtonConfig
 {
     // pointer to existing item or internal
     std::shared_ptr<mvAppItem> texture = nullptr;
-    mvUUID                     textureUUID = 0;
     mvVec2	                   uv_min = { 0.0f, 0.0f };
     mvVec2	                   uv_max = { 1.0f, 1.0f };
     mvColor                    tintColor = { 1.0f, 1.0f, 1.0f, 1.0f };

--- a/src/mvCallbackRegistry.cpp
+++ b/src/mvCallbackRegistry.cpp
@@ -131,9 +131,7 @@ void mvRunCallback(PyObject* callback, PyObject* user_data, mvUUID sender, const
 
 			if (count > 0)
 			{
-				PyTuple_SetItem(pArgs, 0, sender_alias.empty()?
-						ToPyUUID(sender) :
-						ToPyString(sender_alias));
+				PyTuple_SetItem(pArgs, 0, ToPyUUID(sender, sender_alias));
 
 				if (count > 1)
 				{

--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -846,7 +846,7 @@ DearPyGui::draw_tab(ImDrawList* drawlist, mvAppItem& item, mvTabConfig& config)
             // run call back if it exists
             if (parent->getSpecificValue() != item.uuid)
             {
-                parent->submitCallback(item.uuid);
+                parent->submitCallback(&item);
             }
 
             parent->setValue(item.uuid);

--- a/src/mvContainers.h
+++ b/src/mvContainers.h
@@ -246,7 +246,7 @@ public:
     void handleSpecificKeywordArgs(PyObject* dict) override { DearPyGui::set_configuration(dict, configData); }
     void getSpecificConfiguration(PyObject* dict) override { DearPyGui::fill_configuration_dict(configData, dict); }
     void setDataSource(mvUUID dataSource) override { DearPyGui::set_data_source(*this, uuid, configData); }
-    PyObject* getPyValue() override{ return ToPyUUID(*configData.value); }
+    PyObject* getPyValue() override{ return PyUUIDFromItem(*configData.value); }
     void setPyValue(PyObject* value) override{ *configData.value = ToUUID(value); }
     mvUUID getSpecificValue() { return configData.uiValue; }
     void setValue(mvUUID value) { configData.uiValue = value; }

--- a/src/mvDrawings.cpp
+++ b/src/mvDrawings.cpp
@@ -576,7 +576,7 @@ void mvDrawImage::handleSpecificRequiredArgs(PyObject* dict)
 	if (!VerifyRequiredArguments(GetParsers()[GetEntityCommand(type)], dict))
 		return;
 
-	_textureUUID = GetIDFromPyObject(PyTuple_GetItem(dict, 0));
+	mvUUID _textureUUID = GetIDFromPyObject(PyTuple_GetItem(dict, 0));
 	if (_textureUUID == MV_ATLAS_UUID)
 	{
 		_texture = std::make_shared<mvStaticTexture>(_textureUUID);
@@ -606,7 +606,7 @@ void mvDrawImage::handleSpecificKeywordArgs(PyObject* dict)
 	if (PyObject* item = PyDict_GetItemString(dict, "color")) _color = ToColor(item);
 	if (PyObject* item = PyDict_GetItemString(dict, "texture_tag"))
 	{
-		_textureUUID = GetIDFromPyObject(item);
+		mvUUID _textureUUID = GetIDFromPyObject(item);
 		if (_textureUUID == MV_ATLAS_UUID)
 		{
 			_texture = std::make_shared<mvStaticTexture>(_textureUUID);
@@ -633,7 +633,7 @@ void mvDrawImage::getSpecificConfiguration(PyObject* dict)
 	PyDict_SetItemString(dict, "uv_min", mvPyObject(ToPyPair(_uv_min.x, _uv_min.y)));
 	PyDict_SetItemString(dict, "uv_max", mvPyObject(ToPyPair(_uv_max.x, _uv_max.y)));
 	PyDict_SetItemString(dict, "color", mvPyObject(ToPyColor(_color)));
-	PyDict_SetItemString(dict, "texture_tag", mvPyObject(ToPyUUID(_textureUUID)));
+	PyDict_SetItemString(dict, "texture_tag", mvPyObject(ToPyUUID(_texture.get())));
 }
 
 void mvDrawImageQuad::draw(ImDrawList* drawlist, float x, float y)
@@ -696,7 +696,7 @@ void mvDrawImageQuad::handleSpecificRequiredArgs(PyObject* dict)
 	if (!VerifyRequiredArguments(GetParsers()[GetEntityCommand(type)], dict))
 		return;
 
-	_textureUUID = GetIDFromPyObject(PyTuple_GetItem(dict, 0));
+	mvUUID _textureUUID = GetIDFromPyObject(PyTuple_GetItem(dict, 0));
 	if (_textureUUID == MV_ATLAS_UUID)
 	{
 		_texture = std::make_shared<mvStaticTexture>(_textureUUID);
@@ -735,7 +735,7 @@ void mvDrawImageQuad::handleSpecificKeywordArgs(PyObject* dict)
 	if (PyObject* item = PyDict_GetItemString(dict, "color")) _color = ToColor(item);
 	if (PyObject* item = PyDict_GetItemString(dict, "texture_tag"))
 	{
-		_textureUUID = GetIDFromPyObject(item);
+		mvUUID _textureUUID = GetIDFromPyObject(item);
 		if (_textureUUID == MV_ATLAS_UUID)
 		{
 			_texture = std::make_shared<mvStaticTexture>(_textureUUID);
@@ -768,7 +768,7 @@ void mvDrawImageQuad::getSpecificConfiguration(PyObject* dict)
 	PyDict_SetItemString(dict, "uv3", mvPyObject(ToPyPair(_uv3.x, _uv3.y)));
 	PyDict_SetItemString(dict, "uv4", mvPyObject(ToPyPair(_uv4.x, _uv4.y)));
 	PyDict_SetItemString(dict, "color", mvPyObject(ToPyColor(_color)));
-	PyDict_SetItemString(dict, "texture_tag", mvPyObject(ToPyUUID(_textureUUID)));
+	PyDict_SetItemString(dict, "texture_tag", mvPyObject(ToPyUUID(_texture.get())));
 }
 
 mvDrawLayer::~mvDrawLayer()

--- a/src/mvDrawings.h
+++ b/src/mvDrawings.h
@@ -206,7 +206,6 @@ public:
 private:
 
 
-    mvUUID      _textureUUID = 0;
     mvVec4      _pmax = { 0.0f, 0.0f, 0.0f, 1.0f };
     mvVec4      _pmin = { 0.0f, 0.0f, 0.0f, 1.0f };
     mvVec2      _uv_min = { 0.0f, 0.0f };
@@ -234,7 +233,6 @@ public:
 private:
 
 
-    mvUUID      _textureUUID = 0;
     mvVec4      _p1 = { 0.0f, 0.0f, 0.0f, 1.0f };
     mvVec4      _p2 = { 0.0f, 0.0f, 0.0f, 1.0f };
     mvVec4      _p3 = { 0.0f, 0.0f, 0.0f, 1.0f };

--- a/src/mvNodes.cpp
+++ b/src/mvNodes.cpp
@@ -310,26 +310,27 @@ void mvNodeEditor::draw(ImDrawList* drawlist, float x, float y)
     static int start_attr, end_attr;
     if (ImNodes::IsLinkCreated(&start_attr, &end_attr))
     {
-        mvUUID node1, node2;
-        for (const auto& child : childslots[1])
-        {
-
-            // skip menu bars
-            if (child->type != mvAppItemType::mvNode)
-                continue;
-
-            for (const auto& grandchild : child->childslots[1])
-            {
-                if (static_cast<mvNodeAttribute*>(grandchild.get())->getId() == start_attr)
-                    node1 = grandchild->uuid;
-
-                if (static_cast<mvNodeAttribute*>(grandchild.get())->getId() == end_attr)
-                    node2 = grandchild->uuid;
-            }
-        }
-
         if (config.callback)
         {
+            mvAppItem* node1 = nullptr;
+            mvAppItem* node2 = nullptr;
+            for (const auto& child : childslots[1])
+            {
+
+                // skip menu bars
+                if (child->type != mvAppItemType::mvNode)
+                    continue;
+
+                for (const auto& grandchild : child->childslots[1])
+                {
+                    if (static_cast<mvNodeAttribute*>(grandchild.get())->getId() == start_attr)
+                        node1 = grandchild.get();
+
+                    if (static_cast<mvNodeAttribute*>(grandchild.get())->getId() == end_attr)
+                        node2 = grandchild.get();
+                }
+            }
+
             submitCallbackEx([=]() {
                 PyObject* link = PyTuple_New(2);
                 PyTuple_SetItem(link, 0, ToPyUUID(node1));
@@ -342,21 +343,19 @@ void mvNodeEditor::draw(ImDrawList* drawlist, float x, float y)
     static int destroyed_attr;
     if (ImNodes::IsLinkDestroyed(&destroyed_attr))
     {
-        mvUUID name = 0;
-        for (auto& item : childslots[0])
-        {
-            if (item->type == mvAppItemType::mvNodeLink)
-            {
-                if (static_cast<const mvNodeLink*>(item.get())->_id0 == destroyed_attr)
-                {
-                    name = item->uuid;
-                    break;
-                }
-            }
-        }
         if (_delinkCallback)
         {
-            submitCallbackEx(_delinkCallback, [=]() { return ToPyUUID(name); });
+            for (auto& item : childslots[0])
+            {
+                if (item->type == mvAppItemType::mvNodeLink)
+                {
+                    if (static_cast<const mvNodeLink*>(item.get())->_id0 == destroyed_attr)
+                    {
+                        submitCallbackEx(_delinkCallback, [=]() { return ToPyUUID(item.get()); });
+                        break;
+                    }
+                }
+            }
         }
     }
 
@@ -731,6 +730,6 @@ void mvNodeLink::getSpecificConfiguration(PyObject* dict)
     if (dict == nullptr)
         return;
 
-    PyDict_SetItemString(dict, "attr_1", mvPyObject(ToPyUUID(_id1uuid)));
-    PyDict_SetItemString(dict, "attr_2", mvPyObject(ToPyUUID(_id2uuid)));
+    PyDict_SetItemString(dict, "attr_1", mvPyObject(PyUUIDFromItem(_id1uuid)));
+    PyDict_SetItemString(dict, "attr_2", mvPyObject(PyUUIDFromItem(_id2uuid)));
 }

--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -2515,20 +2515,20 @@ DearPyGui::set_required_configuration(PyObject* inDict, mvImageSeriesConfig& out
 	if (!VerifyRequiredArguments(GetParsers()[GetEntityCommand(mvAppItemType::mvImageSeries)], inDict))
 		return;
 
-	outConfig.textureUUID = GetIDFromPyObject(PyTuple_GetItem(inDict, 0));
+	mvUUID textureUUID = GetIDFromPyObject(PyTuple_GetItem(inDict, 0));
 	auto resultmin = ToPoint(PyTuple_GetItem(inDict, 1));
 	auto resultmax = ToPoint(PyTuple_GetItem(inDict, 2));
 	outConfig.bounds_min.x = resultmin.x;
 	outConfig.bounds_min.y = resultmin.y;
 	outConfig.bounds_max.x = resultmax.x;
 	outConfig.bounds_max.y = resultmax.y;
-	if (outConfig.textureUUID == MV_ATLAS_UUID)
+	if (textureUUID == MV_ATLAS_UUID)
 	{
-		outConfig._texture = std::make_shared<mvStaticTexture>(outConfig.textureUUID);
+		outConfig._texture = std::make_shared<mvStaticTexture>(textureUUID);
 	}
 	else
 	{
-		outConfig._texture = GetRefItem(*GContext->itemRegistry, outConfig.textureUUID);
+		outConfig._texture = GetRefItem(*GContext->itemRegistry, textureUUID);
 		if (!outConfig._texture)
 			mvThrowPythonError(mvErrorCode::mvTextureNotFound, GetEntityCommand(mvAppItemType::mvImageSeries), "Texture not found.", nullptr);
 	}
@@ -3139,14 +3139,14 @@ DearPyGui::set_configuration(PyObject* inDict, mvImageSeriesConfig& outConfig)
 
 	if (PyObject* item = PyDict_GetItemString(inDict, "texture_tag"))
 	{
-		outConfig.textureUUID = GetIDFromPyObject(item);
-		if (outConfig.textureUUID == MV_ATLAS_UUID)
+		mvUUID textureUUID = GetIDFromPyObject(item);
+		if (textureUUID == MV_ATLAS_UUID)
 		{
-			outConfig._texture = std::make_shared<mvStaticTexture>(outConfig.textureUUID);
+			outConfig._texture = std::make_shared<mvStaticTexture>(textureUUID);
 		}
 		else
 		{
-			outConfig._texture = GetRefItem(*GContext->itemRegistry, outConfig.textureUUID);
+			outConfig._texture = GetRefItem(*GContext->itemRegistry, textureUUID);
 			if (!outConfig._texture)
 				mvThrowPythonError(mvErrorCode::mvTextureNotFound, GetEntityCommand(mvAppItemType::mvImageSeries), "Texture not found.", nullptr);
 		}
@@ -3744,7 +3744,7 @@ DearPyGui::fill_configuration_dict(const mvImageSeriesConfig& inConfig, PyObject
 {
 	if (outDict == nullptr)
 		return;
-	PyDict_SetItemString(outDict, "texture_tag", mvPyObject(ToPyUUID(inConfig.textureUUID)));
+	PyDict_SetItemString(outDict, "texture_tag", mvPyObject(ToPyUUID(inConfig._texture.get())));
 	PyDict_SetItemString(outDict, "uv_min", mvPyObject(ToPyPair(inConfig.uv_min.x, inConfig.uv_min.y)));
 	PyDict_SetItemString(outDict, "uv_max", mvPyObject(ToPyPair(inConfig.uv_max.x, inConfig.uv_max.y)));
 	PyDict_SetItemString(outDict, "tint_color", mvPyObject(ToPyColor(inConfig.tintColor)));

--- a/src/mvPlotting.h
+++ b/src/mvPlotting.h
@@ -325,7 +325,6 @@ struct mvLabelSeriesConfig : _mvBasicSeriesConfig
 struct mvImageSeriesConfig : _mvBasicSeriesConfig
 {
     // config
-    mvUUID      textureUUID = 0;
     ImPlotPoint bounds_min = { 0.0, 0.0 };
     ImPlotPoint bounds_max = { 0.0, 0.0 };
     mvVec2      uv_min = { 0.0f, 0.0f };

--- a/src/mvPyUtils.cpp
+++ b/src/mvPyUtils.cpp
@@ -508,10 +508,7 @@ ToPyInt(int value)
 PyObject*
 ToPyUUID(mvAppItem* item)
 {
-    if (!item->config.alias.empty())
-        return Py_BuildValue("K", item->uuid);
-
-    return Py_BuildValue("K", item->uuid);
+    return item? ToPyUUID(item->uuid, item->config.alias) : PyLong_FromLong(0);
 }
 
 PyObject*
@@ -523,14 +520,17 @@ ToPyUUID(mvUUID uuid, const std::string& alias)
 }
 
 PyObject*
-ToPyUUID(mvUUID value)
+ToPyUUIDOrNone(mvAppItem* item)
+{
+    return item? ToPyUUID(item->uuid, item->config.alias) : GetPyNone();
+}
+
+PyObject*
+PyUUIDFromItem(mvUUID value)
 {
     mvAppItem* item = GetItem(*GContext->itemRegistry, value);
     if (item)
-    {
-        if (!item->config.alias.empty())
-            return Py_BuildValue("K", item->uuid);
-    }
+        return ToPyUUID(item);
     return Py_BuildValue("K", value);
 }
 

--- a/src/mvPyUtils.h
+++ b/src/mvPyUtils.h
@@ -137,9 +137,36 @@ bool isPyObject_Any           (PyObject* obj);
 // conversion to python
 PyObject*   GetPyNone ();
 PyObject*   GetPyNoneOrError ();
-PyObject*   ToPyUUID  (mvAppItem* item);
-PyObject*   ToPyUUID  (mvUUID value);
+
+// If alias is not empty, returns the alias, otherwise returns the UUID.
 PyObject*   ToPyUUID  (mvUUID uuid, const std::string& alias);
+
+// Returns item UUID or alias, or zero if `item` is null.  An valid item can never
+// a UUID of zero, so it is a good value to designate a "no item" case (also can
+// easily be checked with `if (item)` in Python).
+PyObject*   ToPyUUID  (mvAppItem* item);
+
+// Returns item UUID or alias, or None if `item` is null.
+//
+// This function is kept for compatibility reasons, to keep None as the default value
+// in some cases where it was historically the default.  In new code, prefer returning
+// zero UUID as the default - use one of ToPyUUID() overloads.  This makes typing
+// a bit simpler on Python side of things (`int | str` vs. `int | str | None`).
+PyObject*   ToPyUUIDOrNone(mvAppItem* item);
+
+// Unlike ToPyUUID(), this function peforms item lookup by the UUID passed in,
+// and converts the item found to UUID or alias.  If the item is not found, the
+// value passed in is returned.  That is, this function returns an UUID even
+// after the corresponding item has been deleted.  It *never* returns None.
+//
+// Even though the lookup (GetItem()) uses a hashtable and should be pretty fast,
+// prefer one of the ToPyUUID() overloads over this one if possible.  In new code,
+// it will even be better to do a ToPyUUID(GetItem(uuid)), because after item deletion,
+// this will be returning 0 rather than an invalid UUID.
+//
+// This function is kept mainly for compatibility reasons.
+PyObject*   PyUUIDFromItem(mvUUID value);
+
 PyObject*   ToPyLong  (long value);
 PyObject*   ToPyInt   (int value);
 PyObject*   ToPyFloat (float value);


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: fix: Restored item aliases in node editor and other places #2122
assignees: @hoffstadt

---

**Description:**

Closes #2122.

This PR fixes a regression introduced in #2034. Now, if an item has an alias, its alias is used by DPG in callbacks and other places instead of its numeric UUID, like it was in 1.8 and before.

Also, `generate_uuid()` now does not perform useless item lookup (`GetItem()`). Overall, the use of `ToPyUUID()` has been revisited and somewhat cleaned up.

The code can be improved/cleaned up further by making various pieces return UUID of 0 if the corresponding item has been deleted, but this would break the old behavior (even though it's unlikely that anyone would notice). Currently, functions like `get_active_window` return a nonzero UUID even if it does not exist anymore. I've chosen to keep this old behavior for now. We can always break things later 😂.

**Concerning Areas:**
None.