### PR TITLE
PyObject leaks in custom series and other places

### DIFF
--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -4010,7 +4010,7 @@ get_item_types(PyObject* self, PyObject* args, PyObject* kwargs)
 	mvPySafeLockGuard lk(GContext->mutex);
 
 	PyObject* pdict = PyDict_New();
-	#define X(el) PyDict_SetItemString(pdict, #el, PyLong_FromLong((int)mvAppItemType::el));
+	#define X(el) PyDict_SetItemString(pdict, #el, mvPyObject(PyLong_FromLong((int)mvAppItemType::el)));
 	MV_ITEM_TYPES
 	#undef X
 

--- a/src/mvFontItems.cpp
+++ b/src/mvFontItems.cpp
@@ -116,8 +116,8 @@ void mvFont::getSpecificConfiguration(PyObject* dict)
 	if (dict == nullptr)
 		return;
 
-	PyDict_SetItemString(dict, "file", ToPyString(_file));
-	PyDict_SetItemString(dict, "size", ToPyFloat(_size));
-	PyDict_SetItemString(dict, "pixel_snapH", ToPyBool(_pixelSnapH));
-	PyDict_SetItemString(dict, "pixel_snapV", ToPyBool(_pixelSnapV));
+	PyDict_SetItemString(dict, "file", mvPyObject(ToPyString(_file)));
+	PyDict_SetItemString(dict, "size", mvPyObject(ToPyFloat(_size)));
+	PyDict_SetItemString(dict, "pixel_snapH", mvPyObject(ToPyBool(_pixelSnapH)));
+	PyDict_SetItemString(dict, "pixel_snapV", mvPyObject(ToPyBool(_pixelSnapV)));
 }

--- a/src/mvItemHandlers.cpp
+++ b/src/mvItemHandlers.cpp
@@ -241,7 +241,7 @@ void mvClickedHandler::getSpecificConfiguration(PyObject* dict)
 	if (dict == nullptr)
 		return;
 
-	PyDict_SetItemString(dict, "button", ToPyInt(_button));
+	PyDict_SetItemString(dict, "button", mvPyObject(ToPyInt(_button)));
 }
 
 void mvDoubleClickedHandler::customAction(void* data)
@@ -287,7 +287,7 @@ void mvDoubleClickedHandler::getSpecificConfiguration(PyObject* dict)
 	if (dict == nullptr)
 		return;
 
-	PyDict_SetItemString(dict, "button", ToPyInt(_button));
+	PyDict_SetItemString(dict, "button", mvPyObject(ToPyInt(_button)));
 }
 
 void mvDeactivatedAfterEditHandler::customAction(void* data)

--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -3360,16 +3360,16 @@ DearPyGui::fill_configuration_dict(const mvDragLineConfig& inConfig, PyObject* o
 	if (outDict == nullptr)
 		return;
 
-	PyDict_SetItemString(outDict, "color", ToPyColor(inConfig.color));
-	PyDict_SetItemString(outDict, "thickness", ToPyFloat(inConfig.thickness));
-	PyDict_SetItemString(outDict, "show_label", ToPyBool(inConfig.thickness));
-	PyDict_SetItemString(outDict, "vertical", ToPyBool(inConfig.vertical));
+	PyDict_SetItemString(outDict, "color", mvPyObject(ToPyColor(inConfig.color)));
+	PyDict_SetItemString(outDict, "thickness", mvPyObject(ToPyFloat(inConfig.thickness)));
+	PyDict_SetItemString(outDict, "show_label", mvPyObject(ToPyBool(inConfig.thickness)));
+	PyDict_SetItemString(outDict, "vertical", mvPyObject(ToPyBool(inConfig.vertical)));
 
 
 	// helper to check and set bit
 	auto checkbitset = [outDict](const char* keyword, int flag, const int& flags)
 	{
-		PyDict_SetItemString(outDict, keyword, ToPyBool(flags & flag));
+		PyDict_SetItemString(outDict, keyword, mvPyObject(ToPyBool(flags & flag)));
 	};
 
 	// drag line flags
@@ -3390,7 +3390,7 @@ DearPyGui::fill_configuration_dict(const mvDragRectConfig& inConfig, PyObject* o
 	// helper to check and set bit
 	auto checkbitset = [outDict](const char* keyword, int flag, const int& flags)
 	{
-		PyDict_SetItemString(outDict, keyword, ToPyBool(flags & flag));
+		PyDict_SetItemString(outDict, keyword, mvPyObject(ToPyBool(flags & flag)));
 	};
 
 	// drag rect flags
@@ -3415,7 +3415,7 @@ DearPyGui::fill_configuration_dict(const mvDragPointConfig& inConfig, PyObject* 
 	// helper to check and set bit
 	auto checkbitset = [outDict](const char* keyword, int flag, const int& flags)
 	{
-		PyDict_SetItemString(outDict, keyword, ToPyBool(flags & flag));
+		PyDict_SetItemString(outDict, keyword, mvPyObject(ToPyBool(flags & flag)));
 	};
 
 	// drag rect flags
@@ -3483,7 +3483,7 @@ DearPyGui::fill_configuration_dict(const mvBarSeriesConfig& inConfig, PyObject* 
 	if (outDict == nullptr)
 		return;
 
-	PyDict_SetItemString(outDict, "weight", ToPyFloat(inConfig.weight));
+	PyDict_SetItemString(outDict, "weight", mvPyObject(ToPyFloat(inConfig.weight)));
 
 	// helper to check and set bit
 	auto checkbitset = [outDict](const char* keyword, int flag, const int& flags)
@@ -3518,10 +3518,10 @@ DearPyGui::fill_configuration_dict(const mvBarGroupSeriesConfig& inConfig, PyObj
 	if (outDict == nullptr)
 		return;
 
-	PyDict_SetItemString(outDict, "label_ids", ToPyList(inConfig.label_ids));
-	PyDict_SetItemString(outDict, "group_width", ToPyFloat(inConfig.group_width));
-	PyDict_SetItemString(outDict, "group_size", ToPyInt(inConfig.group_size));
-	PyDict_SetItemString(outDict, "shift", ToPyInt(inConfig.shift));
+	PyDict_SetItemString(outDict, "label_ids", mvPyObject(ToPyList(inConfig.label_ids)));
+	PyDict_SetItemString(outDict, "group_width", mvPyObject(ToPyFloat(inConfig.group_width)));
+	PyDict_SetItemString(outDict, "group_size", mvPyObject(ToPyInt(inConfig.group_size)));
+	PyDict_SetItemString(outDict, "shift", mvPyObject(ToPyInt(inConfig.shift)));
 
 	// helper to check and set bit
 	auto checkbitset = [outDict](const char* keyword, int flag, const int& flags)


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: PyObject leaks in custom series and other places
assignees: @hoffstadt 

---

**Description:**
Closes #2104.

`PyDict_SetItemString` does not steal the reference to the value passed in, and we therefore must `DECREF` it on our own. This PR corrects all the `PyDict_SetItemString` calls and fixes the associated object leaks.

**Concerning Areas:**
None.