### PR TITLE
A menu bar in node editor no longer segfaults (#2070)

### DIFF
--- a/src/mvNodes.cpp
+++ b/src/mvNodes.cpp
@@ -127,6 +127,8 @@ std::vector<mvUUID> mvNodeEditor::getSelectedNodes() const
     {
         for (const auto& child : childslots[1])
         {
+            if (child->type != mvAppItemType::mvNode)
+                continue;
             int i1 = item;
             int i2 = static_cast<mvNode*>(child.get())->getId();
             //if (static_cast<mvNode*>(child.get())->getId() == item)
@@ -256,6 +258,10 @@ void mvNodeEditor::draw(ImDrawList* drawlist, float x, float y)
 
     for (auto& child : childslots[1])
     {
+        // skip non-node children (e.g. menu bars)
+        if (child->type != mvAppItemType::mvNode)
+            continue;
+
         child->state.lastFrameUpdate = GContext->frame;
         child->state.prevHovered = child->state.hovered;
         child->state.hovered = false;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve
title: A menu bar in node editor no longer segfaults (#2070)
assignees: ''

---

Closes #2070.

**Description:**

Since both nodes and menu items are stored as slot 1 children in the node editor, we need to check item type before treating it as a node (or as anything else). Type checks were missing in a couple of places - this PR adds them.

**Concerning Areas:**
None.
