### PR TITLE
fix: Proper release of the buffer obtained via PyObject_GetBuffer

### DIFF
--- a/src/mvPyUtils.cpp
+++ b/src/mvPyUtils.cpp
@@ -1135,9 +1135,8 @@ ToUCharVect(PyObject* value, const std::string& message)
             {
                 items.emplace_back((unsigned char)BufferViewer(buffer_info, i));
             }
+            PyBuffer_Release(&buffer_info);
         }
-
-        PyBuffer_Release(&buffer_info);
     }
 
     else
@@ -1188,9 +1187,8 @@ ToIntVect(PyObject* value, const std::string& message)
             {
                 items.emplace_back(BufferViewer(buffer_info, i));
             }
+            PyBuffer_Release(&buffer_info);
         }
-
-        PyBuffer_Release(&buffer_info);
     }
 
     else
@@ -1276,8 +1274,8 @@ ToFloatVect(PyObject* value, const std::string& message)
             {
                 items.emplace_back(BufferViewer(buffer_info, i));
             }
+            PyBuffer_Release(&buffer_info);
         }
-        PyBuffer_Release(&buffer_info);
     }
 
     else
@@ -1328,8 +1326,8 @@ ToDoubleVect(PyObject* value, const std::string& message)
             {
                 items.emplace_back(BufferViewer(buffer_info, i));
             }
+            PyBuffer_Release(&buffer_info);
         }
-        PyBuffer_Release(&buffer_info);
     }
 
     else

--- a/src/mvTextureItems.cpp
+++ b/src/mvTextureItems.cpp
@@ -218,8 +218,8 @@ void mvRawTexture::setPyValue(PyObject* value)
 			{
 				mvThrowPythonError(mvErrorCode::mvTextureNotFound, GetEntityCommand(type), "Texture data not valid", this);
 			}
+			PyBuffer_Release(&buffer_info);
 		}
-		PyBuffer_Release(&buffer_info);
 		_buffer = mvPyObject(value, true);
 	}
 }


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Proper release of the buffer obtained via PyObject_GetBuffer
assignees: ''

---

<!-- dont forget to use the reviewer settings to notify any required reviewers -->
<!-- using "Closes #issue-number" will link and autoclose all issue that this pull fixes upon accepting pull request -->

**Description:**

This PR addresses an issue with the use of buffer protocol in DPG that was discovered in #2577 - see [this comment](https://github.com/hoffstadt/DearPyGui/issues/2577#issuecomment-3666997137). It does _not_ fix the issue #2577 itself (we'll need to properly return `nullptr` to get a correct exception there), but fixes the segfaults caused by incorrect release of a buffer that was never obtained.

**Concerning Areas:**
None.