### PR TITLE
Per-texture filter option for add_static_texture / add_dynamic_texture / add_raw_texture

### DIFF
--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -178,7 +178,7 @@ def add_drawlist(width : int, height : int, *, label: str ='', user_data: Any ='
 	"""Adds a drawing canvas."""
 	...
 
-def add_dynamic_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', parent: Union[int, str] ='') -> Union[int, str]:
+def add_dynamic_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', parent: Union[int, str] ='', filter: int ='') -> Union[int, str]:
 	"""Adds a dynamic texture."""
 	...
 
@@ -455,7 +455,7 @@ def add_radio_button(items : Union[List[str], Tuple[str, ...]] ='', *, label: st
 	"""Adds a set of radio buttons. If items keyword is empty, nothing will be shown."""
 	...
 
-def add_raw_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', format: int ='', parent: Union[int, str] ='') -> Union[int, str]:
+def add_raw_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', format: int ='', parent: Union[int, str] ='', filter: int ='') -> Union[int, str]:
 	"""Adds a raw texture."""
 	...
 
@@ -519,7 +519,7 @@ def add_stair_series(x : Union[List[float], Tuple[float, ...]], y : Union[List[f
 	"""Adds a stair series to a plot."""
 	...
 
-def add_static_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', parent: Union[int, str] ='') -> Union[int, str]:
+def add_static_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str ='', user_data: Any ='', use_internal_label: bool ='', tag: Union[int, str] ='', parent: Union[int, str] ='', filter: int ='') -> Union[int, str]:
 	"""Adds a static texture."""
 	...
 
@@ -1553,6 +1553,8 @@ mvTreeLines_Full=0
 mvTreeLines_ToNodes=0
 mvFormat_Float_rgba=0
 mvFormat_Float_rgb=0
+mvTextureFilter_Linear=0
+mvTextureFilter_Nearest=0
 mvThemeCat_Core=0
 mvThemeCat_Plots=0
 mvThemeCat_Nodes=0

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -4101,6 +4101,7 @@ def add_dynamic_texture(width, height, default_value, **kwargs):
 		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
 		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
 		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
+		filter (int, optional): Texture sampling mode (mvTextureFilter_Linear or mvTextureFilter_Nearest).
 		id (Union[int, str], optional): (deprecated)
 	Returns:
 		Union[int, str]
@@ -5853,6 +5854,7 @@ def add_raw_texture(width, height, default_value, **kwargs):
 		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
 		format (int, optional): Data format.
 		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
+		filter (int, optional): Texture sampling mode (mvTextureFilter_Linear or mvTextureFilter_Nearest).
 		id (Union[int, str], optional): (deprecated)
 	Returns:
 		Union[int, str]
@@ -6308,6 +6310,7 @@ def add_static_texture(width, height, default_value, **kwargs):
 		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
 		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
 		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
+		filter (int, optional): Texture sampling mode (mvTextureFilter_Linear or mvTextureFilter_Nearest).
 		id (Union[int, str], optional): (deprecated)
 	Returns:
 		Union[int, str]
@@ -9218,6 +9221,8 @@ mvTreeLines_Full=internal_dpg.mvTreeLines_Full
 mvTreeLines_ToNodes=internal_dpg.mvTreeLines_ToNodes
 mvFormat_Float_rgba=internal_dpg.mvFormat_Float_rgba
 mvFormat_Float_rgb=internal_dpg.mvFormat_Float_rgb
+mvTextureFilter_Linear=internal_dpg.mvTextureFilter_Linear
+mvTextureFilter_Nearest=internal_dpg.mvTextureFilter_Nearest
 mvThemeCat_Core=internal_dpg.mvThemeCat_Core
 mvThemeCat_Plots=internal_dpg.mvThemeCat_Plots
 mvThemeCat_Nodes=internal_dpg.mvThemeCat_Nodes

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -4536,7 +4536,7 @@ def add_drawlist(width : int, height : int, *, label: str =None, user_data: Any 
 
 	return internal_dpg.add_drawlist(width, height, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, before=before, callback=callback, show=show, pos=pos, filter_key=filter_key, tracked=tracked, track_offset=track_offset, **kwargs)
 
-def add_dynamic_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =internal_dpg.mvReservedUUID_2, **kwargs) -> Union[int, str]:
+def add_dynamic_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =internal_dpg.mvReservedUUID_2, filter: int =0, **kwargs) -> Union[int, str]:
 	"""	 Adds a dynamic texture.
 
 	Args:
@@ -4548,6 +4548,7 @@ def add_dynamic_texture(width : int, height : int, default_value : Union[List[fl
 		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
 		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
 		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
+		filter (int, optional): Texture sampling mode (mvTextureFilter_Linear or mvTextureFilter_Nearest).
 		id (Union[int, str], optional): (deprecated) 
 	Returns:
 		Union[int, str]
@@ -4557,7 +4558,7 @@ def add_dynamic_texture(width : int, height : int, default_value : Union[List[fl
 		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 		tag=kwargs['id']
 
-	return internal_dpg.add_dynamic_texture(width, height, default_value, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, **kwargs)
+	return internal_dpg.add_dynamic_texture(width, height, default_value, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, filter=filter, **kwargs)
 
 def add_error_series(x : Union[List[float], Tuple[float, ...]], y : Union[List[float], Tuple[float, ...]], negative : Union[List[float], Tuple[float, ...]], positive : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, source: Union[int, str] =0, show: bool =True, contribute_to_bounds: bool =True, horizontal: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds an error series to a plot.
@@ -6639,7 +6640,7 @@ def add_radio_button(items : Union[List[str], Tuple[str, ...]] =(), *, label: st
 
 	return internal_dpg.add_radio_button(items, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, indent=indent, parent=parent, before=before, source=source, payload_type=payload_type, callback=callback, drag_callback=drag_callback, drop_callback=drop_callback, show=show, enabled=enabled, pos=pos, filter_key=filter_key, tracked=tracked, track_offset=track_offset, default_value=default_value, horizontal=horizontal, **kwargs)
 
-def add_raw_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, format: int =internal_dpg.mvFormat_Float_rgba, parent: Union[int, str] =internal_dpg.mvReservedUUID_2, **kwargs) -> Union[int, str]:
+def add_raw_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, format: int =internal_dpg.mvFormat_Float_rgba, parent: Union[int, str] =internal_dpg.mvReservedUUID_2, filter: int =0, **kwargs) -> Union[int, str]:
 	"""	 Adds a raw texture.
 
 	Args:
@@ -6652,6 +6653,7 @@ def add_raw_texture(width : int, height : int, default_value : Union[List[float]
 		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
 		format (int, optional): Data format.
 		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
+		filter (int, optional): Texture sampling mode (mvTextureFilter_Linear or mvTextureFilter_Nearest).
 		id (Union[int, str], optional): (deprecated) 
 	Returns:
 		Union[int, str]
@@ -6661,7 +6663,7 @@ def add_raw_texture(width : int, height : int, default_value : Union[List[float]
 		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 		tag=kwargs['id']
 
-	return internal_dpg.add_raw_texture(width, height, default_value, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, format=format, parent=parent, **kwargs)
+	return internal_dpg.add_raw_texture(width, height, default_value, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, format=format, parent=parent, filter=filter, **kwargs)
 
 def add_scatter_series(x : Union[List[float], Tuple[float, ...]], y : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =0, before: Union[int, str] =0, source: Union[int, str] =0, show: bool =True, no_clip: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds a scatter series to a plot.
@@ -7159,7 +7161,7 @@ def add_stair_series(x : Union[List[float], Tuple[float, ...]], y : Union[List[f
 
 	return internal_dpg.add_stair_series(x, y, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, before=before, source=source, show=show, pre_step=pre_step, shaded=shaded, **kwargs)
 
-def add_static_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =internal_dpg.mvReservedUUID_2, **kwargs) -> Union[int, str]:
+def add_static_texture(width : int, height : int, default_value : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, parent: Union[int, str] =internal_dpg.mvReservedUUID_2, filter: int =0, **kwargs) -> Union[int, str]:
 	"""	 Adds a static texture.
 
 	Args:
@@ -7171,6 +7173,7 @@ def add_static_texture(width : int, height : int, default_value : Union[List[flo
 		use_internal_label (bool, optional): Use generated internal label instead of user specified (appends ### uuid).
 		tag (Union[int, str], optional): Unique id used to programmatically refer to the item.If label is unused this will be the label.
 		parent (Union[int, str], optional): Parent to add this item to. (runtime adding)
+		filter (int, optional): Texture sampling mode (mvTextureFilter_Linear or mvTextureFilter_Nearest).
 		id (Union[int, str], optional): (deprecated) 
 	Returns:
 		Union[int, str]
@@ -7180,7 +7183,7 @@ def add_static_texture(width : int, height : int, default_value : Union[List[flo
 		warnings.warn('id keyword renamed to tag', DeprecationWarning, 2)
 		tag=kwargs['id']
 
-	return internal_dpg.add_static_texture(width, height, default_value, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, **kwargs)
+	return internal_dpg.add_static_texture(width, height, default_value, label=label, user_data=user_data, use_internal_label=use_internal_label, tag=tag, parent=parent, filter=filter, **kwargs)
 
 def add_stem_series(x : Union[List[float], Tuple[float, ...]], y : Union[List[float], Tuple[float, ...]], *, label: str =None, user_data: Any =None, use_internal_label: bool =True, tag: Union[int, str] =0, indent: int =-1, parent: Union[int, str] =0, before: Union[int, str] =0, source: Union[int, str] =0, show: bool =True, horizontal: bool =False, **kwargs) -> Union[int, str]:
 	"""	 Adds a stem series to a plot.
@@ -10311,6 +10314,8 @@ mvTreeLines_Full=internal_dpg.mvTreeLines_Full
 mvTreeLines_ToNodes=internal_dpg.mvTreeLines_ToNodes
 mvFormat_Float_rgba=internal_dpg.mvFormat_Float_rgba
 mvFormat_Float_rgb=internal_dpg.mvFormat_Float_rgb
+mvTextureFilter_Linear=internal_dpg.mvTextureFilter_Linear
+mvTextureFilter_Nearest=internal_dpg.mvTextureFilter_Nearest
 mvThemeCat_Core=internal_dpg.mvThemeCat_Core
 mvThemeCat_Plots=internal_dpg.mvThemeCat_Plots
 mvThemeCat_Nodes=internal_dpg.mvThemeCat_Nodes

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -229,6 +229,9 @@ GetModuleConstants()
 		ModuleConstants.push_back({ "mvFormat_Float_rgba", 0L });
 		ModuleConstants.push_back({ "mvFormat_Float_rgb", 1L });
 
+		ModuleConstants.push_back({ "mvTextureFilter_Linear", 0L });
+		ModuleConstants.push_back({ "mvTextureFilter_Nearest", 1L });
+
 		ModuleConstants.push_back({ "mvThemeCat_Core", 0L });
 		ModuleConstants.push_back({ "mvThemeCat_Plots", 1L});
 		ModuleConstants.push_back({ "mvThemeCat_Nodes", 2L});

--- a/src/dearpygui.cpp
+++ b/src/dearpygui.cpp
@@ -229,8 +229,8 @@ GetModuleConstants()
 		ModuleConstants.push_back({ "mvFormat_Float_rgba", 0L });
 		ModuleConstants.push_back({ "mvFormat_Float_rgb", 1L });
 
-		ModuleConstants.push_back({ "mvTextureFilter_Linear", 0L });
-		ModuleConstants.push_back({ "mvTextureFilter_Nearest", 1L });
+		ModuleConstants.push_back({ "mvTextureFilter_Linear",  mvTextureFilter_Linear });
+		ModuleConstants.push_back({ "mvTextureFilter_Nearest", mvTextureFilter_Nearest });
 
 		ModuleConstants.push_back({ "mvThemeCat_Core", 0L });
 		ModuleConstants.push_back({ "mvThemeCat_Plots", 1L});

--- a/src/mvAppItem.cpp
+++ b/src/mvAppItem.cpp
@@ -4636,7 +4636,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         setup.createContextManager = true;
         break;
     }
-    case mvAppItemType::mvStaticTexture:               
+    case mvAppItemType::mvStaticTexture:
     {
         AddCommonArgs(args, (CommonParserArgs)(
             MV_PARSER_ARG_ID)
@@ -4646,12 +4646,13 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         args.push_back({ mvPyDataType::Integer, "height" });
         args.push_back({ mvPyDataType::FloatList, "default_value" });
         args.push_back({ mvPyDataType::UUID, "parent", mvArgType::KEYWORD_ARG, "internal_dpg.mvReservedUUID_2", "Parent to add this item to. (runtime adding)" });
+        args.push_back({ mvPyDataType::Integer, "filter", mvArgType::KEYWORD_ARG, "0", "Texture sampling mode (mvTextureFilter_Linear or mvTextureFilter_Nearest)." });
 
         setup.about = "Adds a static texture.";
         setup.category = { "Textures", "Widgets" };
         break;
     }
-    case mvAppItemType::mvDynamicTexture:              
+    case mvAppItemType::mvDynamicTexture:
     {
         AddCommonArgs(args, (CommonParserArgs)(
             MV_PARSER_ARG_ID)
@@ -4661,6 +4662,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         args.push_back({ mvPyDataType::Integer, "height" });
         args.push_back({ mvPyDataType::FloatList, "default_value" });
         args.push_back({ mvPyDataType::UUID, "parent", mvArgType::KEYWORD_ARG, "internal_dpg.mvReservedUUID_2", "Parent to add this item to. (runtime adding)" });
+        args.push_back({ mvPyDataType::Integer, "filter", mvArgType::KEYWORD_ARG, "0", "Texture sampling mode (mvTextureFilter_Linear or mvTextureFilter_Nearest)." });
 
         setup.about = "Adds a dynamic texture.";
         setup.category = { "Textures", "Widgets" };
@@ -5414,7 +5416,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         setup.category = { "Widgets", "Values" };
         break;
     }
-    case mvAppItemType::mvRawTexture:                  
+    case mvAppItemType::mvRawTexture:
     {
         AddCommonArgs(args, (CommonParserArgs)(
             MV_PARSER_ARG_ID)
@@ -5425,6 +5427,7 @@ DearPyGui::GetEntityParser(mvAppItemType type)
         args.push_back({ mvPyDataType::FloatList, "default_value" });
         args.push_back({ mvPyDataType::Integer, "format", mvArgType::KEYWORD_ARG, "internal_dpg.mvFormat_Float_rgba", "Data format." });
         args.push_back({ mvPyDataType::UUID, "parent", mvArgType::KEYWORD_ARG, "internal_dpg.mvReservedUUID_2", "Parent to add this item to. (runtime adding)" });
+        args.push_back({ mvPyDataType::Integer, "filter", mvArgType::KEYWORD_ARG, "0", "Texture sampling mode (mvTextureFilter_Linear or mvTextureFilter_Nearest)." });
 
         setup.about = "Adds a raw texture.";
         setup.category = { "Textures", "Widgets" };

--- a/src/mvAppleSpecifics.h
+++ b/src/mvAppleSpecifics.h
@@ -16,7 +16,11 @@ struct mvViewportData
 
 struct mvGraphics_Metal
 {
-    MTLRenderPassDescriptor* renderPassDescriptor;
-    id <MTLCommandQueue>     commandQueue;
-    id <MTLDevice>           device;
+    MTLRenderPassDescriptor*      renderPassDescriptor;
+    id <MTLCommandQueue>          commandQueue;
+    id <MTLDevice>                device;
+
+    id <MTLRenderPipelineState>   nearestPipelineState;
+    id <MTLSamplerState>          nearestSampler;
+    id <MTLRenderCommandEncoder> __unsafe_unretained currentEncoder;
 };

--- a/src/mvBasicWidgets.cpp
+++ b/src/mvBasicWidgets.cpp
@@ -5605,7 +5605,7 @@ DearPyGui::draw_image(ImDrawList* drawlist, mvAppItem& item, mvImageConfig& conf
 				ImGuiContext& g = *GImGui;
 				ImGui::PushStyleVar(ImGuiStyleVar_ImageBorderSize, (config.borderColor.a > 0.0f) ? ImMax(1.0f, g.Style.ImageBorderSize) : 0.0f);
 				ImGui::PushStyleColor(ImGuiCol_Border, config.borderColor.toVec4());
-				const bool wantNearest = (static_cast<mvTextureItem*>(config.texture.get())->_filter == 1);
+				const bool wantNearest = (static_cast<mvTextureItem*>(config.texture.get())->_filter == mvTextureFilter_Nearest);
 				ImDrawList* windowDrawList = wantNearest ? ImGui::GetWindowDrawList() : nullptr;
 				if (wantNearest) EnterNearestFilterScope(windowDrawList);
 				ImGui::ImageWithBg(
@@ -5722,7 +5722,7 @@ DearPyGui::draw_image_button(ImDrawList* drawlist, mvAppItem& item, mvImageButto
 				if (config.framePadding >= 0)
 					ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2((float)config.framePadding, (float)config.framePadding));
 
-				const bool wantNearest = (static_cast<mvTextureItem*>(config.texture.get())->_filter == 1);
+				const bool wantNearest = (static_cast<mvTextureItem*>(config.texture.get())->_filter == mvTextureFilter_Nearest);
 				ImDrawList* windowDrawList = wantNearest ? ImGui::GetWindowDrawList() : nullptr;
 				if (wantNearest) EnterNearestFilterScope(windowDrawList);
 				if (ImGui::ImageButton(item.info.internalLabel.c_str(), texture, ImVec2((float)item.config.width, (float)item.config.height),

--- a/src/mvBasicWidgets.cpp
+++ b/src/mvBasicWidgets.cpp
@@ -8,6 +8,7 @@
 #include "mvContainers.h"
 #include "mvItemHandlers.h"
 #include "mvTextureItems.h"
+#include "mvUtilities.h"
 
 #include <misc/cpp/imgui_stdlib.h>
 #include <imgui_internal.h>
@@ -5604,6 +5605,9 @@ DearPyGui::draw_image(ImDrawList* drawlist, mvAppItem& item, mvImageConfig& conf
 				ImGuiContext& g = *GImGui;
 				ImGui::PushStyleVar(ImGuiStyleVar_ImageBorderSize, (config.borderColor.a > 0.0f) ? ImMax(1.0f, g.Style.ImageBorderSize) : 0.0f);
 				ImGui::PushStyleColor(ImGuiCol_Border, config.borderColor.toVec4());
+				const bool wantNearest = (static_cast<mvTextureItem*>(config.texture.get())->_filter == 1);
+				ImDrawList* windowDrawList = wantNearest ? ImGui::GetWindowDrawList() : nullptr;
+				if (wantNearest) EnterNearestFilterScope(windowDrawList);
 				ImGui::ImageWithBg(
 					texture,
 					ImVec2((float)item.config.width, (float)item.config.height),
@@ -5611,6 +5615,7 @@ DearPyGui::draw_image(ImDrawList* drawlist, mvAppItem& item, mvImageConfig& conf
 					ImVec2(config.uv_max.x, config.uv_max.y),
 					ImVec4(0, 0, 0, 0),
 					config.tintColor.toVec4());
+				if (wantNearest) LeaveNearestFilterScope(windowDrawList);
 				ImGui::PopStyleColor();
 				ImGui::PopStyleVar();
 			}
@@ -5717,12 +5722,16 @@ DearPyGui::draw_image_button(ImDrawList* drawlist, mvAppItem& item, mvImageButto
 				if (config.framePadding >= 0)
 					ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2((float)config.framePadding, (float)config.framePadding));
 
+				const bool wantNearest = (static_cast<mvTextureItem*>(config.texture.get())->_filter == 1);
+				ImDrawList* windowDrawList = wantNearest ? ImGui::GetWindowDrawList() : nullptr;
+				if (wantNearest) EnterNearestFilterScope(windowDrawList);
 				if (ImGui::ImageButton(item.info.internalLabel.c_str(), texture, ImVec2((float)item.config.width, (float)item.config.height),
 					ImVec2(config.uv_min.x, config.uv_min.y), ImVec2(config.uv_max.x, config.uv_max.y),
 					config.backgroundColor, config.tintColor))
 				{
 					item.submitCallback();
 				}
+				if (wantNearest) LeaveNearestFilterScope(windowDrawList);
 
 				if (config.framePadding >= 0)
 					ImGui::PopStyleVar();

--- a/src/mvDrawings.cpp
+++ b/src/mvDrawings.cpp
@@ -562,7 +562,7 @@ void mvDrawImage::draw(ImDrawList* drawlist, float x, float y)
 			if (mvClipPoint(drawInfo->clipViewport, tpmax)) return;
 		}
 
-		const bool wantNearest = (static_cast<mvTextureItem*>(_texture.get())->_filter == 1);
+		const bool wantNearest = (static_cast<mvTextureItem*>(_texture.get())->_filter == mvTextureFilter_Nearest);
 		if (wantNearest) EnterNearestFilterScope(drawlist);
 		if (ImPlot::GetCurrentContext()->CurrentPlot)
 			drawlist->AddImage(texture, ImPlot::PlotToPixels(tpmin), ImPlot::PlotToPixels(tpmax), _uv_min, _uv_max, _color);
@@ -683,7 +683,7 @@ void mvDrawImageQuad::draw(ImDrawList* drawlist, float x, float y)
 			if (mvClipPoint(drawInfo->clipViewport, tp4)) return;
 		}
 
-		const bool wantNearest = (static_cast<mvTextureItem*>(_texture.get())->_filter == 1);
+		const bool wantNearest = (static_cast<mvTextureItem*>(_texture.get())->_filter == mvTextureFilter_Nearest);
 		if (wantNearest) EnterNearestFilterScope(drawlist);
 		if (ImPlot::GetCurrentContext()->CurrentPlot)
 			drawlist->AddImageQuad(texture, ImPlot::PlotToPixels(tp1),

--- a/src/mvDrawings.cpp
+++ b/src/mvDrawings.cpp
@@ -8,6 +8,7 @@
 #include "mvFontItems.h"
 #include "mvItemHandlers.h"
 #include "mvTextureItems.h"
+#include "mvUtilities.h"
 #include "mvCustomTypes.h"
 
 #include <math.h>
@@ -561,6 +562,8 @@ void mvDrawImage::draw(ImDrawList* drawlist, float x, float y)
 			if (mvClipPoint(drawInfo->clipViewport, tpmax)) return;
 		}
 
+		const bool wantNearest = (static_cast<mvTextureItem*>(_texture.get())->_filter == 1);
+		if (wantNearest) EnterNearestFilterScope(drawlist);
 		if (ImPlot::GetCurrentContext()->CurrentPlot)
 			drawlist->AddImage(texture, ImPlot::PlotToPixels(tpmin), ImPlot::PlotToPixels(tpmax), _uv_min, _uv_max, _color);
 		else
@@ -568,6 +571,7 @@ void mvDrawImage::draw(ImDrawList* drawlist, float x, float y)
 			mvVec2 start = { x, y };
 			drawlist->AddImage(texture, tpmin + start, tpmax + start, _uv_min, _uv_max, _color);
 		}
+		if (wantNearest) LeaveNearestFilterScope(drawlist);
 	}
 }
 
@@ -679,6 +683,8 @@ void mvDrawImageQuad::draw(ImDrawList* drawlist, float x, float y)
 			if (mvClipPoint(drawInfo->clipViewport, tp4)) return;
 		}
 
+		const bool wantNearest = (static_cast<mvTextureItem*>(_texture.get())->_filter == 1);
+		if (wantNearest) EnterNearestFilterScope(drawlist);
 		if (ImPlot::GetCurrentContext()->CurrentPlot)
 			drawlist->AddImageQuad(texture, ImPlot::PlotToPixels(tp1),
 				ImPlot::PlotToPixels(tp2), ImPlot::PlotToPixels(tp3), ImPlot::PlotToPixels(tp4),
@@ -688,6 +694,7 @@ void mvDrawImageQuad::draw(ImDrawList* drawlist, float x, float y)
 			mvVec2 start = { x, y };
 			drawlist->AddImageQuad(texture, tp1 + start, tp2 + start, tp3 + start, tp4 + start, _uv1, _uv2, _uv3, _uv4, _color);
 		}
+		if (wantNearest) LeaveNearestFilterScope(drawlist);
 	}
 }
 

--- a/src/mvGraphics_apple.mm
+++ b/src/mvGraphics_apple.mm
@@ -7,6 +7,106 @@
 #include "imgui_impl_glfw.h"
 #include "imgui_impl_metal.h"
 
+static void
+BuildNearestFilterMetalState(mvGraphics_Metal* graphicsData, MTLPixelFormat colorPixelFormat)
+{
+    MTLSamplerDescriptor* samplerDesc = [MTLSamplerDescriptor new];
+    samplerDesc.minFilter    = MTLSamplerMinMagFilterNearest;
+    samplerDesc.magFilter    = MTLSamplerMinMagFilterNearest;
+    samplerDesc.mipFilter    = MTLSamplerMipFilterNearest;
+    samplerDesc.sAddressMode = MTLSamplerAddressModeClampToEdge;
+    samplerDesc.tAddressMode = MTLSamplerAddressModeClampToEdge;
+    samplerDesc.rAddressMode = MTLSamplerAddressModeClampToEdge;
+    graphicsData->nearestSampler = [graphicsData->device newSamplerStateWithDescriptor:samplerDesc];
+
+    // Mirrors imgui_impl_metal.mm's shader with a bindable sampler.
+    NSString* shaderSource = @""
+    "#include <metal_stdlib>\n"
+    "using namespace metal;\n"
+    "\n"
+    "struct Uniforms { float4x4 projectionMatrix; };\n"
+    "\n"
+    "struct VertexIn {\n"
+    "    float2 position  [[attribute(0)]];\n"
+    "    float2 texCoords [[attribute(1)]];\n"
+    "    uchar4 color     [[attribute(2)]];\n"
+    "};\n"
+    "\n"
+    "struct VertexOut {\n"
+    "    float4 position [[position]];\n"
+    "    float2 texCoords;\n"
+    "    float4 color;\n"
+    "};\n"
+    "\n"
+    "vertex VertexOut dpg_vertex_main(VertexIn in                 [[stage_in]],\n"
+    "                                 constant Uniforms &uniforms [[buffer(1)]]) {\n"
+    "    VertexOut out;\n"
+    "    out.position = uniforms.projectionMatrix * float4(in.position, 0, 1);\n"
+    "    out.texCoords = in.texCoords;\n"
+    "    out.color = float4(in.color) / float4(255.0);\n"
+    "    return out;\n"
+    "}\n"
+    "\n"
+    "fragment half4 dpg_fragment_main(VertexOut in [[stage_in]],\n"
+    "                                 texture2d<half, access::sample> texture [[texture(0)]],\n"
+    "                                 sampler textureSampler [[sampler(0)]]) {\n"
+    "    half4 texColor = texture.sample(textureSampler, in.texCoords);\n"
+    "    return half4(in.color) * texColor;\n"
+    "}\n";
+
+    NSError* error = nil;
+    id<MTLLibrary> library = [graphicsData->device newLibraryWithSource:shaderSource options:nil error:&error];
+    if (library == nil)
+    {
+        NSLog(@"DPG: failed to compile nearest-filter Metal library: %@", error);
+        return;
+    }
+
+    id<MTLFunction> vertexFunction   = [library newFunctionWithName:@"dpg_vertex_main"];
+    id<MTLFunction> fragmentFunction = [library newFunctionWithName:@"dpg_fragment_main"];
+    if (!vertexFunction || !fragmentFunction)
+    {
+        NSLog(@"DPG: failed to resolve nearest-filter Metal functions");
+        return;
+    }
+
+    MTLVertexDescriptor* vertexDescriptor = [MTLVertexDescriptor vertexDescriptor];
+    vertexDescriptor.attributes[0].offset      = offsetof(ImDrawVert, pos);
+    vertexDescriptor.attributes[0].format      = MTLVertexFormatFloat2;
+    vertexDescriptor.attributes[0].bufferIndex = 0;
+    vertexDescriptor.attributes[1].offset      = offsetof(ImDrawVert, uv);
+    vertexDescriptor.attributes[1].format      = MTLVertexFormatFloat2;
+    vertexDescriptor.attributes[1].bufferIndex = 0;
+    vertexDescriptor.attributes[2].offset      = offsetof(ImDrawVert, col);
+    vertexDescriptor.attributes[2].format      = MTLVertexFormatUChar4;
+    vertexDescriptor.attributes[2].bufferIndex = 0;
+    vertexDescriptor.layouts[0].stepRate      = 1;
+    vertexDescriptor.layouts[0].stepFunction  = MTLVertexStepFunctionPerVertex;
+    vertexDescriptor.layouts[0].stride        = sizeof(ImDrawVert);
+
+    MTLRenderPipelineDescriptor* pipelineDescriptor = [[MTLRenderPipelineDescriptor alloc] init];
+    pipelineDescriptor.vertexFunction   = vertexFunction;
+    pipelineDescriptor.fragmentFunction = fragmentFunction;
+    pipelineDescriptor.vertexDescriptor = vertexDescriptor;
+    pipelineDescriptor.rasterSampleCount                         = 1;
+    pipelineDescriptor.colorAttachments[0].pixelFormat           = colorPixelFormat;
+    pipelineDescriptor.colorAttachments[0].blendingEnabled       = YES;
+    pipelineDescriptor.colorAttachments[0].rgbBlendOperation     = MTLBlendOperationAdd;
+    pipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor  = MTLBlendFactorSourceAlpha;
+    pipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+    pipelineDescriptor.colorAttachments[0].alphaBlendOperation   = MTLBlendOperationAdd;
+    pipelineDescriptor.colorAttachments[0].sourceAlphaBlendFactor= MTLBlendFactorOne;
+    pipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+    pipelineDescriptor.depthAttachmentPixelFormat   = MTLPixelFormatInvalid;
+    pipelineDescriptor.stencilAttachmentPixelFormat = MTLPixelFormatInvalid;
+
+    graphicsData->nearestPipelineState = [graphicsData->device newRenderPipelineStateWithDescriptor:pipelineDescriptor error:&error];
+    if (error != nil)
+        NSLog(@"DPG: failed to create nearest-filter pipeline state: %@", error);
+
+    static_assert(sizeof(ImDrawVert) == 20, "ImDrawVert layout changed; update DPG nearest-filter pipeline");
+}
+
 mvGraphics
 setup_graphics(mvViewport &viewport)
 {
@@ -29,6 +129,8 @@ setup_graphics(mvViewport &viewport)
     nswin.contentView.wantsLayer = YES;
 
     graphicsData->renderPassDescriptor = [MTLRenderPassDescriptor new];
+
+    BuildNearestFilterMetalState(graphicsData, viewportData->layer.pixelFormat);
 
     return graphics;
 }

--- a/src/mvGraphics_win32.cpp
+++ b/src/mvGraphics_win32.cpp
@@ -124,6 +124,16 @@ setup_graphics(mvViewport& viewport)
 
 	ImGui_ImplDX11_Init(graphicsData->device, graphicsData->deviceContext);
 
+	{
+		D3D11_SAMPLER_DESC desc;
+		ZeroMemory(&desc, sizeof(desc));
+		desc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+		desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+		desc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+		desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+		graphicsData->device->CreateSamplerState(&desc, &graphicsData->pTexSamplerNearest);
+	}
+
 	return graphics;
 }
 
@@ -133,6 +143,12 @@ cleanup_graphics(mvGraphics& graphics)
 	mvGraphics_D3D11* graphicsData = (mvGraphics_D3D11*)graphics.backendSpecifics;
 
 	ImGui_ImplDX11_Shutdown();
+
+	if (graphicsData->pTexSamplerNearest)
+	{
+		graphicsData->pTexSamplerNearest->Release();
+		graphicsData->pTexSamplerNearest = nullptr;
+	}
 
 	if (graphicsData->target)
 	{

--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -10,6 +10,7 @@
 #include "mvThemes.h"
 #include "mvContainers.h"
 #include "mvTextureItems.h"
+#include "mvUtilities.h"
 #include "mvItemHandlers.h"
 
 #include <utility>
@@ -1934,7 +1935,11 @@ DearPyGui::draw_image_series(ImDrawList* drawlist, mvAppItem& item, mvImageSerie
 				// ImTextureRef texture = static_cast<mvTextureItem*>(config._texture.get())->getTexRef();
 				ImTextureID texture = static_cast<mvTextureItem*>(config._texture.get())->_texture;
 
+				const bool wantNearest = (static_cast<mvTextureItem*>(config._texture.get())->_filter == 1);
+				ImDrawList* plotDrawList = wantNearest ? ImPlot::GetPlotDrawList() : nullptr;
+				if (wantNearest) EnterNearestFilterScope(plotDrawList);
 				ImPlot::PlotImage(item.info.internalLabel.c_str(), texture, config.bounds_min, config.bounds_max, config.uv_min, config.uv_max, config.tintColor, config.flags);
+				if (wantNearest) LeaveNearestFilterScope(plotDrawList);
 
 				// Begin a popup for a legend entry.
 				if (ImPlot::BeginLegendPopup(item.info.internalLabel.c_str(), 1))

--- a/src/mvPlotting.cpp
+++ b/src/mvPlotting.cpp
@@ -1935,7 +1935,7 @@ DearPyGui::draw_image_series(ImDrawList* drawlist, mvAppItem& item, mvImageSerie
 				// ImTextureRef texture = static_cast<mvTextureItem*>(config._texture.get())->getTexRef();
 				ImTextureID texture = static_cast<mvTextureItem*>(config._texture.get())->_texture;
 
-				const bool wantNearest = (static_cast<mvTextureItem*>(config._texture.get())->_filter == 1);
+				const bool wantNearest = (static_cast<mvTextureItem*>(config._texture.get())->_filter == mvTextureFilter_Nearest);
 				ImDrawList* plotDrawList = wantNearest ? ImPlot::GetPlotDrawList() : nullptr;
 				if (wantNearest) EnterNearestFilterScope(plotDrawList);
 				ImPlot::PlotImage(item.info.internalLabel.c_str(), texture, config.bounds_min, config.bounds_max, config.uv_min, config.uv_max, config.tintColor, config.flags);

--- a/src/mvTextureItems.cpp
+++ b/src/mvTextureItems.cpp
@@ -163,7 +163,14 @@ void mvDynamicTexture::draw(ImDrawList* drawlist, float x, float y)
 			state.ok = false;
 
 		_dirty = false;
+		_filterDirty = false;
 		return;
+	}
+
+	if (_filterDirty && _texture != ImTextureID_Invalid)
+	{
+		ApplyTextureFilter(_texture, _filter);
+		_filterDirty = false;
 	}
 
 	UpdateTexture(_texture, _permWidth, _permHeight, *_value);
@@ -188,13 +195,22 @@ void mvDynamicTexture::handleSpecificKeywordArgs(PyObject* dict)
 		return;
 
 	if (PyObject* item = PyDict_GetItemString(dict, "filter"))
-		_filter = ToInt(item);
+	{
+		const int v = ToInt(item);
+		if (v != _filter)
+		{
+			_filter = v;
+			_filterDirty = true;
+		}
+	}
 }
 
 void mvDynamicTexture::getSpecificConfiguration(PyObject* dict)
 {
 	if (dict == nullptr)
 		return;
+
+	PyDict_SetItemString(dict, "filter", mvPyObject(ToPyInt(_filter)));
 }
 
 PyObject* mvRawTexture::getPyValue()
@@ -241,7 +257,14 @@ void mvRawTexture::draw(ImDrawList* drawlist, float x, float y)
 			state.ok = false;
 
 		_dirty = false;
+		_filterDirty = false;
 		return;
+	}
+
+	if (_filterDirty && _texture != ImTextureID_Invalid)
+	{
+		ApplyTextureFilter(_texture, _filter);
+		_filterDirty = false;
 	}
 
 	if (_componentType == ComponentType::MV_FLOAT_COMPONENT)
@@ -285,13 +308,22 @@ void mvRawTexture::handleSpecificKeywordArgs(PyObject* dict)
 	}
 
 	if (PyObject* item = PyDict_GetItemString(dict, "filter"))
-		_filter = ToInt(item);
+	{
+		const int v = ToInt(item);
+		if (v != _filter)
+		{
+			_filter = v;
+			_filterDirty = true;
+		}
+	}
 }
 
 void mvRawTexture::getSpecificConfiguration(PyObject* dict)
 {
 	if (dict == nullptr)
 		return;
+
+	PyDict_SetItemString(dict, "filter", mvPyObject(ToPyInt(_filter)));
 }
 
 void mvStaticTexture::draw(ImDrawList* drawlist, float x, float y)
@@ -306,6 +338,12 @@ void mvStaticTexture::draw(ImDrawList* drawlist, float x, float y)
 		config.width = ImGui::GetIO().Fonts->TexData->Width;
 		config.height = ImGui::GetIO().Fonts->TexData->Height;
 		return;
+	}
+
+	if (_filterDirty && _texture != ImTextureID_Invalid)
+	{
+		ApplyTextureFilter(_texture, _filter);
+		_filterDirty = false;
 	}
 
 	if (!_dirty)
@@ -325,6 +363,7 @@ void mvStaticTexture::draw(ImDrawList* drawlist, float x, float y)
 
 
 	_dirty = false;
+	_filterDirty = false;
 }
 
 void mvStaticTexture::handleSpecificRequiredArgs(PyObject* dict)
@@ -345,7 +384,22 @@ void mvStaticTexture::handleSpecificKeywordArgs(PyObject* dict)
 		return;
 
 	if (PyObject* item = PyDict_GetItemString(dict, "filter"))
-		_filter = ToInt(item);
+	{
+		const int v = ToInt(item);
+		if (v != _filter)
+		{
+			_filter = v;
+			_filterDirty = true;
+		}
+	}
+}
+
+void mvStaticTexture::getSpecificConfiguration(PyObject* dict)
+{
+	if (dict == nullptr)
+		return;
+
+	PyDict_SetItemString(dict, "filter", mvPyObject(ToPyInt(_filter)));
 }
 
 PyObject* mvStaticTexture::getPyValue()

--- a/src/mvTextureItems.cpp
+++ b/src/mvTextureItems.cpp
@@ -157,7 +157,7 @@ void mvDynamicTexture::draw(ImDrawList* drawlist, float x, float y)
 	if (_dirty)
 	{
 
-		_texture = LoadTextureFromArrayDynamic(_permWidth, _permHeight, _value->data());
+		_texture = LoadTextureFromArrayDynamic(_permWidth, _permHeight, _value->data(), _filter);
 
 		if (_texture == ImTextureID_Invalid)
 			state.ok = false;
@@ -187,6 +187,8 @@ void mvDynamicTexture::handleSpecificKeywordArgs(PyObject* dict)
 	if (dict == nullptr)
 		return;
 
+	if (PyObject* item = PyDict_GetItemString(dict, "filter"))
+		_filter = ToInt(item);
 }
 
 void mvDynamicTexture::getSpecificConfiguration(PyObject* dict)
@@ -233,7 +235,7 @@ void mvRawTexture::draw(ImDrawList* drawlist, float x, float y)
 			return;
 
 		if (_componentType == ComponentType::MV_FLOAT_COMPONENT)
-			_texture = LoadTextureFromArrayRaw(_permWidth, _permHeight, (float*)_value, _components);
+			_texture = LoadTextureFromArrayRaw(_permWidth, _permHeight, (float*)_value, _components, _filter);
 
 		if (_texture == ImTextureID_Invalid)
 			state.ok = false;
@@ -281,6 +283,9 @@ void mvRawTexture::handleSpecificKeywordArgs(PyObject* dict)
 			_componentType = mvRawTexture::ComponentType::MV_FLOAT_COMPONENT;
 		}
 	}
+
+	if (PyObject* item = PyDict_GetItemString(dict, "filter"))
+		_filter = ToInt(item);
 }
 
 void mvRawTexture::getSpecificConfiguration(PyObject* dict)
@@ -309,7 +314,7 @@ void mvStaticTexture::draw(ImDrawList* drawlist, float x, float y)
 	if (!state.ok)
 		return;
 
-	_texture = LoadTextureFromArray(_permWidth, _permHeight, _value->data());
+	_texture = LoadTextureFromArray(_permWidth, _permHeight, _value->data(), _filter);
 
 	if (_texture == ImTextureID_Invalid)
 	{
@@ -332,6 +337,15 @@ void mvStaticTexture::handleSpecificRequiredArgs(PyObject* dict)
 	_permHeight = ToInt(PyTuple_GetItem(dict, 1));
 	config.height = _permHeight;
 	*_value = ToFloatVect(PyTuple_GetItem(dict, 2));
+}
+
+void mvStaticTexture::handleSpecificKeywordArgs(PyObject* dict)
+{
+	if (dict == nullptr)
+		return;
+
+	if (PyObject* item = PyDict_GetItemString(dict, "filter"))
+		_filter = ToInt(item);
 }
 
 PyObject* mvStaticTexture::getPyValue()

--- a/src/mvTextureItems.h
+++ b/src/mvTextureItems.h
@@ -35,7 +35,8 @@ public:
 public:
 
     ImTextureID               _texture = ImTextureID_Invalid;
-    int                       _filter = 0;  // mvTextureFilter_*
+    int                       _filter = 0;      // mvTextureFilter_*
+    bool                      _filterDirty = false;
 };
 
 
@@ -49,6 +50,7 @@ public:
     void draw(ImDrawList* drawlist, float x, float y) override;
     void handleSpecificRequiredArgs(PyObject* dict) override;
     void handleSpecificKeywordArgs(PyObject* dict) override;
+    void getSpecificConfiguration(PyObject* dict) override;
 
     // values
     void setDataSource(mvUUID dataSource) override;

--- a/src/mvTextureItems.h
+++ b/src/mvTextureItems.h
@@ -35,6 +35,7 @@ public:
 public:
 
     ImTextureID               _texture = ImTextureID_Invalid;
+    int                       _filter = 0;  // mvTextureFilter_*
 };
 
 
@@ -47,6 +48,7 @@ public:
 
     void draw(ImDrawList* drawlist, float x, float y) override;
     void handleSpecificRequiredArgs(PyObject* dict) override;
+    void handleSpecificKeywordArgs(PyObject* dict) override;
 
     // values
     void setDataSource(mvUUID dataSource) override;

--- a/src/mvUtilities.h
+++ b/src/mvUtilities.h
@@ -19,21 +19,26 @@ typedef _object PyObject;
 #endif
 
 struct PymvBuffer;
+struct ImDrawList;
 
 // general
 void FreeTexture(ImTextureID texture);
 b8 UnloadTexture(const std::string& filename);
-	
+
+// Bracket ImDrawList::AddImage calls to render with nearest-neighbor sampling.
+void EnterNearestFilterScope(ImDrawList* drawlist);
+void LeaveNearestFilterScope(ImDrawList* drawlist);
+
 // static textures
 ImTextureID LoadTextureFromFile(const char* filename, i32& width, i32& height);
-ImTextureID LoadTextureFromArray(u32 width, u32 height, f32* data);
+ImTextureID LoadTextureFromArray(u32 width, u32 height, f32* data, i32 filter = 0);
 
 // dynamic textures
-ImTextureID LoadTextureFromArrayDynamic(u32 width, u32 height, f32* data);
+ImTextureID LoadTextureFromArrayDynamic(u32 width, u32 height, f32* data, i32 filter = 0);
 void  UpdateTexture(ImTextureID texture, u32 width, u32 height, std::vector<f32>& data);
 
 // raw textures
-ImTextureID LoadTextureFromArrayRaw(u32 width, u32 height, f32* data, i32 components);
+ImTextureID LoadTextureFromArrayRaw(u32 width, u32 height, f32* data, i32 components, i32 filter = 0);
 void  UpdateRawTexture(ImTextureID texture, u32 width, u32 height, f32* data, i32 components);
 
 // framebuffer output

--- a/src/mvUtilities.h
+++ b/src/mvUtilities.h
@@ -21,6 +21,12 @@ typedef _object PyObject;
 struct PymvBuffer;
 struct ImDrawList;
 
+// mvTextureFilter_* constants (also registered on the Python module).
+enum {
+	mvTextureFilter_Linear  = 0,
+	mvTextureFilter_Nearest = 1,
+};
+
 // general
 void FreeTexture(ImTextureID texture);
 b8 UnloadTexture(const std::string& filename);
@@ -29,16 +35,19 @@ b8 UnloadTexture(const std::string& filename);
 void EnterNearestFilterScope(ImDrawList* drawlist);
 void LeaveNearestFilterScope(ImDrawList* drawlist);
 
+// Re-apply the filter state to an existing texture. Render-thread only.
+void ApplyTextureFilter(ImTextureID texture, i32 filter);
+
 // static textures
 ImTextureID LoadTextureFromFile(const char* filename, i32& width, i32& height);
-ImTextureID LoadTextureFromArray(u32 width, u32 height, f32* data, i32 filter = 0);
+ImTextureID LoadTextureFromArray(u32 width, u32 height, f32* data, i32 filter = mvTextureFilter_Linear);
 
 // dynamic textures
-ImTextureID LoadTextureFromArrayDynamic(u32 width, u32 height, f32* data, i32 filter = 0);
+ImTextureID LoadTextureFromArrayDynamic(u32 width, u32 height, f32* data, i32 filter = mvTextureFilter_Linear);
 void  UpdateTexture(ImTextureID texture, u32 width, u32 height, std::vector<f32>& data);
 
 // raw textures
-ImTextureID LoadTextureFromArrayRaw(u32 width, u32 height, f32* data, i32 components, i32 filter = 0);
+ImTextureID LoadTextureFromArrayRaw(u32 width, u32 height, f32* data, i32 components, i32 filter = mvTextureFilter_Linear);
 void  UpdateRawTexture(ImTextureID texture, u32 width, u32 height, f32* data, i32 components);
 
 // framebuffer output

--- a/src/mvUtilities_apple.mm
+++ b/src/mvUtilities_apple.mm
@@ -182,3 +182,9 @@ LeaveNearestFilterScope(ImDrawList* drawlist)
     if (drawlist == nullptr) return;
     drawlist->AddCallback(ImDrawCallback_ResetRenderState, nullptr);
 }
+
+void
+ApplyTextureFilter(ImTextureID, int)
+{
+    // No-op: the sampler is swapped per-draw via the callback above.
+}

--- a/src/mvUtilities_apple.mm
+++ b/src/mvUtilities_apple.mm
@@ -4,6 +4,7 @@
 #include "mvUtilities.h"
 
 #include "mvViewport.h"
+#include "mvContext.h"
 
 #include "mvAppleSpecifics.h"
 
@@ -13,6 +14,7 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 
+#include <imgui.h>
 #include <Metal/Metal.h>
 #include <MetalKit/MetalKit.h>
 #include <Quartz/Quartz.h>
@@ -36,8 +38,9 @@ OutputFrameBuffer(const char* filepath)
 }
 
  ImTextureID
-LoadTextureFromArray(unsigned width, unsigned height, float* data)
+LoadTextureFromArray(unsigned width, unsigned height, float* data, int filter)
 {
+    (void)filter;
     mvGraphics& graphics = GContext->graphics;
     auto graphicsData = (mvGraphics_Metal*)graphics.backendSpecifics;
 
@@ -55,8 +58,9 @@ LoadTextureFromArray(unsigned width, unsigned height, float* data)
 }
 
  ImTextureID
-LoadTextureFromArrayDynamic(unsigned width, unsigned height, float* data)
+LoadTextureFromArrayDynamic(unsigned width, unsigned height, float* data, int filter)
 {
+    (void)filter;
     mvGraphics& graphics = GContext->graphics;
     auto graphicsData = (mvGraphics_Metal*)graphics.backendSpecifics;
 
@@ -74,8 +78,9 @@ LoadTextureFromArrayDynamic(unsigned width, unsigned height, float* data)
 }
 
  ImTextureID
-LoadTextureFromArrayRaw(unsigned width, unsigned height, float* data, int components)
+LoadTextureFromArrayRaw(unsigned width, unsigned height, float* data, int components, int filter)
 {
+    (void)filter;
     mvGraphics& graphics = GContext->graphics;
     auto graphicsData = (mvGraphics_Metal*)graphics.backendSpecifics;
 
@@ -151,4 +156,29 @@ UpdateRawTexture(ImTextureID texture, unsigned width, unsigned height, float* da
 {
     id <MTLTexture> out_srv = (__bridge id <MTLTexture>)texture;
     [out_srv replaceRegion:MTLRegionMake2D(0, 0, width, height) mipmapLevel:0 withBytes:data bytesPerRow:width * components * 4];
+}
+
+static void
+DpgMetalBindNearestPipeline(const ImDrawList* /*parent_list*/, const ImDrawCmd* /*cmd*/)
+{
+    auto* graphicsData = (mvGraphics_Metal*)GContext->graphics.backendSpecifics;
+    if (graphicsData == nullptr || graphicsData->currentEncoder == nil ||
+        graphicsData->nearestPipelineState == nil || graphicsData->nearestSampler == nil)
+        return;
+    [graphicsData->currentEncoder setRenderPipelineState:graphicsData->nearestPipelineState];
+    [graphicsData->currentEncoder setFragmentSamplerState:graphicsData->nearestSampler atIndex:0];
+}
+
+void
+EnterNearestFilterScope(ImDrawList* drawlist)
+{
+    if (drawlist == nullptr) return;
+    drawlist->AddCallback(DpgMetalBindNearestPipeline, nullptr);
+}
+
+void
+LeaveNearestFilterScope(ImDrawList* drawlist)
+{
+    if (drawlist == nullptr) return;
+    drawlist->AddCallback(ImDrawCallback_ResetRenderState, nullptr);
 }

--- a/src/mvUtilities_linux.cpp
+++ b/src/mvUtilities_linux.cpp
@@ -94,7 +94,7 @@ OutputFrameBuffer(const char* filepath)
 
 static GLint FilterToGL(int filter)
 {
-    return (filter == 1) ? GL_NEAREST : GL_LINEAR;
+    return (filter == mvTextureFilter_Nearest) ? GL_NEAREST : GL_LINEAR;
 }
 
  ImTextureID
@@ -217,6 +217,16 @@ UnloadTexture(const std::string& filename)
 
 void EnterNearestFilterScope(ImDrawList*) {}
 void LeaveNearestFilterScope(ImDrawList*) {}
+
+void ApplyTextureFilter(ImTextureID texture, int filter)
+{
+    GLuint tex = (GLuint)(uintptr_t)texture;
+    if (tex == 0) return;
+    glBindTexture(GL_TEXTURE_2D, tex);
+    GLint f = FilterToGL(filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, f);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, f);
+}
 
  void
 FreeTexture(ImTextureID texture)

--- a/src/mvUtilities_linux.cpp
+++ b/src/mvUtilities_linux.cpp
@@ -92,8 +92,13 @@ OutputFrameBuffer(const char* filepath)
     free(data);
 }
 
+static GLint FilterToGL(int filter)
+{
+    return (filter == 1) ? GL_NEAREST : GL_LINEAR;
+}
+
  ImTextureID
-LoadTextureFromArray(unsigned width, unsigned height, float* data)
+LoadTextureFromArray(unsigned width, unsigned height, float* data, int filter)
 {
 
     // Create a OpenGL texture identifier
@@ -102,8 +107,9 @@ LoadTextureFromArray(unsigned width, unsigned height, float* data)
     glBindTexture(GL_TEXTURE_2D, image_texture);
 
     // Setup filtering parameters for display
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    GLint glFilter = FilterToGL(filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, glFilter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, glFilter);
 
     // Upload pixels into texture
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
@@ -113,7 +119,7 @@ LoadTextureFromArray(unsigned width, unsigned height, float* data)
 }
 
  ImTextureID
-LoadTextureFromArrayDynamic(unsigned width, unsigned height, float* data)
+LoadTextureFromArrayDynamic(unsigned width, unsigned height, float* data, int filter)
 {
 
     // Create a OpenGL texture identifier
@@ -122,8 +128,9 @@ LoadTextureFromArrayDynamic(unsigned width, unsigned height, float* data)
     glBindTexture(GL_TEXTURE_2D, image_texture);
 
     // Setup filtering parameters for display
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    GLint glFilter = FilterToGL(filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, glFilter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, glFilter);
 
     // Upload pixels into texture
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
@@ -140,7 +147,7 @@ LoadTextureFromArrayDynamic(unsigned width, unsigned height, float* data)
 }
 
  ImTextureID
-LoadTextureFromArrayRaw(unsigned width, unsigned height, float* data, int components)
+LoadTextureFromArrayRaw(unsigned width, unsigned height, float* data, int components, int filter)
 {
 
     // Create a OpenGL texture identifier
@@ -149,8 +156,9 @@ LoadTextureFromArrayRaw(unsigned width, unsigned height, float* data, int compon
     glBindTexture(GL_TEXTURE_2D, image_texture);
 
     // Setup filtering parameters for display
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    GLint glFilter = FilterToGL(filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, glFilter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, glFilter);
 
     // Upload pixels into texture
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
@@ -206,6 +214,9 @@ UnloadTexture(const std::string& filename)
     // TODO : decide if cleanup is necessary
     return true;
 }
+
+void EnterNearestFilterScope(ImDrawList*) {}
+void LeaveNearestFilterScope(ImDrawList*) {}
 
  void
 FreeTexture(ImTextureID texture)

--- a/src/mvUtilities_win32.cpp
+++ b/src/mvUtilities_win32.cpp
@@ -484,3 +484,9 @@ LeaveNearestFilterScope(ImDrawList* drawlist)
     if (drawlist == nullptr) return;
     drawlist->AddCallback(ImDrawCallback_ResetRenderState, nullptr);
 }
+
+void
+ApplyTextureFilter(ImTextureID, int)
+{
+    // No-op: the sampler is swapped per-draw via the callback above.
+}

--- a/src/mvUtilities_win32.cpp
+++ b/src/mvUtilities_win32.cpp
@@ -5,6 +5,9 @@
 #include "mvWindowsSpecifics.h"
 
 #include "mvCustomTypes.h"
+#include "mvContext.h"
+
+#include <imgui.h>
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
@@ -145,8 +148,9 @@ LoadTextureFromFile(const char* filename, int& width, int& height)
 }
 
  ImTextureID
-LoadTextureFromArray(unsigned width, unsigned height, float* data)
+LoadTextureFromArray(unsigned width, unsigned height, float* data, int filter)
 {
+    (void)filter;
     mvGraphics_D3D11* graphicsData = (mvGraphics_D3D11*)GContext->graphics.backendSpecifics;
     ID3D11ShaderResourceView* out_srv = nullptr;
 
@@ -223,8 +227,9 @@ LoadTextureFromArray(unsigned width, unsigned height, int* data)
 }
 
  ImTextureID
-LoadTextureFromArrayDynamic(unsigned width, unsigned height, float* data)
+LoadTextureFromArrayDynamic(unsigned width, unsigned height, float* data, int filter)
 {
+    (void)filter;
     mvGraphics_D3D11* graphicsData = (mvGraphics_D3D11*)GContext->graphics.backendSpecifics;
     ID3D11ShaderResourceView* out_srv = nullptr;
 
@@ -388,8 +393,9 @@ UpdateRawTexture(ImTextureID texture, unsigned width, unsigned height, float* da
 }
 
  ImTextureID
-LoadTextureFromArrayRaw(unsigned width, unsigned height, float* data, int components)
+LoadTextureFromArrayRaw(unsigned width, unsigned height, float* data, int components, int filter)
 {
+    (void)filter;
     mvGraphics_D3D11* graphicsData = (mvGraphics_D3D11*)GContext->graphics.backendSpecifics;
     ID3D11ShaderResourceView* out_srv = nullptr;
 
@@ -453,4 +459,28 @@ UnloadTexture(const std::string& filename)
 {
     // TODO : decide if cleanup is necessary
     return true;
+}
+
+static void
+DpgD3D11BindNearestSampler(const ImDrawList* /*parent_list*/, const ImDrawCmd* /*cmd*/)
+{
+    auto* graphicsData = (mvGraphics_D3D11*)GContext->graphics.backendSpecifics;
+    if (graphicsData == nullptr || graphicsData->deviceContext == nullptr ||
+        graphicsData->pTexSamplerNearest == nullptr)
+        return;
+    graphicsData->deviceContext->PSSetSamplers(0, 1, &graphicsData->pTexSamplerNearest);
+}
+
+void
+EnterNearestFilterScope(ImDrawList* drawlist)
+{
+    if (drawlist == nullptr) return;
+    drawlist->AddCallback(DpgD3D11BindNearestSampler, nullptr);
+}
+
+void
+LeaveNearestFilterScope(ImDrawList* drawlist)
+{
+    if (drawlist == nullptr) return;
+    drawlist->AddCallback(ImDrawCallback_ResetRenderState, nullptr);
 }

--- a/src/mvViewport_apple.mm
+++ b/src/mvViewport_apple.mm
@@ -241,6 +241,7 @@ mvRenderFrame()
         graphicsData->renderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
         graphicsData->renderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
         id <MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:graphicsData->renderPassDescriptor];
+        graphicsData->currentEncoder = renderEncoder;
         [renderEncoder pushDebugGroup:@"ImGui demo"];
 
 
@@ -269,6 +270,7 @@ mvRenderFrame()
 
         [renderEncoder popDebugGroup];
         [renderEncoder endEncoding];
+        graphicsData->currentEncoder = nil;
 
         [commandBuffer presentDrawable:drawable];
         [commandBuffer commit];

--- a/src/mvWindowsSpecifics.h
+++ b/src/mvWindowsSpecifics.h
@@ -32,4 +32,5 @@ struct mvGraphics_D3D11
 	IDXGISwapChain*         swapChain     = nullptr;
 	ID3D11RenderTargetView* target        = nullptr;
 	ID3D11Texture2D*        backBuffer    = nullptr;
+	ID3D11SamplerState*     pTexSamplerNearest = nullptr;
 };


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Per-texture filter option for add_static_texture / add_dynamic_texture / add_raw_texture
assignees: @hoffstadt @v-ein 

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**

Closes #773 

Adds a `filter` keyword argument to `add_static_texture`, `add_dynamic_texture`, and `add_raw_texture`, letting the caller choose between bilinear (default) and nearest-neighbor sampling. Addresses the long-standing request to avoid blurred interpolation on pixel-art, discrete heatmaps, and other textures where point sampling is the right call.

```python
with dpg.texture_registry():
    dpg.add_static_texture(w, h, data, tag="pixels",
                           filter=dpg.mvTextureFilter_Nearest)

dpg.add_image("pixels")          # renders with nearest
dpg.draw_image("pixels", ...)    # same
```

Two new module constants are exposed: `mvTextureFilter_Linear` (0, default) and `mvTextureFilter_Nearest` (1). The filter lives on the texture item, so every widget that references that texture inherits its mode. Affects `add_image`, `add_image_button`, `draw_image`, `draw_image_quad`, and `add_image_series`.

The filter is **mutable** after creation via `configure_item`, and round-trips through `get_item_configuration`:

```python
dpg.configure_item("pixels", filter=dpg.mvTextureFilter_Linear)
dpg.get_item_configuration("pixels")["filter"]  # 0
```

Internally, the constants are defined as a file-scoped enum in `src/mvUtilities.h` so C++ call sites reference them by name.

**Cross-platform.** Filter state lives in a different architectural layer on each backend, so the implementation differs:

- **OpenGL (Linux)**: `glTexParameteri(GL_TEXTURE_MIN/MAG_FILTER, ...)` is set on the GL texture object. Mutation is handled by a render-thread `ApplyTextureFilter` call on the next `draw()` after `configure_item` marks `_filterDirty`.

- **D3D11 (Windows)**: `imgui_impl_dx11.cpp` uses a single global `pTexSamplerLinear`. DPG creates a second sampler (`pTexSamplerNearest`) on `mvGraphics_D3D11` at init, and image-drawing widgets emit an `ImDrawList::AddCallback` pair around the draw: the first swaps `PSSetSamplers` to nearest, the second is the built-in `ImDrawCallback_ResetRenderState` sentinel which restores the backend's defaults. Since the callback reads `_filter` live every frame, mutation requires no GPU-side rebuild.

- **Metal (macOS)**: `imgui_impl_metal.mm` bakes a `constexpr sampler linearSampler` into its MSL fragment shader, so a CPU-side `setFragmentSamplerState` call has no effect without a shader change. Rather than patch the ImGui backend, DPG ships a small parallel Metal pipeline in `mvGraphics_apple.mm` with a bindable sampler. The shader mirrors the ImGui one and consumes the same vertex buffer and uniforms layout; the callback binds the DPG pipeline + a nearest `MTLSamplerState`, and `ImDrawCallback_ResetRenderState` hands rendering back to the ImGui pipeline. `mvViewport_apple.mm` stashes the current `MTLRenderCommandEncoder` on `mvGraphics_Metal` each frame so the callback can reach it. A `static_assert` on `sizeof(ImDrawVert)` guards against future vertex-format drift.

Fully backwards compatible. Default path is linear and has zero overhead — the `ImDrawList::AddCallback` pair is only emitted when the bound texture has `_filter == mvTextureFilter_Nearest`.

Tested end-to-end on all three backends:

- **macOS** (Apple Silicon, Metal) [Native].
- **Windows 11** (ARM64 host via Parallels Desktop; x64 Python through Prism emulation → D3D11).
- **Ubuntu 24.04.3 LTS** (ARM64 via Parallels Desktop; native OpenGL).

Each platform ran side-by-side comparisons of linear vs. nearest across `add_image`, `draw_image`, and `add_image_series`, plus runtime toggling via `configure_item`. Surrounding ImGui widgets (text, buttons, plot axes) render with linear filtering every frame regardless of any texture's filter state. The callback swap is scoped per image and `ImDrawCallback_ResetRenderState` restores the backend's defaults. Additional verification on bare-metal x64 Windows and native Linux hardware from contributors with access to those machines would be welcome.

**Demo**

<img width="636" height="576" alt="texture_filter_toggle" src="https://github.com/user-attachments/assets/969855fe-5998-4f7a-ae0c-f306b5b0c53c" />

> The new per-texture filter option switched live via `configure_item` on six 4×4 checkerboards rendered at 200×200. No data re-upload. Only the sampling mode changes, so toggling is free regardless of texture size.

**Concerning Areas:**

- **Metal shader duplication.** The DPG-owned pipeline in `mvGraphics_apple.mm` duplicates the vertex layout and blend state of ImGui's Metal shader. A future change to ImGui's `ImDrawVert` layout would require updating the DPG shader as the `static_assert` on `sizeof(ImDrawVert) == 20` turns this into a build-time failure rather than a runtime one. The cleaner long-term fix is an upstream PR to `imgui_impl_metal.mm` making its sampler bindable, after which this parallel pipeline can be removed. Happy to follow up separately if desired.

- **Draw-call batching on nearest-filtered images.** Each nearest-filtered draw emits two `ImDrawList::AddCallback` entries, which break ImGui's draw-call merging. Cost is bounded (a few hundred extra GPU commands for a few hundred nearest images — sub-millisecond on any modern GPU) and is only paid on the nearest path. The default linear path is unchanged.

- **`ImFontAtlasFlags_NoBakedLines` not set.** The ImGui DX11 backend comments that bilinear sampling is required for baked antialiased lines (`imgui_impl_dx11.cpp:578`), but our sampler swap is scoped per-image-draw and `ImDrawCallback_ResetRenderState` restores linear before the AA-line textures are sampled. Worth flagging in case DX11 testing on native machines surfaces an interaction not reproducible on macOS-native host.
