### PR TITLE
fix: set_primary_window no longer breaks other windows

### DIFF
--- a/dearpygui/_dearpygui.pyi
+++ b/dearpygui/_dearpygui.pyi
@@ -1159,7 +1159,7 @@ def set_item_children(item : Union[int, str], source : Union[int, str], slot : i
 	"""Sets an item's children."""
 	...
 
-def set_primary_window(window : Union[int, str], value : bool) -> None:
+def set_primary_window(window : Union[int, str], value : bool ='') -> None:
 	"""Sets the primary window."""
 	...
 

--- a/dearpygui/_dearpygui_RTD.py
+++ b/dearpygui/_dearpygui_RTD.py
@@ -8655,12 +8655,12 @@ def set_item_children(item, source, slot):
 
 	return internal_dpg.set_item_children(item, source, slot)
 
-def set_primary_window(window, value):
+def set_primary_window(window, value=True):
 	"""	 Sets the primary window.
 
 	Args:
 		window (Union[int, str]): 
-		value (bool): 
+		value (bool, optional): True to select this window as primary, False to make it a regular window (without any primary window). Only one window at a time can be primary.
 	Returns:
 		None
 	"""

--- a/dearpygui/dearpygui.py
+++ b/dearpygui/dearpygui.py
@@ -9730,12 +9730,12 @@ def set_item_children(item : Union[int, str], source : Union[int, str], slot : i
 
 	return internal_dpg.set_item_children(item, source, slot, **kwargs)
 
-def set_primary_window(window : Union[int, str], value : bool, **kwargs) -> None:
+def set_primary_window(window : Union[int, str], value : bool =True, **kwargs) -> None:
 	"""	 Sets the primary window.
 
 	Args:
 		window (Union[int, str]): 
-		value (bool): 
+		value (bool, optional): True to select this window as primary, False to make it a regular window (without any primary window). Only one window at a time can be primary.
 	Returns:
 		None
 	"""

--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -3015,7 +3015,7 @@ static PyObject*
 set_primary_window(PyObject* self, PyObject* args, PyObject* kwargs)
 {
 	PyObject* itemraw;
-	i32 value;
+	i32 value = 1;
 
 	if (!VerifyRequiredArguments(GetParsers()["set_primary_window"], args))
 		return GetPyNoneOrError();
@@ -3027,73 +3027,60 @@ set_primary_window(PyObject* self, PyObject* args, PyObject* kwargs)
 
 	mvUUID item = GetIDFromPyObject(itemraw);
 
+	mvWindowAppItem* window = GetWindow(*GContext->itemRegistry, item);
+
+	if (!window)
 	{
-		mvWindowAppItem* window = GetWindow(*GContext->itemRegistry, item);
-
-		if (!window)
-		{
-			mvThrowPythonError(mvErrorCode::mvItemNotFound, "set_primary_window",
-				"Item not found: " + std::to_string(item), nullptr);
-			assert(false);
-			return nullptr;
-		}
-		else
-		{
-			if (window->configData.mainWindow == (bool)value)
-				return GetPyNone();
-			else
-			{
-				window->configData.mainWindow = value;
-				if (value)
-				{
-					window->configData._oldWindowflags = window->configData.windowflags;
-					window->configData.windowflags = ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings
-						| ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar;
-
-					if (window->configData._oldWindowflags & ImGuiWindowFlags_MenuBar)
-						window->configData.windowflags |= ImGuiWindowFlags_MenuBar;
-					window->configData._oldxpos = window->state.pos.x;
-					window->configData._oldypos = window->state.pos.y;
-					window->configData._oldWidth = window->config.width;
-					window->configData._oldHeight = window->config.height;
-				}
-				else
-				{
-					window->info.focusNextFrame = true;
-					if (window->configData.windowflags & ImGuiWindowFlags_MenuBar)
-						window->configData._oldWindowflags |= ImGuiWindowFlags_MenuBar;
-					window->configData.windowflags = window->configData._oldWindowflags;
-					if (window->configData.windowflags & ImGuiWindowFlags_MenuBar)
-						window->configData.windowflags |= ImGuiWindowFlags_MenuBar;
-					window->state.pos = { window->configData._oldxpos , window->configData._oldypos };
-					window->config.width = window->configData._oldWidth;
-					window->config.height = window->configData._oldHeight;
-					window->info.dirtyPos = true;
-					window->info.dirty_size = true;
-				}
-			}
-		}
+		mvThrowPythonError(mvErrorCode::mvItemNotFound, "set_primary_window",
+			"Item not found: " + std::to_string(item), nullptr);
+		assert(false);
+		return nullptr;
 	}
 
-	// reset other windows
-	for (auto& window : GContext->itemRegistry->windowRoots)
+	if (window->configData.mainWindow == (bool)value)
+		// Nothing to do!
+		return GetPyNone();
+
+	// Now, we either demote this (primary) window back to a regular window, or demote
+	// another window and set this one to be the new primary.  The `value` shows us
+	// the direction.
+	mvWindowAppItem* old_primary = nullptr;
+
+	if (value)
 	{
-		if (window->uuid != item)
+		// Find old primary, if any.  Also re-focus all windows except the current one
+		// so that they float atop of the primary window (otherwise they'd stay hidden
+		// behind it).  Unfortunately ImGui does not have better means for controlling z-order.
+		for (auto& root : GContext->itemRegistry->windowRoots)
 		{
-			mvWindowAppItem* windowActual = static_cast<mvWindowAppItem*>(window.get());
-			windowActual->configData.mainWindow = false;
-			window->info.focusNextFrame = true;
-			if (windowActual->configData.windowflags & ImGuiWindowFlags_MenuBar)
-				windowActual->configData._oldWindowflags |= ImGuiWindowFlags_MenuBar;
-			windowActual->configData.windowflags = windowActual->configData._oldWindowflags;
-			if (windowActual->configData.windowflags & ImGuiWindowFlags_MenuBar)
-				windowActual->configData.windowflags |= ImGuiWindowFlags_MenuBar;
-			window->state.pos = { windowActual->configData._oldxpos , windowActual->configData._oldypos };
-			window->config.width = windowActual->configData._oldWidth;
-			window->config.height = windowActual->configData._oldHeight;
-			window->info.dirtyPos = true;
-			window->info.dirty_size = true;
+			mvWindowAppItem* cur_window = static_cast<mvWindowAppItem*>(root.get());
+			if (cur_window->configData.mainWindow)
+				old_primary = cur_window;
+			
+			cur_window->info.focusNextFrame = (cur_window->uuid != item);
 		}
+
+		// Select the window passed in as a primary
+		window->configData.mainWindow = true;
+		window->configData._oldxpos = window->state.pos.x;
+		window->configData._oldypos = window->state.pos.y;
+		window->configData._oldWidth = window->config.width;
+		window->configData._oldHeight = window->config.height;
+	}
+	else
+		// Just demote this window, nothing special
+		old_primary = window;
+
+	// Now whatever old primary was there (it might be the window passed in -
+	// if `value` is False), we want to make it a regular window.
+	if (old_primary)
+	{
+		old_primary->configData.mainWindow = false;
+		old_primary->state.pos = { old_primary->configData._oldxpos , old_primary->configData._oldypos };
+		old_primary->config.width = old_primary->configData._oldWidth;
+		old_primary->config.height = old_primary->configData._oldHeight;
+		old_primary->info.dirtyPos = true;
+		old_primary->info.dirty_size = true;
 	}
 
 	return GetPyNone();

--- a/src/dearpygui_parsers.h
+++ b/src/dearpygui_parsers.h
@@ -1289,7 +1289,7 @@ InsertParser_Block2(std::map<std::string, mvPythonParser>& parsers)
 	{
 		std::vector<mvPythonDataElement> args;
 		args.push_back({ mvPyDataType::UUID, "window" });
-		args.push_back({ mvPyDataType::Bool, "value" });
+		args.push_back({ mvPyDataType::Bool, "value", mvArgType::POSITIONAL_ARG, "True", "True to select this window as primary, False to make it a regular window (without any primary window). Only one window at a time can be primary." });
 
 		mvPythonParserSetup setup;
 		setup.about = "Sets the primary window.";

--- a/src/mvContainers.cpp
+++ b/src/mvContainers.cpp
@@ -485,13 +485,6 @@ DearPyGui::set_configuration(PyObject* inDict, mvAppItem& itemc, mvWindowAppItem
     flagop("no_scroll_with_mouse", ImGuiWindowFlags_NoScrollWithMouse, outConfig.windowflags);
     flagop("unsaved_document", ImGuiWindowFlags_UnsavedDocument, outConfig.windowflags);
     flagop("no_docking", ImGuiWindowFlags_NoDocking, outConfig.windowflags);
-
-
-    outConfig._oldxpos = itemc.state.pos.x;
-    outConfig._oldypos = itemc.state.pos.y;
-    outConfig._oldWidth = itemc.config.width;
-    outConfig._oldHeight = itemc.config.height;
-    outConfig._oldWindowflags = outConfig.windowflags;
 }
 
 //-----------------------------------------------------------------------------
@@ -1476,12 +1469,17 @@ DearPyGui::draw_window(ImDrawList* drawlist, mvAppItem& item, mvWindowAppItemCon
 
     ScopedID id(item.uuid);
 
+    // For primary windows, we'll need to massage the flags
+    ImGuiWindowFlags windowFlags = config.windowflags;
     if (config.mainWindow)
     {
         ImGui::SetNextWindowBgAlpha(1.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f); // to prevent main window corners from showing
         ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f));
         ImGui::SetNextWindowSize(ImVec2((float)GContext->viewport->clientWidth, (float)GContext->viewport->clientHeight));
+        windowFlags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings
+            | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove;
+        windowFlags &= ~ImGuiWindowFlags_AlwaysAutoResize;
     }
 
     else if (item.info.dirtyPos)
@@ -1514,7 +1512,7 @@ DearPyGui::draw_window(ImDrawList* drawlist, mvAppItem& item, mvWindowAppItemCon
             ImGui::OpenPopup(item.info.internalLabel.c_str(), config.no_open_over_existing_popup ? ImGuiPopupFlags_NoOpenOverExistingPopup : ImGuiPopupFlags_None);
         }
 
-        if (!ImGui::BeginPopupModal(item.info.internalLabel.c_str(), config.no_close ? nullptr : &item.config.show, config.windowflags))
+        if (!ImGui::BeginPopupModal(item.info.internalLabel.c_str(), config.no_close ? nullptr : &item.config.show, windowFlags))
         {
             if (config.mainWindow)
                 ImGui::PopStyleVar();
@@ -1546,7 +1544,7 @@ DearPyGui::draw_window(ImDrawList* drawlist, mvAppItem& item, mvWindowAppItemCon
             ImGui::OpenPopup(item.info.internalLabel.c_str(), config.no_open_over_existing_popup ? ImGuiPopupFlags_NoOpenOverExistingPopup : ImGuiPopupFlags_None);
         }
 
-        if (!ImGui::BeginPopup(item.info.internalLabel.c_str(), config.windowflags))
+        if (!ImGui::BeginPopup(item.info.internalLabel.c_str(), windowFlags))
         {
             if (config.mainWindow)
                 ImGui::PopStyleVar();
@@ -1581,7 +1579,7 @@ DearPyGui::draw_window(ImDrawList* drawlist, mvAppItem& item, mvWindowAppItemCon
 		ImGuiIO &io = ImGui::GetIO();
         io.ConfigWindowsCopyContentsWithCtrlC = config.copy_contents_shortcut;
 
-        if (!ImGui::Begin(item.info.internalLabel.c_str(), config.no_close ? nullptr : &item.config.show, config.windowflags))
+        if (!ImGui::Begin(item.info.internalLabel.c_str(), config.no_close ? nullptr : &item.config.show, windowFlags))
         {
             if (config.mainWindow)
                 ImGui::PopStyleVar();

--- a/src/mvContainers.h
+++ b/src/mvContainers.h
@@ -156,7 +156,6 @@ struct mvWindowAppItemConfig
     mvVec2           min_size = { 100.0f, 100.0f };
     mvVec2           max_size = { 30000.0f, 30000.0f };
     bool             _collapsedDirty = true;
-    ImGuiWindowFlags _oldWindowflags = ImGuiWindowFlags_None;
     float            _oldxpos = 200;
     float            _oldypos = 200;
     int              _oldWidth = 200;
@@ -269,7 +268,7 @@ class mvWindowAppItem : public mvAppItem
 {
 public:
     mvWindowAppItemConfig configData{};
-    explicit mvWindowAppItem(mvUUID uuid, bool mainWindow = false) : mvAppItem(uuid) { configData.mainWindow = mainWindow; config.width = config.height = 500; info.dirty_size = true; if (mainWindow) configData.windowflags = ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar;}
+    explicit mvWindowAppItem(mvUUID uuid) : mvAppItem(uuid) { config.width = config.height = 500; info.dirty_size = true; }
     void draw(ImDrawList* drawlist, float x, float y) override { DearPyGui::draw_window(drawlist, *this, configData); }
     void handleSpecificKeywordArgs(PyObject* dict) override { DearPyGui::set_configuration(dict, *this, configData); }
     void getSpecificConfiguration(PyObject* dict) override { DearPyGui::fill_configuration_dict(configData, dict); }


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: fix: set_primary_window no longer breaks other windows
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**

With this PR, `set_primary_window` no longer modifies windows other than the window passed in and the previous primary window (if it was set). This fixes #1691, effectively changing window position only when the window switches between primary and regular state. No other windows, in particular, popups and modals, are affected (keep in mind that a modal that has a non-empty label still won't center properly - see #2323 which is not fixed yet).

The only change `set_primary_window` still does to every window is re-focusing them - this is necessary to place the primary window to the bottom of Z-order. There are no public functions in ImGui API to control Z order, so re-focusing is the only way to place them atop of the primary window (so that they are not hidden behind). As a result, all windows after this call are always reordered according to their creation order. This matches behavior that existed before this PR.

Another change in this PR is that `set_primary_window` keeps window flags that are not related to positioning it as a primary window, for example, `horizontal_scrollbar`. This fixes #1978.

Also, the 2nd argument of `set_primary_window` is now optional, which allows for a more intuitive call like `set_primary_window(wnd)` rather than `set_primary_window(wnd, True)` (you know, I always hated to type that `True` 😂).

**Concerning Areas:**
If ImGui ever provides API to conrol windows' Z-order, we'll need to make use of it in place of refocusing every window.