### PR TITLE
docs: Fixed links in README - removed Dev roadmap, added Project status (#2572)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Or you can use [this code](https://dearpygui.readthedocs.io/en/latest/tutorials/
   
 ## Resources
 
-- [API documentation](https://dearpygui.readthedocs.io/en/latest/index.html) :books: 
-- [Development Roadmap](https://github.com/hoffstadt/DearPyGui/projects/4)
+- [Documentation / Tutorials](https://dearpygui.readthedocs.io/en/latest/index.html) :books: 
+- [Project status](https://github.com/hoffstadt/DearPyGui/wiki/What's-going-on%3F)
 - [FAQ](https://github.com/hoffstadt/DearPyGui/discussions/categories/frequently-asked-questions-faq)
 - [Feature Tracker](https://github.com/hoffstadt/DearPyGui/issues?q=is%3Aissue+is%3Aopen+label%3A%22type%3A+feature%22)
 - [Bug Tracker](https://github.com/hoffstadt/DearPyGui/issues?q=is%3Aissue+is%3Aopen+label%3A%22type%3A+bug%22)


### PR DESCRIPTION
Closes #2572.

**Description:**

Removed a broken link to development roadmap, replaced it with a link to the "What's going on?" page (already updated to clearly state the maintenance status of the project).

Also changed the name on the doc link - IMHO "API documentation" can scare away those few newbies who scroll to that point 😂.

**Concerning Areas:**
None.
