### PR TITLE
Segfault on deletion of an item residing in the container stack

### DIFF
--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -2933,10 +2933,10 @@ pop_container_stack(PyObject* self, PyObject* args, PyObject* kwargs)
 		return nullptr;
 	}
 
-	mvAppItem* item = containers.top();
+	PyObject* top = ToPyUUIDOrNone(containers.top().get());
 	containers.pop();
 
-	return ToPyUUIDOrNone(item);
+	return top;
 
 }
 
@@ -2958,7 +2958,7 @@ top_container_stack(PyObject* self, PyObject* args, PyObject* kwargs)
 	mvAppItem* item = nullptr;
 	auto& containers = mvItemRegistry::threadContext.containers;
 	if (!containers.empty())
-		item = containers.top();
+		item = containers.top().get();
 
 	return ToPyUUIDOrNone(item);
 }
@@ -2999,7 +2999,7 @@ push_container_stack(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	mvUUID item = GetIDFromPyObject(itemraw);
 
-	mvAppItem* parent = GetItem((*GContext->itemRegistry), item);
+	auto parent = GetRefItem((*GContext->itemRegistry), item);
 	if (parent)
 	{
 		if (DearPyGui::GetEntityDesciptionFlags(parent->type) & MV_ITEM_DESC_CONTAINER)

--- a/src/mvItemRegistry.cpp
+++ b/src/mvItemRegistry.cpp
@@ -43,7 +43,7 @@ TopParent(mvItemRegistry& registry)
 {
 	auto& containers = mvItemRegistry::threadContext.containers;
     if (!containers.empty())
-        return containers.top();
+        return containers.top().get();
     return nullptr;
 }
 

--- a/src/mvItemRegistry.h
+++ b/src/mvItemRegistry.h
@@ -60,7 +60,7 @@ struct mvThreadContext
     mvUUID     lastContainerAdded = 0;
     mvUUID     lastRootAdded = 0;
 
-    std::stack<mvAppItem*>                  containers;      // parent stack, top of stack becomes widget's parent
+    std::stack<std::shared_ptr<mvAppItem>>  containers;      // parent stack, top of stack becomes widget's parent
 
     std::shared_ptr<mvAppItem>              capturedItem = nullptr;
     mvPyObject                              captureCallback = nullptr;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Segfault on deletion of an item residing in the container stack
assignees: @hoffstadt 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
The container stack stores raw `mvAppItem` pointers, which makes item deletion potentially unsafe. Of course nobody in their right mind would delete an item being in the container stack (because it's unclear what's expected of the stack then), but just in case someone does, DPG must handle it gracefully.

This PR changes the container stack to use `shared_ptr` and therefore prevents the segfault. If the item being deleted is still on the container stack, it will be destroyed once it's popped from the stack.

**Concerning Areas:**
None.