### PR TITLE
fix (mvSlider3D): fixed thumbgs drag being reset after 1 frame (#2640).

### DIFF
--- a/src/mvSlider3D.cpp
+++ b/src/mvSlider3D.cpp
@@ -120,8 +120,10 @@ static bool SliderScalar3D(char const* pLabel, float* pValueX, float* pValueY, f
 	bool bModified = false;
 	bool hovered;
 	bool held;
-	bool pressed = ImGui::ButtonBehavior(oZDragRect, ImGui::GetID("##HandleZ"), &hovered, &held);
-	if (hovered && held)
+	ImGuiID iHandleID = ImGui::GetID("##HandleZ");
+	ImGui::KeepAliveID(iHandleID);
+	bool pressed = ImGui::ButtonBehavior(oZDragRect, iHandleID, &hovered, &held);
+	if (held)
 	{
 		if (DistToSegmentSqr(vMousePos, vDragStart, vDragEnd) < 100.0f) // 100 is arbitrary threshold
 		{
@@ -141,8 +143,10 @@ static bool SliderScalar3D(char const* pLabel, float* pValueX, float* pValueY, f
 	ImRect const oXYDrag((vRectEnd - vRectStart) * fScaleZ + vRectStart,
 		(vRectEnd - vRectStart) * fScaleZ + vRectStart + ImVec2(2.0f * fX3, 2.0f * fY3));
 	//if (ImGui::IsMouseHoveringRect(oXYDrag.Min - vSecurity, oXYDrag.Max + vSecurity) && ImGui::IsMouseDown(ImGuiMouseButton_Left))
-	pressed = ImGui::ButtonBehavior(oXYDrag, ImGui::GetID("##Zone"), &hovered, &held);
-	if (hovered && held)
+	iHandleID = ImGui::GetID("##Zone");
+	ImGui::KeepAliveID(iHandleID);
+	pressed = ImGui::ButtonBehavior(oXYDrag, iHandleID, &hovered, &held);
+	if (held)
 	{
 		ImVec2 const vLocalPos = ImGui::GetMousePos() - oXYDrag.Min;
 
@@ -220,8 +224,10 @@ static bool SliderScalar3D(char const* pLabel, float* pValueX, float* pValueY, f
 
 	//if (ImGui::IsMouseHoveringRect(vHandlePosX - ImVec2(fHandleRadius, fHandleRadius) - vSecurity, vHandlePosX + ImVec2(fHandleRadius, fHandleRadius) + vSecurity) &&
 	//	ImGui::IsMouseDown(ImGuiMouseButton_Left))
-	pressed = ImGui::ButtonBehavior(handle_x_bb, ImGui::GetID("##HandleX"), &hovered, &held);
-	if (hovered && held)
+	iHandleID = ImGui::GetID("##HandleX");
+	ImGui::KeepAliveID(iHandleID);
+	pressed = ImGui::ButtonBehavior(handle_x_bb, iHandleID, &hovered, &held);
+	if (held)
 	{
 		float const fCursorPosX = ImGui::GetMousePos().x - vStart.x;
 
@@ -231,8 +237,10 @@ static bool SliderScalar3D(char const* pLabel, float* pValueX, float* pValueY, f
 	}
 	//else if (ImGui::IsMouseHoveringRect(vHandlePosY - ImVec2(fHandleRadius, fHandleRadius) - vSecurity, vHandlePosY + ImVec2(fHandleRadius, fHandleRadius) + vSecurity) &&
 	//	ImGui::IsMouseDown(ImGuiMouseButton_Left))
-	pressed = ImGui::ButtonBehavior(handle_y_bb, ImGui::GetID("##HandleY"), &hovered, &held);
-	if (hovered && held)
+	iHandleID = ImGui::GetID("##HandleY");
+	ImGui::KeepAliveID(iHandleID);
+	pressed = ImGui::ButtonBehavior(handle_y_bb, iHandleID, &hovered, &held);
+	if (held)
 	{
 		float const fCursorPosY = ImGui::GetMousePos().y - vStart.y;
 


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: fix (mvSlider3D): fixed thumbgs drag being reset after 1 frame (#2640).
assignees: ''

---

Closes #2640.

**Description:**

The issue is caused by an old change in ImGui (back in 2022) - see ocornut/imgui#5181. Basically whoever calls `ImGui::ButtonBehavior()` directly must now use `KeepAliveID()` or `ItemAdd()` as well. The fix adds the necessary `KeepAliveID()` calls.

**Concerning Areas:**
None.
