### PR TITLE
feat: add option to disable trickle down event queue

### DIFF
--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -667,7 +667,7 @@ def clear_selected_nodes(node_editor : Union[int, str]) -> None:
 	"""Clears a node editor's selected nodes."""
 	...
 
-def configure_app(*, load_init_file: str ='', docking: bool ='', docking_space: bool ='', docking_shift_only: bool ='', init_file: str ='', auto_save_init_file: bool ='', device: int ='', auto_device: bool ='', allow_alias_overwrites: bool ='', manual_alias_management: bool ='', skip_required_args: bool ='', skip_positional_args: bool ='', skip_keyword_args: bool ='', wait_for_input: bool ='', manual_callback_management: bool ='', keyboard_navigation: bool ='', anti_aliased_lines: bool ='', anti_aliased_lines_use_tex: bool ='', anti_aliased_fill: bool ='', win32_alt_enter_fullscreen: bool ='', **kwargs) -> None:
+def configure_app(*, load_init_file: str ='', docking: bool ='', docking_space: bool ='', docking_shift_only: bool ='', init_file: str ='', auto_save_init_file: bool ='', device: int ='', auto_device: bool ='', allow_alias_overwrites: bool ='', manual_alias_management: bool ='', skip_required_args: bool ='', skip_positional_args: bool ='', skip_keyword_args: bool ='', wait_for_input: bool ='', manual_callback_management: bool ='', keyboard_navigation: bool ='', anti_aliased_lines: bool ='', anti_aliased_lines_use_tex: bool ='', anti_aliased_fill: bool ='', win32_alt_enter_fullscreen: bool ='', input_trickle_event_queue: bool ='', **kwargs) -> None:
 	"""Configures app."""
 	...
 

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -2739,6 +2739,9 @@ configure_app(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	if (PyObject* item = PyDict_GetItemString(kwargs, "win32_alt_enter_fullscreen")) GContext->IO.altEnterFullscreen = ToBool(item);
 
+	ImGuiIO& io = ImGui::GetIO();
+	if (PyObject* item = PyDict_GetItemString(kwargs, "input_trickle_event_queue")) io.ConfigInputTrickleEventQueue = ToBool(item);
+
 	return GetPyNone();
 }
 
@@ -2775,6 +2778,9 @@ get_app_configuration(PyObject* self, PyObject* args, PyObject* kwargs)
 	PyDict_SetItemString(pdict, "anti_aliased_fill", mvPyObject(ToPyBool(style.AntiAliasedFill)));
 
 	PyDict_SetItemString(pdict, "win32_alt_enter_fullscreen", mvPyObject(ToPyBool(GContext->IO.altEnterFullscreen)));
+
+	ImGuiIO& io = ImGui::GetIO();
+	PyDict_SetItemString(pdict, "input_trickle_event_queue", mvPyObject(ToPyBool(io.ConfigInputTrickleEventQueue)));
 
 	return pdict;
 }

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -539,6 +539,7 @@ InsertParser_Block1(std::map<std::string, mvPythonParser>& parsers)
 		args.push_back({ mvPyDataType::Bool, "anti_aliased_lines_use_tex", mvArgType::KEYWORD_ARG, "False", "Enable anti-aliased lines/borders using textures where possible. Require backend to render with bilinear filtering (NOT point/nearest filtering). Latched at the beginning of the frame." });
 		args.push_back({ mvPyDataType::Bool, "anti_aliased_fill", mvArgType::KEYWORD_ARG, "False", "Enable anti-aliased edges around filled shapes (rounded rectangles, circles, etc.). Disable if you are really tight on CPU/GPU. Latched at the beginning of the frame." });
 		args.push_back({ mvPyDataType::Bool, "win32_alt_enter_fullscreen", mvArgType::KEYWORD_ARG, "False", "Windows only: configures Alt+Enter as a fullscreen hotkey." });
+		args.push_back({ mvPyDataType::Bool, "input_trickle_event_queue", mvArgType::KEYWORD_ARG, "True", "Enable input event trickling: distributes rapid input events across multiple frames to prevent missed inputs at low framerates. Disable for high-frequency input devices like barcode scanners." });
 
 		mvPythonParserSetup setup;
 		setup.about = "Configures app.";


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: add option to disable trickle down event queue
assignees: @hoffstadt @v-ein 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**
This PR exposes Dear ImGui's io.ConfigInputTrickleEventQueue to the dearpygui python interface as a configure_app() option. This allows users to disable input event trickling.

Dear ImGui 1.87+ introduced event trickling (default: enabled), ([release notes](https://github.com/ocornut/imgui/releases/tag/v1.87)) which distributes rapid input events across multiple frames to prevent missed inputs at low framerates. However, this causes visible input lag with high-frequency input devices like barcode scanners — characters appear one-per-frame instead of all at once.

Note: Claude was used to find the source of the barcode input slowness and to implement the solution. The results were tested manually.

Closes #2633 

**Concerning Areas:**
- The default is unchanged (True), so existing behavior is unaffected.
- At very low framerates (<30fps) with trickling disabled, rapid key-down/key-up pairs within a single frame may be collapsed, causing missed inputs. This is the tradeoff ImGui documented when introducing the feature. At typical framerates (60fps+) this is not an issue.