### PR TITLE
fix: Restored "handlers" entry in item info

### DIFF
--- a/src/dearpygui_commands.h
+++ b/src/dearpygui_commands.h
@@ -3630,6 +3630,7 @@ get_item_info(PyObject* self, PyObject* args, PyObject* kwargs)
 	PyDict_SetItemString(pdict, "parent", mvPyObject(ToPyUUIDOrNone(appitem->info.parentPtr)));
 	PyDict_SetItemString(pdict, "theme", mvPyObject(ToPyUUIDOrNone(appitem->theme.get())));
 	PyDict_SetItemString(pdict, "font", mvPyObject(ToPyUUIDOrNone(appitem->font.get())));
+	PyDict_SetItemString(pdict, "handlers", mvPyObject(ToPyUUIDOrNone(appitem->handlerRegistry.get())));
 
 	if (DearPyGui::GetEntityDesciptionFlags(appitem->type) & MV_ITEM_DESC_CONTAINER)
 		PyDict_SetItemString(pdict, "container", mvPyObject(ToPyBool(true)));


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: Restored "handlers" entry in item info
assignees: ''

---


**Description:**

Closes #2645.

DPG 2.2 had a regression in that it lost the "handlers" entry in what `get_item_info` returns. Fixing this.

**Concerning Areas:**
None.