### PR TITLE
docs: fix available spelling in docs

### DIFF
--- a/docs/source/documentation/plots.rst
+++ b/docs/source/documentation/plots.rst
@@ -13,7 +13,7 @@ X-axis:
 Series:
     These are the containers for the data you wish to display.
     Data series need to be added as a child of a Y-axis to be displayed on the plot.
-    There are many different types of data series avaliable.
+    There are many different types of data series available.
     Series also can contain UI Items that will be displayed when right-clicking the series label in the legend as a context menu.
 
 Legend (optional):


### PR DESCRIPTION
Changes:
- `avaliable` -> `available` in `docs/source/documentation/plots.rst` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked my prior PRs in this repository before opening this PR.
