### PR TITLE
Updated issue and PR templates (again)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
         **Before opening a bug report, please:**
         - Search [existing issues](https://github.com/hoffstadt/DearPyGui/issues?q=is%3Aissue) (including closed ones) — your bug may already be known.
         - Check the [FAQ](https://github.com/hoffstadt/DearPyGui/discussions/categories/frequently-asked-questions-faq), [Wiki](https://github.com/hoffstadt/DearPyGui/wiki), and [online documentation](https://dearpygui.readthedocs.io/en/latest/index.html).
-        - **FOR FIRST-TIME USERS' ISSUES**,  please use the [Discord server](https://discord.gg/tyE7Gu4).
+        - **!!! FOR FIRST-TIME USERS' ISSUES,  please use the [Discord server](https://discord.gg/tyE7Gu4) !!!**
         - Remove all third-party libraries.
         - Confirm that the problem still exists with the **latest released version** of DearPyGui.
         - Be mindful that messages are being sent to the e-mail box of "Watching" users. Try to proof-read your messages before sending them. Edits are not seen by those users.
@@ -18,7 +18,7 @@ body:
     attributes:
       label: "Dear PyGui version:"
       description: >
-        To obtain it, run `python -c "import dearpygui; print(dearpygui.__version__)"` or `pip show dearpygui`.
+        Run `python -c "import dearpygui; print(dearpygui.__version__)"` or `pip show dearpygui` to obtain it.
       placeholder: "e.g. 2.2.1"
     validations:
       required: true
@@ -28,7 +28,7 @@ body:
     attributes:
       label: "Python version:"
       description: >
-        To obtain it, run `python --version`.
+        Run `python --version` to obtain it.
         Note: DearPyGui requires Python 3.8+.
       placeholder: "e.g. 3.11.4"
     validations:
@@ -90,7 +90,7 @@ body:
       label: "Standalone, minimal, complete and verifiable example:"
       description: |
         **Please provide the shortest self-contained Python script that recreates the issue.**
-        Strip your code down to only what is necessary to trigger the bug.<br>
+        Strip your code down to only what is necessary to trigger the bug.<br><br>
         **Anyone** should be able to **copy and paste** this code and recreate your issue.<br>
         Issues without a reproducible example may be closed.
       render: python

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discord.gg/tyE7Gu4
     about: Dear PyGui community is more active on Discord than here. If you're asking a question rather than reporting a bug, head over to Discord for a quick answer.
   - name: Dear PyGui is in maintenance mode!
-    url: https://github.com/hoffstadt/DearPyGui/discussions
+    url: https://github.com/hoffstadt/DearPyGui/wiki/What's-going-on%3F
     about: Read this wiki article if you're unaware of the maintenance-only status of this project.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 **A checklist on final steps:**
 
 I confirm that I have:
-- [ ] listed all necessary tickets in with the "closes" keyword,
+- [ ] listed all necessary tickets with the "closes" keyword,
 - [ ] added reviewers,
 - [ ] proof-read the description in the Preview tab,
 - [ ] removed this checklist from PR description :) (yes, this checklist is for *you*, not for us - use it as a reminder).


### PR DESCRIPTION
<!-- Don't forget to use the reviewer settings to notify any required reviewers. -->
<!-- Using "Closes #issue-number" will link and autoclose an issue that this pull fixes upon accepting the pull request.  If you want to close multiple issues, type "closes" or "fixes" in front of each number (e.g. "closes #123, closes #456"). -->

**Description:**

Found a wrong link in the previous update of GitHub issue templates - fixing this! Also reworded a couple of things in the bug template.

**Concerning Areas:**
None.
