### PR TITLE
fix: A regression in list functions introduced in PR #2613

### DIFF
--- a/src/mvItemRegistry.cpp
+++ b/src/mvItemRegistry.cpp
@@ -776,7 +776,7 @@ AddItemWithRuntimeChecks(mvItemRegistry& registry, std::shared_ptr<mvAppItem> it
         mvAppItem* beforeItem = GetItem(registry, before);
         if (beforeItem == nullptr)
         {
-            mvThrowPythonError(mvErrorCode::mvItemNotFound, "add_*", "Item not found: " + std::to_string(parent), nullptr);
+            mvThrowPythonError(mvErrorCode::mvItemNotFound, "add_*", "Item not found: " + std::to_string(before), nullptr);
             IM_ASSERT(false && "The 'before' item could not be found.");
             return false;
         }

--- a/src/mvPyUtils.cpp
+++ b/src/mvPyUtils.cpp
@@ -1107,7 +1107,7 @@ ToUCharVect(PyObject* value, const std::string& message)
         auto size = VecReserveForTuple(value, items);
         for (Py_ssize_t i = 0; i < size; ++i)
         {
-            items[i] = (unsigned char)PyLong_AsLong(PyTuple_GetItem(value, i));
+            items.emplace_back((unsigned char)PyLong_AsLong(PyTuple_GetItem(value, i)));
         }
     }
 
@@ -1116,7 +1116,7 @@ ToUCharVect(PyObject* value, const std::string& message)
         auto size = VecReserveForList(value, items);
         for (Py_ssize_t i = 0; i < size; ++i)
         {
-            items[i] = (unsigned char)PyLong_AsLong(PyList_GetItem(value, i));
+            items.emplace_back((unsigned char)PyLong_AsLong(PyList_GetItem(value, i)));
         }
     }
 
@@ -1160,7 +1160,7 @@ ToIntVect(PyObject* value, const std::string& message)
         auto size = VecReserveForTuple(value, items);
         for (Py_ssize_t i = 0; i < size; ++i)
         {
-            items[i] = PyLong_AsLong(PyTuple_GetItem(value, i));
+            items.emplace_back(PyLong_AsLong(PyTuple_GetItem(value, i)));
         }
     }
 
@@ -1169,7 +1169,7 @@ ToIntVect(PyObject* value, const std::string& message)
         auto size = VecReserveForList(value, items);
         for (Py_ssize_t i = 0; i < size; ++i)
         {
-            items[i] = PyLong_AsLong(PyList_GetItem(value, i));
+            items.emplace_back(PyLong_AsLong(PyList_GetItem(value, i)));
         }
     }
 
@@ -1214,11 +1214,7 @@ ToUUIDVect(PyObject* value, const std::string& message)
         auto size = VecReserveForTuple(value, items);
         for (Py_ssize_t i = 0; i < size; ++i)
         {
-            PyObject* item = PyTuple_GetItem(value, i);
-            if (isPyObject_Int(item))
-                items[i] = PyLong_AsUnsignedLongLong(item);
-            else if (isPyObject_String(item))
-                items[i] = GetIdFromAlias(*GContext->itemRegistry, ToString(item));
+            items.emplace_back(ToUUID(PyTuple_GetItem(value, i)));
         }
     }
 
@@ -1227,11 +1223,7 @@ ToUUIDVect(PyObject* value, const std::string& message)
         auto size = VecReserveForList(value, items);
         for (Py_ssize_t i = 0; i < size; ++i)
         {
-            PyObject* item = PyList_GetItem(value, i);
-            if (isPyObject_Int(item))
-                items[i] = PyLong_AsUnsignedLongLong(item);
-            else if (isPyObject_String(item))
-                items[i] = GetIdFromAlias(*GContext->itemRegistry, ToString(item));
+            items.emplace_back(ToUUID(PyList_GetItem(value, i)));
         }
     }
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: fix: A regression in list functions introduced in PR #2613
assignees: @hoffstadt

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
PR #2613 modified a number of list conversion functions in `mvPyUtils.cpp` and brought a change where the code that was previously calling `std::vector::resize()` is now calling `reserve()` instead. This is fine, but requires a different way of populating the vector - namely, `emplace_back` or `push_back` instead of assigning a value to `items[i]`. Unfortunately in some places this was not changed and the code was still using `items[i]`, breaking functions like `reorder_items`.

This fix corrects the issue.

As a side effect, it also makes `reorder_items` and `get_values` throw an exception if a _tag_ (not a numeric UUID!) is passed in that does not exist (earlier they would silently skip this error). If a non-existent UUID is passed it, it's still silently skipped, because this is a different code branch and I didn't want to touch it.

**Concerning Areas:**
None.