### PR TITLE
The "toggled open" handler can now fire on both "open" and "close" events

### DIFF
--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -335,7 +335,7 @@ def add_item_scroll_handler(*, label: str ='', user_data: Any ='', use_internal_
 	"""Adds a scroll handler."""
 	...
 
-def add_item_toggled_open_handler(*, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', parent: Union[int, str] ='', callback: Callable ='', show: bool ='') -> Union[int, str]:
+def add_item_toggled_open_handler(*, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', parent: Union[int, str] ='', callback: Callable ='', show: bool ='', two_way: bool ='') -> Union[int, str]:
 	"""Adds a togged open handler."""
 	...
 

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -96,7 +96,6 @@ def start_dearpygui():
 
     if not internal_dpg.is_viewport_ok():
         raise RuntimeError("Viewport was not created and shown.")
-        return
 
     while(internal_dpg.is_dearpygui_running()):
         internal_dpg.render_dearpygui_frame()   
@@ -5083,6 +5082,7 @@ def add_item_toggled_open_handler(**kwargs):
 		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
 		callback (Callable, optional): Registers a callback.
 		show (bool, optional): Attempt to render widget.
+		two_way (bool, optional): Trigger on both 'opened' and 'closed' events, i.e. when the 'opened' state is toggled between the two values. If False, some containers will trigger it only on the 'opened' event.
 		id (Union[int, str], optional): (deprecated)
 	Returns:
 		Union[int, str]

--- a/dearpygui/_header.py
+++ b/dearpygui/_header.py
@@ -80,7 +80,6 @@ def start_dearpygui():
 
     if not internal_dpg.is_viewport_ok():
         raise RuntimeError("Viewport was not created and shown.")
-        return
 
     while(internal_dpg.is_dearpygui_running()):
         internal_dpg.render_dearpygui_frame()   

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -96,7 +96,6 @@ def start_dearpygui():
 
     if not internal_dpg.is_viewport_ok():
         raise RuntimeError("Viewport was not created and shown.")
-        return
 
     while(internal_dpg.is_dearpygui_running()):
         internal_dpg.render_dearpygui_frame()   
@@ -5694,7 +5693,7 @@ def add_item_scroll_handler(*, label: str =None, user_data: Any =None, use_inter
 
 	return internal_dpg.add_item_scroll_handler(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, callback=callback, show=show, **kwargs)
 
-def add_item_toggled_open_handler(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, callback: Callable =None, show: bool =True, **kwargs) -> Union[int, str]:
+def add_item_toggled_open_handler(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, callback: Callable =None, show: bool =True, two_way: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds a togged open handler.
 
 	Args:
@@ -5705,6 +5704,7 @@ def add_item_toggled_open_handler(*, label: str =None, user_data: Any =None, use
 		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
 		callback (Callable, optional): Registers a callback.
 		show (bool, optional): Attempt to render widget.
+		two_way (bool, optional): Trigger on both 'opened' and 'closed' events, i.e. when the 'opened' state is toggled between the two values. If False, some containers will trigger it only on the 'opened' event.
 		id (Union[int, str], optional): (deprecated) 
 	Returns:
 		Union[int, str]
@@ -5714,7 +5714,7 @@ def add_item_toggled_open_handler(*, label: str =None, user_data: Any =None, use
 		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 		tag=kwargs['id']
 
-	return internal_dpg.add_item_toggled_open_handler(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, callback=callback, show=show, **kwargs)
+	return internal_dpg.add_item_toggled_open_handler(label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, callback=callback, show=show, two_way=two_way, **kwargs)
 
 def add_item_visible_handler(*, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, callback: Callable =None, show: bool =True, **kwargs) -> Union[int, str]:
 	"""	 Adds a visible handler.

--- a/dearpygui/demo.py
+++ b/dearpygui/demo.py
@@ -246,7 +246,7 @@ def show_demo():
 
                     with dpg.child_window(height=60, autosize_x=True):
                         for i in range(10):
-                            dpg.add_text(f"Scolling Text{i}")
+                            dpg.add_text(f"Scrolling Text{i}")
 
                     dpg.add_slider_float(label="Slider Float")
                     dpg.add_input_int(label="Input Int")

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -5066,6 +5066,8 @@ DearPyGui::GetEntityParser(mvAppItemType type)
             MV_PARSER_ARG_CALLBACK)
         );
 
+        args.push_back({ mvPyDataType::Bool, "two_way", mvArgType::KEYWORD_ARG, "False", "Trigger on both 'opened' and 'closed' events, i.e. when the 'opened' state is toggled between the two values. If False, some containers will trigger it only on the 'opened' event." });
+
         setup.about = "Adds a togged open handler.";
         setup.category = { "Widgets", "Events" };
         break;

--- a/src/mvAppItem.h
+++ b/src/mvAppItem.h
@@ -56,7 +56,7 @@ enum ItemDescriptionFlags
 enum class mvLibType
 {
     MV_IMGUI = 0,
-    OT = 1,
+    MV_IMPLOT = 1,
     MV_IMNODES = 2
 };
 

--- a/src/mvAppItemState.cpp
+++ b/src/mvAppItemState.cpp
@@ -26,7 +26,7 @@ ResetAppItemState(mvAppItemState& state)
     state.activated = false;
     state.deactivated = false;
     state.deactivatedAfterEdit = false;
-    state.toggledOpen = false;
+    state.toggledOpenPure = state.toggledOpen = false;
     state.mvRectSizeResized = false;
     state.scrolledX = state.scrolledY = false;
     state.isScrollingX = state.isScrollingY = false;
@@ -57,7 +57,7 @@ UpdateAppItemState(mvAppItemState& state)
     state.activated = ImGui::IsItemActivated();
     state.deactivated = ImGui::IsItemDeactivated();
     state.deactivatedAfterEdit = ImGui::IsItemDeactivatedAfterEdit();
-    state.toggledOpen = ImGui::IsItemToggledOpen();
+    state.toggledOpenPure = state.toggledOpen = ImGui::IsItemToggledOpen();
     state.rectMin = { ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y };
     state.rectMax = { ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y };
     state.rectSize = { ImGui::GetItemRectSize().x, ImGui::GetItemRectSize().y };

--- a/src/mvAppItemState.h
+++ b/src/mvAppItemState.h
@@ -85,6 +85,10 @@ struct mvAppItemState
     b8         deactivated          = false;
     b8         deactivatedAfterEdit = false;
     b8         toggledOpen          = false;
+    // This one is not reset by mvCollapsingHeader and mvTreeNode; also, not all items
+    // initialize it (but mvCollapsingHeader and mvTreeNode do, and they in fact are
+    // the only ones that must do it).  Used as an extra flag by the two-way toggled open handler.
+    b8         toggledOpenPure      = false;
     b8         mvRectSizeResized    = false;
     b8         scrolledX            = false;
     b8         scrolledY            = false;

--- a/src/mvItemHandlers.cpp
+++ b/src/mvItemHandlers.cpp
@@ -343,10 +343,26 @@ void mvResizeHandler::customAction(void* data)
 void mvToggledOpenHandler::customAction(void* data)
 {
 	mvAppItemState* state = static_cast<mvAppItemState*>(data);
-	if (state->toggledOpen)
+	if (state->toggledOpen || twoWay && state->toggledOpenPure)
 	{
 		submitHandler(state->parent);
 	}
+}
+
+void mvToggledOpenHandler::handleSpecificKeywordArgs(PyObject* dict)
+{
+	if (dict == nullptr)
+		return;
+
+	if (PyObject* item = PyDict_GetItemString(dict, "two_way")) twoWay = ToBool(item);
+}
+
+void mvToggledOpenHandler::getSpecificConfiguration(PyObject* dict)
+{
+	if (dict == nullptr)
+		return;
+
+	PyDict_SetItemString(dict, "two_way", mvPyObject(ToPyBool(twoWay)));
 }
 
 void mvVisibleHandler::customAction(void* data)

--- a/src/mvItemHandlers.h
+++ b/src/mvItemHandlers.h
@@ -149,6 +149,11 @@ public:
     explicit mvToggledOpenHandler(mvUUID uuid) : mvItemHandler(uuid) {}
     void draw(ImDrawList* drawlist, float x, float y) override {}
     void customAction(void* data = nullptr) override;
+    void handleSpecificKeywordArgs(PyObject* dict) override;
+    void getSpecificConfiguration(PyObject* dict) override;
+
+private:
+    bool twoWay = false;
 };
 
 class mvVisibleHandler : public mvItemHandler

--- a/src/mvPyUtils.h
+++ b/src/mvPyUtils.h
@@ -142,7 +142,7 @@ PyObject*   GetPyNoneOrError ();
 PyObject*   ToPyUUID  (mvUUID uuid, const std::string& alias);
 
 // Returns item UUID or alias, or zero if `item` is null.  An valid item can never
-// a UUID of zero, so it is a good value to designate a "no item" case (also can
+// have a UUID of zero, so it is a good value to designate a "no item" case (also can
 // easily be checked with `if (item)` in Python).
 PyObject*   ToPyUUID  (mvAppItem* item);
 

--- a/src/mvThemes.cpp
+++ b/src/mvThemes.cpp
@@ -135,7 +135,7 @@ void mvThemeColor::push_theme_color()
 	
 		ImGui::PushStyleColor(_targetColor, color);
 	}
-	else if (_libType == mvLibType::OT)
+	else if (_libType == mvLibType::MV_IMPLOT)
 		ImPlot::PushStyleColor(_targetColor, color);
 	else if (_libType == mvLibType::MV_IMNODES)
 		ImNodes::PushColorStyle(_targetColor, ImGui::ColorConvertFloat4ToU32(color));
@@ -145,7 +145,7 @@ void mvThemeColor::pop_theme_color()
 {
 	if (_libType == mvLibType::MV_IMGUI)
 		ImGui::PopStyleColor();
-	else if (_libType == mvLibType::OT)
+	else if (_libType == mvLibType::MV_IMPLOT)
 		ImPlot::PopStyleColor();
 	else if (_libType == mvLibType::MV_IMNODES)
 		ImNodes::PopColorStyle();
@@ -194,7 +194,7 @@ void mvThemeColor::handleSpecificKeywordArgs(PyObject* dict)
 		}
 	}
 
-	else if (_libType == mvLibType::OT)
+	else if (_libType == mvLibType::MV_IMPLOT)
 	{
 		if (_targetColor >= ImPlotCol_COUNT || _targetColor < 0)
 		{
@@ -548,7 +548,7 @@ void mvThemeStyle::push_theme_style()
 		else if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1)
 			ImGui::PushStyleVar(_targetStyle, (*_value)[0]);
 	}
-	else if (_libType == mvLibType::OT)
+	else if (_libType == mvLibType::MV_IMPLOT)
 	{
 		const mvGuiStyleVarInfo* var_info = GetPlotStyleVarInfo(_targetStyle);
 		if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1)
@@ -572,7 +572,7 @@ void mvThemeStyle::pop_theme_style()
 {
 	if (_libType == mvLibType::MV_IMGUI)
 		ImGui::PopStyleVar();
-	else if (_libType == mvLibType::OT)
+	else if (_libType == mvLibType::MV_IMPLOT)
 		ImPlot::PopStyleVar();
 	else if (_libType == mvLibType::MV_IMNODES)
 		ImNodes::PopStyleVar();
@@ -624,7 +624,7 @@ void mvThemeStyle::handleSpecificKeywordArgs(PyObject* dict)
 		}
 	}
 
-	else if (_libType == mvLibType::OT)
+	else if (_libType == mvLibType::MV_IMPLOT)
 	{
 		if (_targetStyle >= ImPlotStyleVar_COUNT || _targetStyle < 0)
 		{

--- a/src/mvThemes.h
+++ b/src/mvThemes.h
@@ -109,7 +109,7 @@ public:
 private:
 
     std::shared_ptr<std::array<float, 4>> _value = std::make_shared<std::array<float, 4>>(std::array<float, 4>{0.0f, -1.0f, 0.0f, 0.0f});
-    ImGuiCol _targetStyle = 0;
+    ImGuiStyleVar _targetStyle = 0;
     mvLibType _libType = mvLibType::MV_IMGUI;
 
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: The "toggled open" handler can now fire on both "open" and "close" events
assignees: @hoffstadt 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
This PR adds an option to `add_item_toggled_open_handler` to make the handler fire when the "open" state is toggled both from closed to open and vice versa, like it is in Dear ImGui. This allows the application to catch it when the user collapses a tree node or a collapsing header, and handle it as needed.

The new option effectively provides an opt-out from #1280.

This PR also fixes some typos in the codebase that I didn't want to put into a separate PR. None of them change DPG behavior.

**Concerning Areas:**
None.